### PR TITLE
Add MATLAB PID design toolchain for motor control

### DIFF
--- a/matlab/README.md
+++ b/matlab/README.md
@@ -1,0 +1,228 @@
+# MATLAB PID Design for STAR Robot
+
+This folder contains MATLAB scripts for PID controller design and motor system modeling for the STAR autonomous mapping robot.
+
+## Quick Start
+
+```matlab
+% 1. Load motor parameters
+motor_params
+
+% 2. Create motor model
+motor_model_1st_order
+
+% 3. Design PID controller
+pid_design_velocity
+
+% 4. Discretize for ESP32
+pid_discretize
+
+% 5. Simulate closed-loop response
+simulate_step_response
+```
+
+## Motor Specifications
+
+Based on **DFRobot FIT0520** DC Gear Motor ([Product Page](https://www.dfrobot.com/product-1617.html)):
+
+| Parameter | Value | Unit |
+|-----------|-------|------|
+| Rated Voltage | 6 | V |
+| No-load Speed | 210 @ 0.13A | RPM |
+| Stall Current | 3.2 | A |
+| Stall Torque | 10 | kg·cm |
+| Gear Ratio | 34.02:1 | - |
+| Encoder PPR | 11 × 34.02 = 341.2 | counts/rev |
+| Max Efficiency | 2.0 kg·cm @ 170 RPM @ 0.6A | - |
+| Max Power | 5.2 kg·cm @ 110 RPM @ 1.1A | - |
+
+### Derived Parameters
+
+| Parameter | Value | Formula |
+|-----------|-------|---------|
+| Armature Resistance | 1.875 Ω | V_rated / I_stall |
+| Torque Constant (Kt) | 0.307 N·m/A | T_stall / I_stall |
+| Back-EMF Constant (Ke) | 0.262 V/(rad/s) | (V - I·R) / ω |
+| No-load ω | 22.0 rad/s | 210 × 2π/60 |
+
+## Script Descriptions
+
+### Core Scripts
+
+| Script | Description |
+|--------|-------------|
+| `motor_params.m` | Motor parameter definitions extracted from FTP |
+| `motor_model_1st_order.m` | First-order transfer function model |
+| `motor_model_2nd_order.m` | Full second-order model with electrical dynamics |
+| `pid_design_velocity.m` | Automatic PID tuning for velocity control |
+| `pid_discretize.m` | Discretization for 100 Hz ESP32 control loop |
+| `simulate_step_response.m` | Closed-loop simulation and analysis |
+| `cascaded_pid_design.m` | Cascaded control (current→velocity→position) |
+| `system_id_template.m` | System identification from encoder data |
+
+### Workflow
+
+```
+┌─────────────────┐
+│  motor_params   │  ← Motor specifications from FTP
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ motor_model_*   │  ← Create transfer function model
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ pid_design_*    │  ← Design PID controller
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ pid_discretize  │  ← Convert to discrete for ESP32
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│  simulate_*     │  ← Validate performance
+└─────────────────┘
+```
+
+## ESP32 Integration
+
+The MATLAB scripts output gains compatible with the ESP32 `star_pid` library:
+
+```c
+// Velocity PID (from pid_design_velocity.m @ 20 rad/s bandwidth)
+star_pid_config_t velocity_pid_config = {
+    .kp = 0.158869f,
+    .ki = 7.032521f,
+    .kd = 0.000000f,
+    .output_min = -100.0f,   // -100% duty cycle
+    .output_max = 100.0f,    // +100% duty cycle
+    .integral_min = -50.0f,  // Anti-windup
+    .integral_max = 50.0f,   // Anti-windup
+};
+star_pid_init(&velocity_pid, &velocity_pid_config);
+```
+
+### Velocity Loop Performance (Simulated)
+
+| Metric | Value |
+|--------|-------|
+| Rise Time | 70 ms |
+| Settling Time | 240 ms |
+| Overshoot | 5.8% |
+| Phase Margin | 69.3° |
+
+### Control Loop Rate
+
+- **ESP32 PID**: 100 Hz (Ts = 10 ms)
+- **Encoder Feedback**: 48 counts per sample (expected at max speed)
+- **Nav2 Commands**: 10 Hz position setpoints
+
+## System Identification
+
+To improve accuracy, collect step response data from the real motor:
+
+1. Run step test on ESP32
+2. Log encoder counts at 100 Hz
+3. Import to MATLAB
+4. Run `system_id_template.m`
+5. Update `motor_params.m` with identified parameters
+
+```matlab
+% After collecting motor_step_data.csv:
+system_id_template
+
+% This will:
+% - Fit transfer function to data
+% - Validate model accuracy
+% - Generate tuned PID gains
+```
+
+## Control Architecture
+
+The STAR robot uses cascaded PID control:
+
+```
+Position Loop (10 Hz) ─┐
+                       │
+                       ▼
+               ┌───────────────┐
+Nav2 ──────────► Position PID  ├──────► Velocity Setpoint
+               └───────────────┘
+                       │
+                       ▼
+               ┌───────────────┐
+Velocity ◄─────┤ Velocity PID  ├──────► Current Setpoint
+Encoder        └───────────────┘
+                       │
+                       ▼
+               ┌───────────────┐
+Current ◄──────┤ Current PID   ├──────► PWM Duty Cycle
+Sense          └───────────────┘
+                       │
+                       ▼
+                   DRV8243
+                   Motor Driver
+```
+
+Use `cascaded_pid_design.m` for full cascade tuning.
+
+## Reference Documents
+
+| Document | Location | Content |
+|----------|----------|---------|
+| FTP Electrical | `Locked_Inc_FTP/sections/15_implementation_electrical.tex` | Motor/driver specs |
+| FTP Embedded | `Locked_Inc_FTP/sections/16_implementation_embedded.tex` | Control architecture |
+| Control Primer | `docs/star_control_systems_primer.tex` | PID theory, initial gains |
+| PID Theory | `star-esp32-firmware/docs/PID_THEORY.tex` | Discrete implementation |
+| star_pid Library | `star-esp32-firmware/lib/star_pid/` | ESP32 PID source code |
+
+## Computed PID Gains (from MATLAB)
+
+### Velocity-Only Control (Simpler)
+| Gain | Value |
+|------|-------|
+| Kp | 0.1589 |
+| Ki | 7.0325 |
+| Kd | 0.0 |
+
+### Cascaded Control (from cascaded_pid_design.m)
+| Loop | Kp | Ki | Kd | Bandwidth |
+|------|----|----|----|-----------|
+| Current (inner) | 0.0 | 375.5 | 0.0 | 200 rad/s |
+| Velocity (middle) | 0.079 | 0.297 | 0.0007 | 20 rad/s |
+| Position (outer) | 1.92 | 0.71 | 0.17 | 2 rad/s |
+
+**Note**: Time constant τ = 50ms is estimated. Run `system_id_template.m` with real encoder data to refine.
+
+## Requirements
+
+- MATLAB R2020a or later
+- Control System Toolbox
+- System Identification Toolbox (for `system_id_template.m`)
+
+## Troubleshooting
+
+### Model doesn't match real motor
+- Run `system_id_template.m` with actual encoder data
+- Update `tau_est` in `motor_model_1st_order.m`
+
+### Excessive overshoot
+- Reduce target bandwidth in `pid_design_velocity.m`
+- Increase derivative gain (Kd)
+
+### Slow response
+- Increase target bandwidth
+- Verify encoder counts/sample is correct (48 expected)
+
+### Oscillation
+- Check bandwidth separation in `cascaded_pid_design.m`
+- Inner loop should be 5-10x faster than outer loop
+
+## Authors
+
+STAR Project Team - Texas A&M University
+ESET 419/420 Senior Design - Fall 2025

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -94,9 +94,10 @@ The MATLAB scripts output gains compatible with the ESP32 `star_pid` library:
 
 ```c
 // Velocity PID (from pid_design_velocity.m @ 20 rad/s bandwidth)
+// Transfer function: G(s) = 3.665 / (0.075s + 1)  [tau = 75ms from design doc]
 star_pid_config_t velocity_pid_config = {
-    .kp = 0.158869f,
-    .ki = 7.032521f,
+    .kp = 0.285647f,
+    .ki = 8.008388f,
     .kd = 0.000000f,
     .output_min = -100.0f,   // -100% duty cycle
     .output_max = 100.0f,    // +100% duty cycle
@@ -111,9 +112,9 @@ star_pid_init(&velocity_pid, &velocity_pid_config);
 | Metric | Value |
 |--------|-------|
 | Rise Time | 70 ms |
-| Settling Time | 240 ms |
-| Overshoot | 5.8% |
-| Phase Margin | 69.3° |
+| Settling Time | 260 ms |
+| Overshoot | 9.7% |
+| Phase Margin | 69.2° |
 
 ### Control Loop Rate
 
@@ -182,21 +183,23 @@ Use `cascaded_pid_design.m` for full cascade tuning.
 
 ## Computed PID Gains (from MATLAB)
 
+**Model:** G(s) = 3.665 / (0.075s + 1) with τ = 75ms from design doc
+
 ### Velocity-Only Control (Simpler)
 | Gain | Value |
 |------|-------|
-| Kp | 0.1589 |
-| Ki | 7.0325 |
+| Kp | 0.2856 |
+| Ki | 8.0084 |
 | Kd | 0.0 |
 
 ### Cascaded Control (from cascaded_pid_design.m)
 | Loop | Kp | Ki | Kd | Bandwidth |
 |------|----|----|----|-----------|
 | Current (inner) | 0.0 | 375.5 | 0.0 | 200 rad/s |
-| Velocity (middle) | 0.079 | 0.297 | 0.0007 | 20 rad/s |
-| Position (outer) | 1.92 | 0.71 | 0.17 | 2 rad/s |
+| Velocity (middle) | 0.118 | 0.552 | 0.001 | 20 rad/s |
+| Position (outer) | 1.94 | 0.72 | 0.18 | 2 rad/s |
 
-**Note**: Time constant τ = 50ms is estimated. Run `system_id_template.m` with real encoder data to refine.
+**Note**: Time constant τ = 75ms from `docs/Protobuf_Protocol_Design_Analysis.tex`. Run `system_id_template.m` with real encoder data to refine.
 
 ## Requirements
 

--- a/matlab/cascaded_pid_design.m
+++ b/matlab/cascaded_pid_design.m
@@ -221,12 +221,14 @@ fprintf('    .integral_max = 50.0f,\n');
 fprintf('};\n\n');
 
 fprintf('// Velocity Loop PID (middle - 100 Hz)\n');
+fprintf('// NOTE: Output limits assume current sensing is available.\n');
+fprintf('//       Without current sensing, use velocity-only config at bottom.\n');
 fprintf('star_pid_config_t velocity_pid_config = {\n');
 fprintf('    .kp = %.6ff,\n', C_velocity.Kp);
 fprintf('    .ki = %.6ff,\n', C_velocity.Ki);
 fprintf('    .kd = %.6ff,\n', C_velocity.Kd);
-fprintf('    .output_min = -%.1ff,   // Max current command (A)\n', I_stall);
-fprintf('    .output_max = %.1ff,    // Max current command (A)\n', I_stall);
+fprintf('    .output_min = -%.1ff,   // Max current command (A) - requires current sensing\n', I_stall);
+fprintf('    .output_max = %.1ff,    // Max current command (A) - requires current sensing\n', I_stall);
 fprintf('    .integral_min = -%.1ff,\n', I_stall * 0.5);
 fprintf('    .integral_max = %.1ff,\n', I_stall * 0.5);
 fprintf('};\n\n');

--- a/matlab/cascaded_pid_design.m
+++ b/matlab/cascaded_pid_design.m
@@ -1,0 +1,282 @@
+%% cascaded_pid_design.m - Cascaded PID Control Design
+% Designs cascaded PID controllers for the STAR robot:
+%   Position Loop (Outer) -> Velocity Loop (Middle) -> Current Loop (Inner)
+%
+% The inner loop must be 5-10x faster than the outer loop for proper
+% cascade operation.
+%
+% Reference: docs/star_control_systems_primer.tex
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Setup
+clear; clc;
+fprintf('=======================================================\n');
+fprintf('    CASCADED PID DESIGN FOR STAR ROBOT\n');
+fprintf('=======================================================\n');
+
+%% Load Motor Parameters
+motor_params;
+
+%% Control Loop Hierarchy
+fprintf('\n=== Control Loop Hierarchy ===\n');
+fprintf('Level 1 (Innermost): Current Loop  - Protect motors, fast response\n');
+fprintf('Level 2 (Middle):    Velocity Loop - Smooth speed control\n');
+fprintf('Level 3 (Outermost): Position Loop - Accurate positioning\n');
+
+% Loop rates (from control systems primer)
+Ts_current  = 0.01;   % 100 Hz (same as velocity for simplicity)
+Ts_velocity = 0.01;   % 100 Hz
+Ts_position = 0.1;    % 10 Hz (from Nav2)
+
+fprintf('\nLoop Rates:\n');
+fprintf('  Current Loop:  %.0f Hz (Ts = %.0f ms)\n', 1/Ts_current, Ts_current*1000);
+fprintf('  Velocity Loop: %.0f Hz (Ts = %.0f ms)\n', 1/Ts_velocity, Ts_velocity*1000);
+fprintf('  Position Loop: %.0f Hz (Ts = %.0f ms)\n', 1/Ts_position, Ts_position*1000);
+
+%% Current Loop Design (Innermost)
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    CURRENT LOOP DESIGN\n');
+fprintf('=======================================================\n');
+
+% Current loop plant: I(s)/V(s) = 1 / (L*s + R)
+s = tf('s');
+G_current = 1 / (L_armature * s + R_armature);
+
+fprintf('Current Loop Plant: I(s)/V(s) = 1 / (L*s + R)\n');
+fprintf('  L = %.2f mH, R = %.3f Ohm\n', L_armature*1000, R_armature);
+
+% Electrical time constant
+tau_e = L_armature / R_armature;
+fprintf('  Electrical time constant: %.3f ms\n', tau_e * 1000);
+
+% Design current controller
+% Target bandwidth: 10x velocity loop = ~200 rad/s
+bw_current = 200;  % rad/s
+opts_current = pidtuneOptions('CrossoverFrequency', bw_current);
+[C_current, info_current] = pidtune(G_current, 'PI', opts_current);
+
+fprintf('\nCurrent Loop Controller (PI):\n');
+fprintf('  Kp_current = %.4f\n', C_current.Kp);
+fprintf('  Ki_current = %.4f\n', C_current.Ki);
+fprintf('  Achieved Bandwidth: %.1f rad/s (%.1f Hz)\n', ...
+        info_current.CrossoverFrequency, info_current.CrossoverFrequency/(2*pi));
+fprintf('  Phase Margin: %.1f degrees\n', info_current.PhaseMargin);
+
+% Closed-loop current dynamics
+sys_current_cl = feedback(C_current * G_current, 1);
+info_current_step = stepinfo(sys_current_cl);
+fprintf('\nCurrent Loop Step Response:\n');
+fprintf('  Rise Time:    %.3f ms\n', info_current_step.RiseTime * 1000);
+fprintf('  Settling Time: %.3f ms\n', info_current_step.SettlingTime * 1000);
+
+%% Velocity Loop Design (Middle)
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    VELOCITY LOOP DESIGN\n');
+fprintf('=======================================================\n');
+
+% Velocity loop sees the closed-loop current dynamics + mechanical system
+% Omega(s)/I(s) = Kt / (J*s + b)
+G_mech = Kt / (J_total * s + b);
+
+% Cascade: velocity plant = closed-loop current * mechanical
+G_velocity = sys_current_cl * G_mech;
+
+fprintf('Velocity Loop Plant: Omega(s)/I_ref(s) = G_current_cl(s) * Kt/(J*s + b)\n');
+
+% Design velocity controller
+% Target bandwidth: 10x position loop but < 0.1x current loop
+bw_velocity = 20;  % rad/s
+opts_velocity = pidtuneOptions('CrossoverFrequency', bw_velocity);
+[C_velocity, info_velocity] = pidtune(G_velocity, 'PID', opts_velocity);
+
+fprintf('\nVelocity Loop Controller (PID):\n');
+fprintf('  Kp_velocity = %.4f\n', C_velocity.Kp);
+fprintf('  Ki_velocity = %.4f\n', C_velocity.Ki);
+fprintf('  Kd_velocity = %.4f\n', C_velocity.Kd);
+fprintf('  Achieved Bandwidth: %.1f rad/s (%.1f Hz)\n', ...
+        info_velocity.CrossoverFrequency, info_velocity.CrossoverFrequency/(2*pi));
+fprintf('  Phase Margin: %.1f degrees\n', info_velocity.PhaseMargin);
+
+% Closed-loop velocity dynamics
+sys_velocity_cl = feedback(C_velocity * G_velocity, 1);
+info_velocity_step = stepinfo(sys_velocity_cl);
+fprintf('\nVelocity Loop Step Response:\n');
+fprintf('  Rise Time:     %.3f ms\n', info_velocity_step.RiseTime * 1000);
+fprintf('  Settling Time: %.3f ms\n', info_velocity_step.SettlingTime * 1000);
+fprintf('  Overshoot:     %.1f%%\n', info_velocity_step.Overshoot);
+
+%% Position Loop Design (Outermost)
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    POSITION LOOP DESIGN\n');
+fprintf('=======================================================\n');
+
+% Position = integral of velocity
+% Position plant = closed-loop velocity * integrator
+G_position = sys_velocity_cl / s;
+
+fprintf('Position Loop Plant: Theta(s)/Omega_ref(s) = G_velocity_cl(s) / s\n');
+
+% Design position controller
+% Target bandwidth: < 0.1x velocity loop
+bw_position = 2;  % rad/s
+opts_position = pidtuneOptions('CrossoverFrequency', bw_position);
+[C_position, info_position] = pidtune(G_position, 'PID', opts_position);
+
+fprintf('\nPosition Loop Controller (PID):\n');
+fprintf('  Kp_position = %.4f\n', C_position.Kp);
+fprintf('  Ki_position = %.4f\n', C_position.Ki);
+fprintf('  Kd_position = %.4f\n', C_position.Kd);
+fprintf('  Achieved Bandwidth: %.1f rad/s (%.1f Hz)\n', ...
+        info_position.CrossoverFrequency, info_position.CrossoverFrequency/(2*pi));
+fprintf('  Phase Margin: %.1f degrees\n', info_position.PhaseMargin);
+
+% Closed-loop position dynamics
+sys_position_cl = feedback(C_position * G_position, 1);
+info_position_step = stepinfo(sys_position_cl);
+fprintf('\nPosition Loop Step Response:\n');
+fprintf('  Rise Time:     %.3f s\n', info_position_step.RiseTime);
+fprintf('  Settling Time: %.3f s\n', info_position_step.SettlingTime);
+fprintf('  Overshoot:     %.1f%%\n', info_position_step.Overshoot);
+
+%% Bandwidth Separation Verification
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    BANDWIDTH SEPARATION VERIFICATION\n');
+fprintf('=======================================================\n');
+
+bw_ratio_cv = info_current.CrossoverFrequency / info_velocity.CrossoverFrequency;
+bw_ratio_vp = info_velocity.CrossoverFrequency / info_position.CrossoverFrequency;
+
+fprintf('Current / Velocity bandwidth ratio: %.1fx\n', bw_ratio_cv);
+fprintf('Velocity / Position bandwidth ratio: %.1fx\n', bw_ratio_vp);
+
+if bw_ratio_cv >= 5 && bw_ratio_vp >= 5
+    fprintf('\nBandwidth separation is ADEQUATE (>= 5x between loops)\n');
+elseif bw_ratio_cv >= 3 && bw_ratio_vp >= 3
+    fprintf('\nWARNING: Bandwidth separation is MARGINAL (3-5x)\n');
+else
+    fprintf('\nERROR: Bandwidth separation is INSUFFICIENT (<3x)\n');
+    fprintf('Consider reducing outer loop bandwidths\n');
+end
+
+%% Plot Cascade Response
+figure('Name', 'Cascaded PID Control', 'Position', [100 100 1400 800]);
+
+% Individual loop step responses
+subplot(2,3,1);
+step(sys_current_cl);
+title('Current Loop Step Response');
+ylabel('Current (A)');
+grid on;
+
+subplot(2,3,2);
+step(sys_velocity_cl);
+title('Velocity Loop Step Response');
+ylabel('Angular Velocity (rad/s)');
+grid on;
+
+subplot(2,3,3);
+step(sys_position_cl);
+title('Position Loop Step Response');
+ylabel('Position (rad)');
+grid on;
+
+% Bode plots
+subplot(2,3,4);
+bode(C_current * G_current);
+title('Current Loop Open-Loop');
+grid on;
+
+subplot(2,3,5);
+bode(C_velocity * G_velocity);
+title('Velocity Loop Open-Loop');
+grid on;
+
+subplot(2,3,6);
+bode(C_position * G_position);
+title('Position Loop Open-Loop');
+grid on;
+
+%% Generate ESP32 Configuration
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    ESP32 star_pid CONFIGURATION\n');
+fprintf('=======================================================\n');
+fprintf('\n');
+
+fprintf('// Current Loop PID (innermost - 100 Hz)\n');
+fprintf('star_pid_config_t current_pid_config = {\n');
+fprintf('    .kp = %.6ff,\n', C_current.Kp);
+fprintf('    .ki = %.6ff,\n', C_current.Ki);
+fprintf('    .kd = 0.0f,  // PI only\n');
+fprintf('    .output_min = -100.0f,   // -100%% duty cycle\n');
+fprintf('    .output_max = 100.0f,    // +100%% duty cycle\n');
+fprintf('    .integral_min = -50.0f,\n');
+fprintf('    .integral_max = 50.0f,\n');
+fprintf('};\n\n');
+
+fprintf('// Velocity Loop PID (middle - 100 Hz)\n');
+fprintf('star_pid_config_t velocity_pid_config = {\n');
+fprintf('    .kp = %.6ff,\n', C_velocity.Kp);
+fprintf('    .ki = %.6ff,\n', C_velocity.Ki);
+fprintf('    .kd = %.6ff,\n', C_velocity.Kd);
+fprintf('    .output_min = -%.1ff,   // Max current command (A)\n', I_stall);
+fprintf('    .output_max = %.1ff,    // Max current command (A)\n', I_stall);
+fprintf('    .integral_min = -%.1ff,\n', I_stall * 0.5);
+fprintf('    .integral_max = %.1ff,\n', I_stall * 0.5);
+fprintf('};\n\n');
+
+fprintf('// Position Loop PID (outermost - 10 Hz from Nav2)\n');
+fprintf('star_pid_config_t position_pid_config = {\n');
+fprintf('    .kp = %.6ff,\n', C_position.Kp);
+fprintf('    .ki = %.6ff,\n', C_position.Ki);
+fprintf('    .kd = %.6ff,\n', C_position.Kd);
+fprintf('    .output_min = -%.1ff,   // Max velocity command (rad/s)\n', omega_no_load);
+fprintf('    .output_max = %.1ff,    // Max velocity command (rad/s)\n', omega_no_load);
+fprintf('    .integral_min = -%.1ff,\n', omega_no_load * 0.5);
+fprintf('    .integral_max = %.1ff,\n', omega_no_load * 0.5);
+fprintf('};\n');
+
+%% Summary Table
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    CASCADED CONTROL SUMMARY\n');
+fprintf('=======================================================\n');
+fprintf('\n');
+fprintf('Loop       | Kp       | Ki       | Kd       | BW (rad/s) | PM (deg)\n');
+fprintf('-----------+----------+----------+----------+------------+---------\n');
+fprintf('Current    | %8.4f | %8.4f | %8.4f | %10.1f | %7.1f\n', ...
+        C_current.Kp, C_current.Ki, 0, info_current.CrossoverFrequency, info_current.PhaseMargin);
+fprintf('Velocity   | %8.4f | %8.4f | %8.4f | %10.1f | %7.1f\n', ...
+        C_velocity.Kp, C_velocity.Ki, C_velocity.Kd, info_velocity.CrossoverFrequency, info_velocity.PhaseMargin);
+fprintf('Position   | %8.4f | %8.4f | %8.4f | %10.1f | %7.1f\n', ...
+        C_position.Kp, C_position.Ki, C_position.Kd, info_position.CrossoverFrequency, info_position.PhaseMargin);
+
+%% Alternative: Velocity-Only Control (Simpler)
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    SIMPLIFIED: VELOCITY LOOP ONLY\n');
+fprintf('=======================================================\n');
+fprintf('\n');
+fprintf('For simpler control without current sensing, use velocity-only:\n\n');
+
+% Direct velocity control (no inner current loop)
+G_velocity_direct = Kt / (J_total * R_armature * s + (b * R_armature + Kt * Ke));
+[C_vel_direct, info_vel_direct] = pidtune(G_velocity_direct, 'PID', ...
+    pidtuneOptions('CrossoverFrequency', 20));
+
+fprintf('// Velocity-Only PID (no current loop)\n');
+fprintf('star_pid_config_t velocity_only_config = {\n');
+fprintf('    .kp = %.6ff,\n', C_vel_direct.Kp);
+fprintf('    .ki = %.6ff,\n', C_vel_direct.Ki);
+fprintf('    .kd = %.6ff,\n', C_vel_direct.Kd);
+fprintf('    .output_min = -100.0f,\n');
+fprintf('    .output_max = 100.0f,\n');
+fprintf('    .integral_min = -50.0f,\n');
+fprintf('    .integral_max = 50.0f,\n');
+fprintf('};\n');

--- a/matlab/identified_params.txt
+++ b/matlab/identified_params.txt
@@ -1,5 +1,7 @@
 % Identified Motor Parameters
-% Generated: 16-Dec-2025 14:27:04
+% NOTE: This is EXAMPLE output from simulated data.
+%       Run system_id_template.m with real encoder data to generate actual values.
+% Generated: 16-Dec-2025 14:27:04 (example)
 
 K_dc = 3.663559;     % DC gain [rad/s per volt]
 tau_est = 0.052269;  % Time constant [s]

--- a/matlab/identified_params.txt
+++ b/matlab/identified_params.txt
@@ -1,0 +1,8 @@
+% Identified Motor Parameters
+% Generated: 16-Dec-2025 14:27:04
+
+K_dc = 3.663559;     % DC gain [rad/s per volt]
+tau_est = 0.052269;  % Time constant [s]
+
+% First-order transfer function:
+% G(s) = 3.6636 / (0.0523*s + 1)

--- a/matlab/motor_model_1st_order.m
+++ b/matlab/motor_model_1st_order.m
@@ -1,0 +1,113 @@
+%% motor_model_1st_order.m - First-Order DC Motor Model
+% Creates a first-order transfer function approximation for velocity control
+%
+% For velocity control of geared DC motors, a first-order model is often
+% sufficient because the electrical time constant (tau_e ~ 0.3ms) is much
+% faster than the mechanical time constant (tau_m ~ 50-100ms).
+%
+% Transfer Function: Omega(s)/V(s) = K / (tau*s + 1)
+%
+% USAGE:
+%   >> motor_model_1st_order
+%   >> step(motor_tf)  % View step response
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Load Motor Parameters
+motor_params;
+
+%% First-Order Model Parameters
+% DC Gain: K = omega_no_load / V_rated [rad/s per volt]
+K_dc = omega_no_load / V_rated;
+
+% Time Constant: tau [seconds]
+% Use mechanical time constant (electrical is negligible)
+% IMPORTANT: This should be measured from actual motor step response!
+tau_est = 0.05;  % Estimated 50ms - MEASURE THIS ON REAL MOTOR
+
+fprintf('\n=== First-Order Motor Model ===\n');
+fprintf('DC Gain K:        %.3f (rad/s)/V\n', K_dc);
+fprintf('Time Constant:    %.0f ms (ESTIMATED - measure on hardware!)\n', tau_est * 1000);
+
+%% Create Transfer Function
+s = tf('s');
+motor_tf = K_dc / (tau_est * s + 1);
+
+fprintf('\nTransfer Function: Omega(s)/V(s)\n');
+motor_tf
+
+%% Frequency Domain Analysis
+fprintf('\n--- Frequency Domain Characteristics ---\n');
+
+% Bandwidth (frequency where gain drops to -3dB)
+bandwidth = 1 / tau_est;  % rad/s
+fprintf('Bandwidth:        %.1f rad/s (%.1f Hz)\n', bandwidth, bandwidth/(2*pi));
+
+% DC Gain in dB
+dc_gain_db = 20 * log10(K_dc);
+fprintf('DC Gain:          %.2f dB\n', dc_gain_db);
+
+%% Time Domain Analysis
+fprintf('\n--- Time Domain Characteristics ---\n');
+
+% Step response metrics
+info = stepinfo(motor_tf);
+fprintf('Rise Time:        %.3f s\n', info.RiseTime);
+fprintf('Settling Time:    %.3f s\n', info.SettlingTime);
+fprintf('Peak Value:       %.3f rad/s (for 1V step)\n', info.Peak);
+
+%% Plot Step Response
+figure('Name', 'First-Order Motor Model - Step Response');
+
+subplot(2,1,1);
+step(motor_tf);
+title('Motor Velocity Response to 1V Step Input');
+ylabel('Angular Velocity (rad/s)');
+xlabel('Time (s)');
+grid on;
+
+% Add annotations
+hold on;
+yline(K_dc, 'r--', 'Steady State', 'LabelHorizontalAlignment', 'left');
+xline(tau_est, 'g--', ['\tau = ' num2str(tau_est*1000) 'ms']);
+xline(info.SettlingTime, 'm--', ['T_s = ' num2str(info.SettlingTime*1000, '%.0f') 'ms']);
+hold off;
+
+subplot(2,1,2);
+bode(motor_tf);
+title('Motor Frequency Response');
+grid on;
+
+%% RPM Response (for practical use)
+figure('Name', 'First-Order Motor Model - RPM Response');
+
+% Convert to RPM units
+K_dc_rpm = n_no_load / V_rated;  % RPM per volt
+motor_tf_rpm = K_dc_rpm / (tau_est * s + 1);
+
+step(motor_tf_rpm);
+title('Motor Speed Response to 1V Step Input');
+ylabel('Speed (RPM)');
+xlabel('Time (s)');
+grid on;
+
+hold on;
+yline(K_dc_rpm, 'r--', ['Steady State = ' num2str(K_dc_rpm, '%.0f') ' RPM/V']);
+hold off;
+
+%% Save Model to Workspace
+fprintf('\n=== Model Saved to Workspace ===\n');
+fprintf('motor_tf     - Transfer function Omega(s)/V(s) [rad/s / V]\n');
+fprintf('motor_tf_rpm - Transfer function Speed(s)/V(s) [RPM / V]\n');
+fprintf('K_dc         - DC gain [rad/s / V]\n');
+fprintf('tau_est      - Time constant [s] (MEASURE THIS!)\n');
+
+%% Instructions for Measuring Time Constant
+fprintf('\n=== HOW TO MEASURE TIME CONSTANT ===\n');
+fprintf('1. Apply a step voltage (e.g., 3V) to motor\n');
+fprintf('2. Log encoder counts at 100Hz\n');
+fprintf('3. Calculate velocity in RPM\n');
+fprintf('4. Find time to reach 63.2%% of final velocity\n');
+fprintf('5. Update tau_est in this script\n');
+fprintf('6. Or use system_id_template.m for automated fitting\n');

--- a/matlab/motor_model_1st_order.m
+++ b/matlab/motor_model_1st_order.m
@@ -24,8 +24,9 @@ K_dc = omega_no_load / V_rated;
 % Time Constant: tau [seconds]
 % Use mechanical time constant (electrical is negligible)
 % IMPORTANT: This should be measured from actual motor step response!
-% Initial estimate of 50ms based on typical geared DC motor values (literature: 30-100ms)
-tau_est = 0.05;  % Estimated 50ms - MEASURE THIS ON REAL MOTOR
+% Time constant from docs/Protobuf_Protocol_Design_Analysis.tex (line 622, 1022)
+% Design doc uses 75ms for all calculations (control frequency, margins)
+tau_est = 0.075;  % Estimated 75ms from design doc - MEASURE ON REAL MOTOR
 
 fprintf('\n=== First-Order Motor Model ===\n');
 fprintf('DC Gain K:        %.3f (rad/s)/V\n', K_dc);

--- a/matlab/motor_model_1st_order.m
+++ b/matlab/motor_model_1st_order.m
@@ -24,6 +24,7 @@ K_dc = omega_no_load / V_rated;
 % Time Constant: tau [seconds]
 % Use mechanical time constant (electrical is negligible)
 % IMPORTANT: This should be measured from actual motor step response!
+% Initial estimate of 50ms based on typical geared DC motor values (literature: 30-100ms)
 tau_est = 0.05;  % Estimated 50ms - MEASURE THIS ON REAL MOTOR
 
 fprintf('\n=== First-Order Motor Model ===\n');

--- a/matlab/motor_model_2nd_order.m
+++ b/matlab/motor_model_2nd_order.m
@@ -1,0 +1,158 @@
+%% motor_model_2nd_order.m - Second-Order DC Motor Model
+% Creates a more detailed second-order transfer function including
+% both electrical and mechanical dynamics.
+%
+% Full DC Motor Model (Velocity):
+%   Omega(s)/V(s) = Kt / (J*L*s^2 + (J*R + b*L)*s + (b*R + Kt*Ke))
+%
+% Simplified (L << R, common for small DC motors):
+%   Omega(s)/V(s) = Kt / (J*R*s + (b*R + Kt*Ke))
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Load Motor Parameters
+motor_params;
+
+%% Second-Order Model (Full Form)
+fprintf('\n=== Second-Order DC Motor Model (Full) ===\n');
+
+% Coefficients for: J*L*s^2 + (J*R + b*L)*s + (b*R + Kt*Ke)
+a2 = J_total * L_armature;                    % s^2 coefficient
+a1 = J_total * R_armature + b * L_armature;   % s^1 coefficient
+a0 = b * R_armature + Kt * Ke;                % s^0 coefficient
+
+% Numerator is just Kt
+num_full = Kt;
+den_full = [a2 a1 a0];
+
+s = tf('s');
+motor_tf_full = tf(num_full, den_full);
+
+fprintf('Full Second-Order Transfer Function:\n');
+motor_tf_full
+
+% Natural frequency and damping ratio
+omega_n = sqrt(a0 / a2);
+zeta = a1 / (2 * sqrt(a0 * a2));
+
+fprintf('Natural Frequency:  %.1f rad/s (%.1f Hz)\n', omega_n, omega_n/(2*pi));
+fprintf('Damping Ratio:      %.3f\n', zeta);
+
+if zeta < 1
+    fprintf('System Type:        Underdamped\n');
+elseif zeta == 1
+    fprintf('System Type:        Critically Damped\n');
+else
+    fprintf('System Type:        Overdamped\n');
+end
+
+%% Simplified Model (Neglecting Inductance)
+fprintf('\n=== Simplified Model (L -> 0) ===\n');
+
+% When L << R, the model reduces to first-order
+% Omega(s)/V(s) = Kt / (J*R*s + (b*R + Kt*Ke))
+% Which is: K / (tau*s + 1) where K = Kt/(b*R + Kt*Ke) and tau = J*R/(b*R + Kt*Ke)
+
+K_simplified = Kt / (b * R_armature + Kt * Ke);
+tau_simplified = J_total * R_armature / (b * R_armature + Kt * Ke);
+
+motor_tf_simplified = K_simplified / (tau_simplified * s + 1);
+
+fprintf('Simplified (ignoring inductance):\n');
+motor_tf_simplified
+fprintf('DC Gain:        %.3f rad/s/V\n', K_simplified);
+fprintf('Time Constant:  %.1f ms\n', tau_simplified * 1000);
+
+%% Current to Velocity Transfer Function
+fprintf('\n=== Current-to-Velocity Model ===\n');
+% Omega(s)/I(s) = Kt / (J*s + b)
+% This is useful for the velocity loop in cascaded control
+
+motor_tf_current = Kt / (J_total * s + b);
+fprintf('Omega(s)/I(s):\n');
+motor_tf_current
+
+%% Voltage to Current Transfer Function
+fprintf('\n=== Voltage-to-Current Model ===\n');
+% I(s)/V(s) = 1 / (L*s + R + Ke*Kt/(J*s + b))
+% Simplified when Ke*Ke/(J*s + b) << R:
+% I(s)/V(s) ≈ 1 / (L*s + R)
+
+motor_tf_electrical = 1 / (L_armature * s + R_armature);
+fprintf('I(s)/V(s) (electrical only):\n');
+motor_tf_electrical
+
+%% Compare Full vs Simplified Models
+figure('Name', 'Second-Order Motor Model Comparison');
+
+subplot(2,2,1);
+step(motor_tf_full, motor_tf_simplified);
+title('Step Response Comparison');
+ylabel('Angular Velocity (rad/s)');
+legend('Full 2nd Order', 'Simplified 1st Order', 'Location', 'southeast');
+grid on;
+
+subplot(2,2,2);
+bode(motor_tf_full, motor_tf_simplified);
+title('Frequency Response Comparison');
+legend('Full 2nd Order', 'Simplified 1st Order');
+grid on;
+
+subplot(2,2,3);
+impulse(motor_tf_full, motor_tf_simplified);
+title('Impulse Response Comparison');
+ylabel('Angular Velocity (rad/s)');
+legend('Full 2nd Order', 'Simplified 1st Order', 'Location', 'northeast');
+grid on;
+
+subplot(2,2,4);
+pzmap(motor_tf_full);
+title('Pole-Zero Map (Full Model)');
+grid on;
+
+%% Display Poles and Zeros
+fprintf('\n=== Poles and Zeros ===\n');
+[poles_full, ~] = pzmap(motor_tf_full);
+fprintf('Full Model Poles:\n');
+for i = 1:length(poles_full)
+    if isreal(poles_full(i))
+        fprintf('  p%d = %.1f rad/s (tau = %.3f ms)\n', i, poles_full(i), -1000/poles_full(i));
+    else
+        fprintf('  p%d = %.1f + %.1fj rad/s\n', i, real(poles_full(i)), imag(poles_full(i)));
+    end
+end
+
+%% Time Constants Summary
+fprintf('\n=== Time Constants Summary ===\n');
+fprintf('Electrical (tau_e = L/R):     %.3f ms (very fast)\n', tau_e * 1000);
+fprintf('Mechanical (simplified):      %.1f ms\n', tau_simplified * 1000);
+fprintf('\nSince tau_e << tau_m, the first-order approximation is usually sufficient.\n');
+
+%% Save Models to Workspace
+fprintf('\n=== Models Saved to Workspace ===\n');
+fprintf('motor_tf_full       - Full 2nd order model\n');
+fprintf('motor_tf_simplified - 1st order approximation (L->0)\n');
+fprintf('motor_tf_current    - Current-to-velocity model (for cascaded control)\n');
+fprintf('motor_tf_electrical - Voltage-to-current model\n');
+
+%% Block Diagram Representation
+fprintf('\n=== State-Space Model ===\n');
+% State variables: x = [omega; i_a]
+% States: angular velocity and armature current
+% Input: voltage
+% Output: angular velocity
+
+A = [-b/J_total, Kt/J_total;
+     -Ke/L_armature, -R_armature/L_armature];
+B = [0; 1/L_armature];
+C = [1, 0];  % Output is omega
+D = 0;
+
+motor_ss = ss(A, B, C, D);
+fprintf('State-Space Matrices:\n');
+fprintf('States: x = [omega; i_armature]\n');
+fprintf('A = [%.3f, %.3f; %.3f, %.3f]\n', A(1,1), A(1,2), A(2,1), A(2,2));
+fprintf('B = [%.3f; %.3f]\n', B(1), B(2));
+fprintf('C = [%.0f, %.0f]\n', C(1), C(2));
+fprintf('D = %.0f\n', D);

--- a/matlab/motor_params.m
+++ b/matlab/motor_params.m
@@ -12,7 +12,7 @@
 %% Motor Electrical Specifications (from FTP Table: Motor and Driver Specifications)
 V_rated = 6;                    % Rated voltage [V]
 n_no_load = 210;                % No-load speed [RPM]
-I_no_load = 0.13;               % No-load current [A] (estimated)
+I_no_load = 0.13;               % No-load current [A] (from datasheet)
 I_stall = 3.2;                  % Stall current [A]
 T_stall_kgcm = 10;              % Stall torque [kg*cm]
 
@@ -26,7 +26,7 @@ T_stall_Nm = T_stall_kgcm * 0.0981;  % Stall torque [N*m] = 0.981 N*m
 %% Derived Electrical Parameters
 R_armature = V_rated / I_stall;      % Armature resistance [Ohm] = 1.875 Ohm
 % Note: Armature inductance is typically small for brushed DC motors
-% Estimate L ~ 0.5 mH (to be measured)
+% Estimate L ~ 0.5 mH (to be measured with LCR meter or from startup transient)
 L_armature = 0.5e-3;                 % Armature inductance [H] (estimated)
 
 %% Derived Motor Constants
@@ -38,15 +38,18 @@ omega_no_load = n_no_load * 2 * pi / 60;  % No-load speed [rad/s] = 22 rad/s
 Ke = (V_rated - I_no_load * R_armature) / omega_no_load;  % Back-EMF constant [V/(rad/s)]
 
 %% Derived Mechanical Parameters (Estimates - To Be Measured)
-% Motor rotor inertia (before gearbox)
-J_motor = 1e-6;                 % Motor rotor inertia [kg*m^2] (estimated)
+% Motor rotor inertia (before gearbox) - typical for small DC motors
+J_motor = 1e-6;                 % Motor rotor inertia [kg*m^2] (estimated, 1e-7 to 1e-5 typical)
 
-% Reflected inertia at output shaft
-J_load = 5e-5;                  % Load inertia [kg*m^2] (estimated for wheel)
+% Reflected inertia at output shaft (wheel as solid disk: J = 0.5*m*r^2)
+wheel_diameter_mm = 144;        % Wheel diameter [mm] (from FTP)
+wheel_mass_kg = 0.25;           % Wheel mass [kg] (estimated)
+J_load = 0.5 * wheel_mass_kg * (wheel_diameter_mm/2000)^2;  % Load inertia [kg*m^2]
 J_total = J_motor * gear_ratio^2 + J_load;  % Total reflected inertia [kg*m^2]
 
-% Viscous friction coefficient
-b = 1e-4;                       % Viscous friction [N*m*s/rad] (estimated)
+% Viscous friction coefficient - estimated from no-load operating point
+% At no-load: T_friction = Kt * I_no_load = b * omega_no_load
+b = (Kt * I_no_load) / omega_no_load;  % Viscous friction [N*m*s/rad]
 
 %% Time Constants
 tau_e = L_armature / R_armature;     % Electrical time constant [s] = 0.27 ms
@@ -62,7 +65,7 @@ encoder_counts_per_sample = 48; % Expected counts per sample at max speed
 % Example: 48 counts in 10ms -> (48/341.2) * 6000 = 844 RPM
 
 %% Physical Dimensions (from FTP)
-wheel_diameter_mm = 144;        % Wheel diameter [mm]
+% wheel_diameter_mm defined above in mechanical parameters
 wheel_radius_m = wheel_diameter_mm / 2000;  % Wheel radius [m]
 max_linear_speed = omega_no_load * wheel_radius_m;  % Max speed [m/s] = 1.58 m/s
 

--- a/matlab/motor_params.m
+++ b/matlab/motor_params.m
@@ -1,0 +1,90 @@
+%% motor_params.m - STAR Robot Motor Parameters
+% DFRobot FIT0520 DC Gear Motor Specifications
+% Source: Locked_Inc_FTP/sections/15_implementation_electrical.tex
+%
+% USAGE:
+%   Run this script to load motor parameters into workspace:
+%   >> motor_params
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Motor Electrical Specifications (from FTP Table: Motor and Driver Specifications)
+V_rated = 6;                    % Rated voltage [V]
+n_no_load = 210;                % No-load speed [RPM]
+I_no_load = 0.13;               % No-load current [A] (estimated)
+I_stall = 3.2;                  % Stall current [A]
+T_stall_kgcm = 10;              % Stall torque [kg*cm]
+
+%% Motor Mechanical Specifications
+gear_ratio = 34.02;             % Gear reduction ratio (34:1 nominal)
+encoder_ppr = 341.2;            % Pulses per revolution (after gearbox)
+
+%% Unit Conversions
+T_stall_Nm = T_stall_kgcm * 0.0981;  % Stall torque [N*m] = 0.981 N*m
+
+%% Derived Electrical Parameters
+R_armature = V_rated / I_stall;      % Armature resistance [Ohm] = 1.875 Ohm
+% Note: Armature inductance is typically small for brushed DC motors
+% Estimate L ~ 0.5 mH (to be measured)
+L_armature = 0.5e-3;                 % Armature inductance [H] (estimated)
+
+%% Derived Motor Constants
+% Torque constant: Kt = T_stall / I_stall
+Kt = T_stall_Nm / I_stall;           % Torque constant [N*m/A] = 0.307 N*m/A
+
+% Back-EMF constant: Ke = (V - I*R) / omega at no-load
+omega_no_load = n_no_load * 2 * pi / 60;  % No-load speed [rad/s] = 22 rad/s
+Ke = (V_rated - I_no_load * R_armature) / omega_no_load;  % Back-EMF constant [V/(rad/s)]
+
+%% Derived Mechanical Parameters (Estimates - To Be Measured)
+% Motor rotor inertia (before gearbox)
+J_motor = 1e-6;                 % Motor rotor inertia [kg*m^2] (estimated)
+
+% Reflected inertia at output shaft
+J_load = 5e-5;                  % Load inertia [kg*m^2] (estimated for wheel)
+J_total = J_motor * gear_ratio^2 + J_load;  % Total reflected inertia [kg*m^2]
+
+% Viscous friction coefficient
+b = 1e-4;                       % Viscous friction [N*m*s/rad] (estimated)
+
+%% Time Constants
+tau_e = L_armature / R_armature;     % Electrical time constant [s] = 0.27 ms
+tau_m = J_total * R_armature / (Ke * Kt + b * R_armature);  % Mechanical time constant [s]
+
+%% Control System Parameters
+Ts = 0.01;                      % Sample time [s] (100 Hz motor control loop)
+encoder_counts_per_sample = 48; % Expected counts per sample at max speed
+
+%% Velocity Calculation
+% At 100 Hz with encoder_ppr counts/rev:
+% velocity_rpm = (delta_counts / encoder_ppr) * (60 / Ts)
+% Example: 48 counts in 10ms -> (48/341.2) * 6000 = 844 RPM
+
+%% Physical Dimensions (from FTP)
+wheel_diameter_mm = 144;        % Wheel diameter [mm]
+wheel_radius_m = wheel_diameter_mm / 2000;  % Wheel radius [m]
+max_linear_speed = omega_no_load * wheel_radius_m;  % Max speed [m/s] = 1.58 m/s
+
+%% Display Summary
+fprintf('=== STAR Motor Parameters (DFRobot FIT0520) ===\n');
+fprintf('\n--- Electrical ---\n');
+fprintf('Rated Voltage:     %.1f V\n', V_rated);
+fprintf('Stall Current:     %.1f A\n', I_stall);
+fprintf('Armature R:        %.3f Ohm\n', R_armature);
+fprintf('Armature L:        %.2f mH (estimated)\n', L_armature * 1000);
+fprintf('\n--- Mechanical ---\n');
+fprintf('No-load Speed:     %d RPM (%.1f rad/s)\n', n_no_load, omega_no_load);
+fprintf('Stall Torque:      %.2f kg*cm (%.3f N*m)\n', T_stall_kgcm, T_stall_Nm);
+fprintf('Gear Ratio:        %.2f:1\n', gear_ratio);
+fprintf('Encoder PPR:       %.1f counts/rev\n', encoder_ppr);
+fprintf('\n--- Motor Constants ---\n');
+fprintf('Torque Constant:   %.4f N*m/A\n', Kt);
+fprintf('Back-EMF Constant: %.4f V/(rad/s)\n', Ke);
+fprintf('\n--- Time Constants ---\n');
+fprintf('Electrical tau_e:  %.3f ms\n', tau_e * 1000);
+fprintf('Mechanical tau_m:  %.3f ms (estimated)\n', tau_m * 1000);
+fprintf('\n--- Control ---\n');
+fprintf('Sample Time:       %.0f ms (%.0f Hz)\n', Ts * 1000, 1/Ts);
+fprintf('Max Wheel Speed:   %.2f m/s\n', max_linear_speed);
+fprintf('============================================\n');

--- a/matlab/pid_config_output.txt
+++ b/matlab/pid_config_output.txt
@@ -1,0 +1,13 @@
+// Auto-generated PID configuration
+// Sample Time: 10 ms (100 Hz)
+// Target Bandwidth: 20 rad/s
+
+star_pid_config_t velocity_pid_config = {
+    .kp = 0.158869f,
+    .ki = 7.032521f,
+    .kd = 0.000000f,
+    .output_min = -100.0f,
+    .output_max = 100.0f,
+    .integral_min = -100.0f,
+    .integral_max = 100.0f,
+};

--- a/matlab/pid_config_output.txt
+++ b/matlab/pid_config_output.txt
@@ -3,8 +3,8 @@
 // Target Bandwidth: 20 rad/s
 
 star_pid_config_t velocity_pid_config = {
-    .kp = 0.158869f,
-    .ki = 7.032521f,
+    .kp = 0.285647f,
+    .ki = 8.008388f,
     .kd = 0.000000f,
     .output_min = -100.0f,
     .output_max = 100.0f,

--- a/matlab/pid_config_output.txt
+++ b/matlab/pid_config_output.txt
@@ -8,6 +8,6 @@ star_pid_config_t velocity_pid_config = {
     .kd = 0.000000f,
     .output_min = -100.0f,
     .output_max = 100.0f,
-    .integral_min = -100.0f,
-    .integral_max = 100.0f,
+    .integral_min = -50.0f,   // 50% of output range for anti-windup
+    .integral_max = 50.0f,    // 50% of output range for anti-windup
 };

--- a/matlab/pid_design_velocity.m
+++ b/matlab/pid_design_velocity.m
@@ -1,0 +1,196 @@
+%% pid_design_velocity.m - Velocity Loop PID Design
+% Designs a PID controller for motor velocity control using MATLAB's
+% automatic tuning tools (pidtune) and interactive tuner (pidTuner).
+%
+% The gains are compatible with the ESP32 star_pid library parallel form:
+%   u = Kp*e + Ki*integral(e) + Kd*d(e)/dt
+%
+% USAGE:
+%   >> pid_design_velocity        % Auto-tune and display results
+%   >> pidTuner(motor_tf, 'PID')  % Interactive tuning
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Load Motor Model
+motor_model_1st_order;
+
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('       VELOCITY LOOP PID DESIGN FOR STAR ROBOT\n');
+fprintf('=======================================================\n');
+
+%% Design Specifications
+fprintf('\n=== Design Specifications ===\n');
+
+% Target specifications for velocity control
+target_bandwidth = 20;        % rad/s - desired closed-loop bandwidth
+target_phase_margin = 60;     % degrees - for stability margin
+target_settling_time = 0.1;   % seconds - 100ms settling
+
+fprintf('Target Bandwidth:      %.0f rad/s (%.1f Hz)\n', target_bandwidth, target_bandwidth/(2*pi));
+fprintf('Target Phase Margin:   %.0f degrees\n', target_phase_margin);
+fprintf('Target Settling Time:  %.0f ms\n', target_settling_time * 1000);
+
+%% Automatic PID Tuning - Default
+fprintf('\n=== Auto-Tuned PID (Default) ===\n');
+
+% Use MATLAB's pidtune for automatic tuning
+[C_pid_default, info_default] = pidtune(motor_tf, 'PID');
+
+fprintf('Default Auto-Tune Results:\n');
+fprintf('  Kp = %.4f\n', C_pid_default.Kp);
+fprintf('  Ki = %.4f\n', C_pid_default.Ki);
+fprintf('  Kd = %.4f\n', C_pid_default.Kd);
+fprintf('  Achieved Bandwidth: %.1f rad/s\n', info_default.CrossoverFrequency);
+fprintf('  Phase Margin:       %.1f degrees\n', info_default.PhaseMargin);
+
+%% Automatic PID Tuning - With Bandwidth Target
+fprintf('\n=== Auto-Tuned PID (Bandwidth = %.0f rad/s) ===\n', target_bandwidth);
+
+opts = pidtuneOptions('CrossoverFrequency', target_bandwidth, ...
+                      'PhaseMargin', target_phase_margin);
+[C_pid_bw, info_bw] = pidtune(motor_tf, 'PID', opts);
+
+fprintf('Bandwidth-Targeted Results:\n');
+fprintf('  Kp = %.4f\n', C_pid_bw.Kp);
+fprintf('  Ki = %.4f\n', C_pid_bw.Ki);
+fprintf('  Kd = %.4f\n', C_pid_bw.Kd);
+fprintf('  Achieved Bandwidth: %.1f rad/s\n', info_bw.CrossoverFrequency);
+fprintf('  Phase Margin:       %.1f degrees\n', info_bw.PhaseMargin);
+
+%% Automatic PI Tuning (No Derivative)
+fprintf('\n=== Auto-Tuned PI (No Derivative) ===\n');
+
+[C_pi, info_pi] = pidtune(motor_tf, 'PI', opts);
+
+fprintf('PI Controller Results:\n');
+fprintf('  Kp = %.4f\n', C_pi.Kp);
+fprintf('  Ki = %.4f\n', C_pi.Ki);
+fprintf('  Kd = 0 (PI only)\n');
+fprintf('  Achieved Bandwidth: %.1f rad/s\n', info_pi.CrossoverFrequency);
+fprintf('  Phase Margin:       %.1f degrees\n', info_pi.PhaseMargin);
+
+%% Select Best Controller
+% Use bandwidth-targeted PID as default
+C_pid = C_pid_bw;
+Kp = C_pid.Kp;
+Ki = C_pid.Ki;
+Kd = C_pid.Kd;
+
+fprintf('\n=== SELECTED CONTROLLER ===\n');
+fprintf('Using bandwidth-targeted PID:\n');
+fprintf('  Kp = %.4f\n', Kp);
+fprintf('  Ki = %.4f\n', Ki);
+fprintf('  Kd = %.4f\n', Kd);
+
+%% Closed-Loop Analysis
+fprintf('\n=== Closed-Loop Analysis ===\n');
+
+% Create closed-loop system
+sys_cl = feedback(C_pid * motor_tf, 1);
+
+% Step response info
+info_cl = stepinfo(sys_cl);
+fprintf('Step Response Metrics:\n');
+fprintf('  Rise Time:      %.3f s\n', info_cl.RiseTime);
+fprintf('  Settling Time:  %.3f s\n', info_cl.SettlingTime);
+fprintf('  Overshoot:      %.1f%%\n', info_cl.Overshoot);
+fprintf('  Peak:           %.3f rad/s (for 1 rad/s step)\n', info_cl.Peak);
+
+% Stability margins
+[Gm, Pm, Wcg, Wcp] = margin(C_pid * motor_tf);
+fprintf('\nStability Margins:\n');
+fprintf('  Gain Margin:    %.1f dB at %.1f rad/s\n', 20*log10(Gm), Wcg);
+fprintf('  Phase Margin:   %.1f degrees at %.1f rad/s\n', Pm, Wcp);
+
+%% Sensitivity Analysis
+fprintf('\n=== Sensitivity Analysis ===\n');
+
+S = feedback(1, C_pid * motor_tf);          % Sensitivity
+T = feedback(C_pid * motor_tf, 1);          % Complementary sensitivity
+SG = feedback(motor_tf, C_pid * motor_tf);  % Load disturbance
+
+% Peak sensitivities
+[Ms, wMs] = getPeakGain(S);
+[Mt, wMt] = getPeakGain(T);
+
+fprintf('Peak Sensitivity:  Ms = %.2f (%.1f dB) at %.1f rad/s\n', Ms, 20*log10(Ms), wMs);
+fprintf('Peak Comp. Sens.:  Mt = %.2f (%.1f dB) at %.1f rad/s\n', Mt, 20*log10(Mt), wMt);
+
+if Ms < 2
+    fprintf('Sensitivity OK (Ms < 2)\n');
+else
+    fprintf('WARNING: High sensitivity (Ms >= 2). Consider reducing bandwidth.\n');
+end
+
+%% Plot Results
+figure('Name', 'Velocity PID Design Results', 'Position', [100 100 1200 800]);
+
+% Step Response Comparison
+subplot(2,3,1);
+step(sys_cl, feedback(C_pi * motor_tf, 1), feedback(C_pid_default * motor_tf, 1));
+title('Closed-Loop Step Response');
+ylabel('Angular Velocity (rad/s)');
+legend('PID (BW target)', 'PI only', 'PID (default)', 'Location', 'southeast');
+grid on;
+
+% Open-Loop Bode
+subplot(2,3,2);
+margin(C_pid * motor_tf);
+title('Open-Loop Frequency Response');
+
+% Sensitivity Functions
+subplot(2,3,3);
+bodemag(S, T, SG);
+title('Sensitivity Functions');
+legend('S (sensitivity)', 'T (comp. sens.)', 'SG (dist. reject.)', 'Location', 'southwest');
+grid on;
+
+% Nichols Chart
+subplot(2,3,4);
+nichols(C_pid * motor_tf);
+ngrid;
+title('Nichols Chart');
+
+% Root Locus
+subplot(2,3,5);
+rlocus(motor_tf);
+title('Root Locus (Plant Only)');
+grid on;
+
+% Closed-Loop Poles
+subplot(2,3,6);
+pzmap(sys_cl);
+title('Closed-Loop Pole-Zero Map');
+grid on;
+
+%% Format for ESP32 star_pid Library
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('       ESP32 star_pid CONFIGURATION\n');
+fprintf('=======================================================\n');
+fprintf('\n');
+fprintf('// Copy this to your ESP32 initialization code:\n');
+fprintf('star_pid_config_t velocity_pid_config = {\n');
+fprintf('    .kp = %.6ff,\n', Kp);
+fprintf('    .ki = %.6ff,\n', Ki);
+fprintf('    .kd = %.6ff,\n', Kd);
+fprintf('    .output_min = -100.0f,   // -100%% duty cycle\n');
+fprintf('    .output_max = 100.0f,    // +100%% duty cycle\n');
+fprintf('    .integral_min = -50.0f,  // Anti-windup\n');
+fprintf('    .integral_max = 50.0f,   // Anti-windup\n');
+fprintf('};\n');
+fprintf('star_pid_init(&velocity_pid, &velocity_pid_config);\n');
+
+%% Interactive Tuning Option
+fprintf('\n=== Interactive Tuning ===\n');
+fprintf('For interactive tuning, run:\n');
+fprintf('  >> pidTuner(motor_tf, ''PID'')\n');
+fprintf('\nThis opens a GUI to adjust gains and see real-time response.\n');
+
+%% Save to Workspace
+fprintf('\n=== Saved to Workspace ===\n');
+fprintf('C_pid      - PID controller object\n');
+fprintf('Kp, Ki, Kd - Individual gains\n');
+fprintf('sys_cl     - Closed-loop transfer function\n');

--- a/matlab/pid_discretize.m
+++ b/matlab/pid_discretize.m
@@ -206,8 +206,8 @@ output_min = -100.0;
 
 % Integral term should not exceed what could saturate output alone
 % At steady-state error, I_term = Ki * error * t_accum
-% To prevent windup, limit I_term to +/- 50% of output range
-integral_limit = 0.5 * (output_max - output_min);
+% To prevent windup, limit I_term to +/- 50% of output max
+integral_limit = 0.5 * output_max;  % 50% of max = 50
 
 fprintf('Output Limits:     [%.0f, %.0f] %%\n', output_min, output_max);
 fprintf('Integral Limits:   [%.0f, %.0f] (50%% of output range)\n', -integral_limit, integral_limit);

--- a/matlab/pid_discretize.m
+++ b/matlab/pid_discretize.m
@@ -1,0 +1,235 @@
+%% pid_discretize.m - Discretize PID for ESP32 Implementation
+% Converts continuous-time PID gains to discrete form for ESP32 deployment.
+%
+% The ESP32 star_pid library uses the parallel form with rectangular
+% integration for the integral term and backward difference for derivative:
+%
+%   P[k] = Kp * e[k]
+%   I[k] = I[k-1] + Ki * e[k] * dt
+%   D[k] = Kd * (e[k] - e[k-1]) / dt
+%   u[k] = P[k] + I[k] + D[k]
+%
+% This script validates that the continuous gains work correctly when
+% discretized at 100 Hz (Ts = 10ms).
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Configuration
+clear; clc;
+
+% Sample time (100 Hz motor control loop)
+Ts = 0.01;  % 10 ms
+Fs = 1 / Ts;  % 100 Hz
+
+fprintf('=== PID Discretization for ESP32 ===\n');
+fprintf('Sample Time: %.0f ms (%.0f Hz)\n', Ts * 1000, Fs);
+
+%% Load Motor Model and Design PID
+motor_model_1st_order;
+fprintf('\n');
+
+% Design continuous PID
+target_bandwidth = 20;  % rad/s
+opts = pidtuneOptions('CrossoverFrequency', target_bandwidth);
+[C_pid_cont, info] = pidtune(motor_tf, 'PID', opts);
+
+Kp = C_pid_cont.Kp;
+Ki = C_pid_cont.Ki;
+Kd = C_pid_cont.Kd;
+
+fprintf('Continuous PID Gains:\n');
+fprintf('  Kp = %.6f\n', Kp);
+fprintf('  Ki = %.6f\n', Ki);
+fprintf('  Kd = %.6f\n', Kd);
+
+%% Discretize Using Tustin (Bilinear) Transform
+fprintf('\n=== Tustin (Bilinear) Discretization ===\n');
+
+C_pid_tustin = c2d(C_pid_cont, Ts, 'tustin');
+[num_tustin, den_tustin] = tfdata(C_pid_tustin, 'v');
+
+fprintf('Discrete Transfer Function (Tustin):\n');
+C_pid_tustin
+
+fprintf('Numerator coefficients:   [%.6f, %.6f, %.6f]\n', num_tustin);
+fprintf('Denominator coefficients: [%.6f, %.6f, %.6f]\n', den_tustin);
+
+%% Discretize Using Forward Euler (Matches star_pid)
+fprintf('\n=== Forward Euler Discretization (Matches star_pid) ===\n');
+
+% The star_pid library uses:
+% - Rectangular integration: I[k] = I[k-1] + Ki * e[k] * dt
+% - Backward difference: D[k] = Kd * (e[k] - e[k-1]) / dt
+%
+% This is effectively "Forward Euler" for I and "Backward Euler" for D
+
+% For the parallel form, gains don't need transformation:
+Kp_d = Kp;              % Proportional: no change
+Ki_d = Ki;              % Integral: Ki * Ts applied per sample in code
+Kd_d = Kd;              % Derivative: Kd / Ts applied per sample in code
+
+fprintf('Discrete Gains (for star_pid parallel form):\n');
+fprintf('  Kp = %.6f (same as continuous)\n', Kp_d);
+fprintf('  Ki = %.6f (multiply by Ts=%.3f in each iteration)\n', Ki_d, Ts);
+fprintf('  Kd = %.6f (divide by Ts=%.3f in each iteration)\n', Kd_d, Ts);
+fprintf('\nPer-sample contributions:\n');
+fprintf('  I_increment = Ki * e * Ts = %.6f * e\n', Ki_d * Ts);
+fprintf('  D_term = Kd * (e - e_prev) / Ts = %.3f * delta_e\n', Kd_d / Ts);
+
+%% Compare Continuous vs Discrete Step Response
+fprintf('\n=== Comparing Continuous vs Discrete ===\n');
+
+% Discretize plant
+motor_tf_d = c2d(motor_tf, Ts, 'zoh');
+
+% Continuous closed-loop
+sys_cl_cont = feedback(C_pid_cont * motor_tf, 1);
+
+% Discrete closed-loop (Tustin)
+sys_cl_tustin = feedback(C_pid_tustin * motor_tf_d, 1);
+
+% Create a discrete PID using forward Euler (like star_pid)
+% P(z) = Kp
+% I(z) = Ki * Ts * z / (z - 1)  [Forward Euler]
+% D(z) = Kd * (z - 1) / (Ts * z) [Backward Euler]
+z = tf('z', Ts);
+if Kd > 0
+    C_pid_euler = Kp + Ki * Ts * z / (z - 1) + Kd * (z - 1) / (Ts * z);
+else
+    % PI only (no derivative term)
+    C_pid_euler = Kp + Ki * Ts * z / (z - 1);
+end
+sys_cl_euler = feedback(C_pid_euler * motor_tf_d, 1);
+
+% Step response comparison
+figure('Name', 'Continuous vs Discrete PID Comparison');
+
+subplot(2,2,1);
+t = 0:Ts:0.5;
+[y_cont, t_cont] = step(sys_cl_cont, t);
+[y_tustin, ~] = step(sys_cl_tustin, t);
+[y_euler, ~] = step(sys_cl_euler, t);
+
+plot(t_cont, y_cont, 'b-', 'LineWidth', 2); hold on;
+stairs(t, y_tustin, 'r--', 'LineWidth', 1.5);
+stairs(t, y_euler, 'g:', 'LineWidth', 1.5);
+xlabel('Time (s)');
+ylabel('Angular Velocity (rad/s)');
+title('Step Response Comparison');
+legend('Continuous', 'Discrete (Tustin)', 'Discrete (Euler)', 'Location', 'southeast');
+grid on;
+
+subplot(2,2,2);
+error_tustin = y_cont - y_tustin;
+error_euler = y_cont - y_euler;
+plot(t, error_tustin, 'r-', t, error_euler, 'g-');
+xlabel('Time (s)');
+ylabel('Error from Continuous');
+title('Discretization Error');
+legend('Tustin Error', 'Euler Error');
+grid on;
+
+subplot(2,2,3);
+bode(C_pid_cont, C_pid_tustin, C_pid_euler);
+title('PID Controller Frequency Response');
+legend('Continuous', 'Tustin', 'Euler');
+
+subplot(2,2,4);
+nyquist(C_pid_cont * motor_tf);
+title('Nyquist Plot (Continuous)');
+grid on;
+
+%% Verify Sampling Rate Adequacy
+fprintf('\n=== Sampling Rate Verification ===\n');
+
+% Nyquist frequency
+f_nyquist = Fs / 2;
+omega_nyquist = 2 * pi * f_nyquist;
+
+% Closed-loop bandwidth (use stepinfo as fallback)
+try
+    bw_cl = bandwidth(sys_cl_cont);
+    if isa(bw_cl, 'tf') || isempty(bw_cl) || ~isfinite(bw_cl)
+        % Fallback: estimate from step response
+        info_cl = stepinfo(sys_cl_cont);
+        bw_cl = 0.35 / info_cl.RiseTime;  % Approximate bandwidth
+    end
+catch
+    % Fallback: estimate from step response
+    info_cl = stepinfo(sys_cl_cont);
+    bw_cl = 0.35 / info_cl.RiseTime;  % Approximate bandwidth
+end
+
+fprintf('Nyquist Frequency:     %.1f Hz (%.1f rad/s)\n', f_nyquist, omega_nyquist);
+fprintf('Closed-Loop Bandwidth: %.1f rad/s (%.1f Hz)\n', bw_cl, bw_cl/(2*pi));
+fprintf('Oversampling Ratio:    %.1fx\n', omega_nyquist / bw_cl);
+
+if omega_nyquist > 5 * bw_cl
+    fprintf('Sampling rate is ADEQUATE (>5x bandwidth)\n');
+elseif omega_nyquist > 2 * bw_cl
+    fprintf('Sampling rate is MARGINAL (2-5x bandwidth)\n');
+else
+    fprintf('WARNING: Sampling rate may be TOO LOW (<2x bandwidth)\n');
+end
+
+%% Generate ESP32 Code
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('       ESP32 star_pid CONFIGURATION (VERIFIED)\n');
+fprintf('=======================================================\n');
+fprintf('\n');
+fprintf('// Velocity PID for 100 Hz control loop\n');
+fprintf('// Verified: Discrete response matches continuous within %.1f%%\n', ...
+        max(abs(error_euler)) / max(y_cont) * 100);
+fprintf('\n');
+fprintf('star_pid_config_t velocity_pid_config = {\n');
+fprintf('    .kp = %.6ff,\n', Kp);
+fprintf('    .ki = %.6ff,\n', Ki);
+fprintf('    .kd = %.6ff,\n', Kd);
+fprintf('    .output_min = -100.0f,   // -100%% duty cycle\n');
+fprintf('    .output_max = 100.0f,    // +100%% duty cycle\n');
+fprintf('    .integral_min = -50.0f,  // Anti-windup\n');
+fprintf('    .integral_max = 50.0f,   // Anti-windup\n');
+fprintf('};\n');
+fprintf('\n');
+fprintf('// In control loop (every 10ms = 100Hz):\n');
+fprintf('float dt = 0.01f;  // 10ms sample time\n');
+fprintf('star_pid_compute(&velocity_pid, setpoint_rpm, measured_rpm, dt, &output);\n');
+
+%% Anti-Windup Considerations
+fprintf('\n=== Anti-Windup Configuration ===\n');
+
+% Calculate integral limits based on output saturation
+output_max = 100.0;  % Maximum duty cycle percentage
+output_min = -100.0;
+
+% Integral term should not exceed what could saturate output alone
+% At steady-state error, I_term = Ki * error * t_accum
+% To prevent windup, limit I_term to +/- 50% of output range
+integral_limit = 0.5 * (output_max - output_min);
+
+fprintf('Output Limits:     [%.0f, %.0f] %%\n', output_min, output_max);
+fprintf('Integral Limits:   [%.0f, %.0f] (50%% of output range)\n', -integral_limit, integral_limit);
+fprintf('\nNote: These limits are for the accumulated integral VALUE,\n');
+fprintf('not the Ki gain itself.\n');
+
+%% Save Configuration to File
+config_file = 'pid_config_output.txt';
+fid = fopen(config_file, 'w');
+fprintf(fid, '// Auto-generated PID configuration\n');
+fprintf(fid, '// Sample Time: %.0f ms (%.0f Hz)\n', Ts * 1000, Fs);
+fprintf(fid, '// Target Bandwidth: %.0f rad/s\n', target_bandwidth);
+fprintf(fid, '\n');
+fprintf(fid, 'star_pid_config_t velocity_pid_config = {\n');
+fprintf(fid, '    .kp = %.6ff,\n', Kp);
+fprintf(fid, '    .ki = %.6ff,\n', Ki);
+fprintf(fid, '    .kd = %.6ff,\n', Kd);
+fprintf(fid, '    .output_min = %.1ff,\n', output_min);
+fprintf(fid, '    .output_max = %.1ff,\n', output_max);
+fprintf(fid, '    .integral_min = %.1ff,\n', -integral_limit);
+fprintf(fid, '    .integral_max = %.1ff,\n', integral_limit);
+fprintf(fid, '};\n');
+fclose(fid);
+
+fprintf('\n=== Configuration saved to %s ===\n', config_file);

--- a/matlab/simulate_step_response.m
+++ b/matlab/simulate_step_response.m
@@ -61,13 +61,15 @@ error_rads = setpoint_rads' - velocity_rads;
 %% Add Disturbance Simulation
 fprintf('--- Adding Disturbance ---\n');
 
-% Disturbance: torque disturbance at t=1.0s (load applied)
+% Disturbance: output disturbance at t=1.0s (models load torque effect on velocity)
+% Magnitude represents velocity deviation in rad/s if uncontrolled
 disturbance = zeros(size(t));
-disturbance(t >= 1.0 & t < 1.5) = 50;  % 50% equivalent load
+disturbance(t >= 1.0 & t < 1.5) = 5;  % 5 rad/s (~48 RPM) disturbance
 
-% Simulate with disturbance (approximate as output disturbance)
-sys_dist = feedback(motor_tf_d, C_pid_d);  % Disturbance rejection TF
-[dist_response, ~] = lsim(sys_dist, disturbance', t);
+% Simulate with disturbance using sensitivity function S = 1/(1+GC)
+% Output disturbance rejection: y_dist = S * d
+sys_sensitivity = feedback(1, C_pid_d * motor_tf_d);  % S = 1/(1+GC)
+[dist_response, ~] = lsim(sys_sensitivity, disturbance', t);
 velocity_with_dist = velocity_rpm + dist_response * (60/(2*pi));
 
 %% Calculate Performance Metrics

--- a/matlab/simulate_step_response.m
+++ b/matlab/simulate_step_response.m
@@ -1,0 +1,267 @@
+%% simulate_step_response.m - Motor Control Simulation
+% Simulates the closed-loop step response with PID control and
+% analyzes performance metrics.
+%
+% Features:
+% - Step response simulation
+% - Disturbance rejection analysis
+% - Setpoint tracking
+% - Control effort visualization
+% - Performance metrics comparison
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Setup
+clear; clc;
+fprintf('=== STAR Motor Control Simulation ===\n');
+
+%% Load Motor Model and PID
+motor_model_1st_order;
+pid_design_velocity;
+
+fprintf('\n=== Starting Simulation ===\n');
+
+%% Simulation Parameters
+Ts = 0.01;           % 10 ms sample time (100 Hz)
+T_sim = 2.0;         % 2 second simulation
+t = 0:Ts:T_sim;
+N = length(t);
+
+% Setpoint profile: step from 0 to 100 RPM at t=0.2s
+setpoint_rpm = zeros(size(t));
+setpoint_rpm(t >= 0.2) = 100;  % 100 RPM step
+
+% Convert to rad/s for internal calculations
+setpoint_rads = setpoint_rpm * (2*pi/60);
+
+fprintf('Simulation Duration: %.1f s\n', T_sim);
+fprintf('Sample Time:         %.0f ms\n', Ts * 1000);
+fprintf('Setpoint:            %.0f RPM step at t=0.2s\n', 100);
+
+%% Discretize Plant and Controller
+motor_tf_d = c2d(motor_tf, Ts, 'zoh');
+C_pid_d = c2d(C_pid, Ts, 'tustin');
+
+% Create closed-loop system
+sys_cl_d = feedback(C_pid_d * motor_tf_d, 1);
+
+%% Simulate Step Response
+fprintf('\n--- Running Simulation ---\n');
+
+% Use lsim for discrete simulation
+[velocity_rads, ~] = lsim(sys_cl_d, setpoint_rads, t);
+velocity_rpm = velocity_rads * (60/(2*pi));
+
+% Calculate control effort
+% u = C * e, where e = setpoint - velocity
+error_rads = setpoint_rads' - velocity_rads;
+[control_output, ~] = lsim(C_pid_d, error_rads, t);
+
+%% Add Disturbance Simulation
+fprintf('--- Adding Disturbance ---\n');
+
+% Disturbance: torque disturbance at t=1.0s (load applied)
+disturbance = zeros(size(t));
+disturbance(t >= 1.0 & t < 1.5) = 50;  % 50% equivalent load
+
+% Simulate with disturbance (approximate as output disturbance)
+sys_dist = feedback(motor_tf_d, C_pid_d);  % Disturbance rejection TF
+[dist_response, ~] = lsim(sys_dist, disturbance', t);
+velocity_with_dist = velocity_rpm + dist_response * (60/(2*pi));
+
+%% Calculate Performance Metrics
+fprintf('\n=== Performance Metrics ===\n');
+
+% Find step response after t=0.2s
+idx_step = find(t >= 0.2, 1);
+step_response = velocity_rpm(idx_step:end);
+step_time = t(idx_step:end) - t(idx_step);
+
+% Final value
+final_value = setpoint_rpm(end);
+
+% Rise time (10% to 90%)
+idx_10 = find(step_response >= 0.1 * final_value, 1);
+idx_90 = find(step_response >= 0.9 * final_value, 1);
+if ~isempty(idx_10) && ~isempty(idx_90)
+    rise_time = step_time(idx_90) - step_time(idx_10);
+else
+    rise_time = NaN;
+end
+
+% Settling time (within 2%)
+settling_band = 0.02 * final_value;
+idx_settled = find(abs(step_response - final_value) <= settling_band, 1);
+if ~isempty(idx_settled)
+    settling_time = step_time(idx_settled);
+else
+    settling_time = NaN;
+end
+
+% Overshoot
+peak_value = max(step_response);
+overshoot = (peak_value - final_value) / final_value * 100;
+if overshoot < 0
+    overshoot = 0;
+end
+
+% Steady-state error
+ss_error = abs(final_value - mean(step_response(end-10:end)));
+
+fprintf('Rise Time (10-90%%):  %.3f s\n', rise_time);
+fprintf('Settling Time (2%%):  %.3f s\n', settling_time);
+fprintf('Overshoot:           %.1f%%\n', overshoot);
+fprintf('Peak Value:          %.1f RPM\n', peak_value);
+fprintf('Steady-State Error:  %.2f RPM\n', ss_error);
+
+%% Disturbance Rejection Metrics
+fprintf('\n=== Disturbance Rejection ===\n');
+
+idx_dist = find(t >= 1.0, 1);
+dist_deviation = velocity_with_dist(idx_dist:end) - velocity_rpm(idx_dist:end);
+max_dist_deviation = max(abs(dist_deviation));
+dist_recovery_idx = find(abs(dist_deviation(50:end)) < 2, 1) + 50;  % Within 2 RPM
+if ~isempty(dist_recovery_idx)
+    dist_recovery_time = (dist_recovery_idx - 1) * Ts;
+else
+    dist_recovery_time = NaN;
+end
+
+fprintf('Max Disturbance Deviation: %.1f RPM\n', max_dist_deviation);
+fprintf('Disturbance Recovery Time: %.3f s\n', dist_recovery_time);
+
+%% Plot Results
+figure('Name', 'Motor Control Simulation', 'Position', [100 100 1400 900]);
+
+% Velocity Response
+subplot(2,3,1);
+plot(t, velocity_rpm, 'b-', 'LineWidth', 2); hold on;
+plot(t, setpoint_rpm, 'r--', 'LineWidth', 1.5);
+xlabel('Time (s)');
+ylabel('Velocity (RPM)');
+title('Velocity Step Response');
+legend('Actual', 'Setpoint', 'Location', 'southeast');
+grid on;
+ylim([-10 120]);
+
+% Velocity with Disturbance
+subplot(2,3,2);
+plot(t, velocity_with_dist, 'b-', 'LineWidth', 2); hold on;
+plot(t, setpoint_rpm, 'r--', 'LineWidth', 1.5);
+area(t, disturbance * 0.5, 'FaceColor', [1 0.8 0.8], 'EdgeColor', 'none', 'FaceAlpha', 0.5);
+xlabel('Time (s)');
+ylabel('Velocity (RPM)');
+title('Response with Load Disturbance');
+legend('Actual', 'Setpoint', 'Disturbance', 'Location', 'southeast');
+grid on;
+ylim([-10 150]);
+
+% Control Effort
+subplot(2,3,3);
+plot(t, control_output, 'g-', 'LineWidth', 1.5); hold on;
+yline(100, 'r--', 'Saturation');
+yline(-100, 'r--');
+xlabel('Time (s)');
+ylabel('Control Output (%)');
+title('Control Effort (PWM Duty Cycle)');
+grid on;
+ylim([-120 120]);
+
+% Error Signal
+subplot(2,3,4);
+error_rpm = setpoint_rpm' - velocity_rpm;
+plot(t, error_rpm, 'm-', 'LineWidth', 1.5);
+xlabel('Time (s)');
+ylabel('Error (RPM)');
+title('Tracking Error');
+grid on;
+
+% Zoomed Step Response
+subplot(2,3,5);
+idx_zoom = t >= 0.15 & t <= 0.6;
+plot(t(idx_zoom), velocity_rpm(idx_zoom), 'b-', 'LineWidth', 2); hold on;
+plot(t(idx_zoom), setpoint_rpm(idx_zoom), 'r--', 'LineWidth', 1.5);
+yline(final_value * 0.9, 'g:', '90%');
+yline(final_value * 1.02, 'c:', '+2%');
+yline(final_value * 0.98, 'c:', '-2%');
+xlabel('Time (s)');
+ylabel('Velocity (RPM)');
+title('Step Response (Zoomed)');
+legend('Actual', 'Setpoint', 'Location', 'southeast');
+grid on;
+
+% Performance Summary
+subplot(2,3,6);
+axis off;
+text(0.1, 0.9, 'Performance Summary', 'FontSize', 14, 'FontWeight', 'bold');
+text(0.1, 0.75, sprintf('Rise Time: %.0f ms', rise_time * 1000), 'FontSize', 12);
+text(0.1, 0.60, sprintf('Settling Time: %.0f ms', settling_time * 1000), 'FontSize', 12);
+text(0.1, 0.45, sprintf('Overshoot: %.1f%%', overshoot), 'FontSize', 12);
+text(0.1, 0.30, sprintf('SS Error: %.2f RPM', ss_error), 'FontSize', 12);
+text(0.1, 0.15, sprintf('Max Dist. Dev: %.1f RPM', max_dist_deviation), 'FontSize', 12);
+
+% PID Gains
+text(0.55, 0.9, 'PID Gains', 'FontSize', 14, 'FontWeight', 'bold');
+text(0.55, 0.75, sprintf('Kp = %.4f', Kp), 'FontSize', 12);
+text(0.55, 0.60, sprintf('Ki = %.4f', Ki), 'FontSize', 12);
+text(0.55, 0.45, sprintf('Kd = %.4f', Kd), 'FontSize', 12);
+text(0.55, 0.30, sprintf('Sample Rate: %.0f Hz', 1/Ts), 'FontSize', 12);
+
+%% Compare Different Tuning Strategies
+fprintf('\n=== Comparing Tuning Strategies ===\n');
+
+figure('Name', 'Tuning Strategy Comparison', 'Position', [200 200 1000 600]);
+
+% Conservative tuning (lower bandwidth)
+opts_cons = pidtuneOptions('CrossoverFrequency', 10);
+[C_cons, ~] = pidtune(motor_tf, 'PID', opts_cons);
+sys_cons = feedback(c2d(C_cons, Ts, 'tustin') * motor_tf_d, 1);
+[y_cons, ~] = lsim(sys_cons, setpoint_rads, t);
+
+% Aggressive tuning (higher bandwidth)
+opts_aggr = pidtuneOptions('CrossoverFrequency', 30);
+[C_aggr, ~] = pidtune(motor_tf, 'PID', opts_aggr);
+sys_aggr = feedback(c2d(C_aggr, Ts, 'tustin') * motor_tf_d, 1);
+[y_aggr, ~] = lsim(sys_aggr, setpoint_rads, t);
+
+subplot(1,2,1);
+plot(t, y_cons * (60/(2*pi)), 'b-', 'LineWidth', 1.5); hold on;
+plot(t, velocity_rpm, 'g-', 'LineWidth', 1.5);
+plot(t, y_aggr * (60/(2*pi)), 'r-', 'LineWidth', 1.5);
+plot(t, setpoint_rpm, 'k--', 'LineWidth', 1);
+xlabel('Time (s)');
+ylabel('Velocity (RPM)');
+title('Tuning Strategy Comparison');
+legend('Conservative (BW=10)', 'Default (BW=20)', 'Aggressive (BW=30)', 'Setpoint', 'Location', 'southeast');
+grid on;
+
+subplot(1,2,2);
+info_cons = stepinfo(sys_cons);
+info_default = stepinfo(sys_cl_d);
+info_aggr = stepinfo(sys_aggr);
+
+bar_data = [info_cons.RiseTime*1000, info_default.RiseTime*1000, info_aggr.RiseTime*1000;
+            info_cons.SettlingTime*1000, info_default.SettlingTime*1000, info_aggr.SettlingTime*1000;
+            info_cons.Overshoot, info_default.Overshoot, info_aggr.Overshoot];
+bar(bar_data');
+set(gca, 'XTickLabel', {'Conservative', 'Default', 'Aggressive'});
+legend('Rise Time (ms)', 'Settling Time (ms)', 'Overshoot (%)', 'Location', 'northwest');
+title('Performance Comparison');
+ylabel('Value');
+grid on;
+
+fprintf('Conservative: Rise=%.0fms, Settle=%.0fms, OS=%.1f%%\n', ...
+    info_cons.RiseTime*1000, info_cons.SettlingTime*1000, info_cons.Overshoot);
+fprintf('Default:      Rise=%.0fms, Settle=%.0fms, OS=%.1f%%\n', ...
+    info_default.RiseTime*1000, info_default.SettlingTime*1000, info_default.Overshoot);
+fprintf('Aggressive:   Rise=%.0fms, Settle=%.0fms, OS=%.1f%%\n', ...
+    info_aggr.RiseTime*1000, info_aggr.SettlingTime*1000, info_aggr.Overshoot);
+
+%% Save Simulation Data
+fprintf('\n=== Saved to Workspace ===\n');
+fprintf('t             - Time vector\n');
+fprintf('velocity_rpm  - Simulated velocity response\n');
+fprintf('setpoint_rpm  - Setpoint profile\n');
+fprintf('control_output - Control effort\n');
+fprintf('error_rpm     - Tracking error\n');

--- a/matlab/system_id_template.m
+++ b/matlab/system_id_template.m
@@ -237,7 +237,7 @@ fprintf('\n');
 % Also save to file
 fid = fopen('identified_params.txt', 'w');
 fprintf(fid, '%% Identified Motor Parameters\n');
-fprintf(fid, '%% Generated: %s\n\n', datestr(now));
+fprintf(fid, '%% Generated: %s\n\n', char(datetime('now', 'Format', 'dd-MMM-yyyy HH:mm:ss')));
 fprintf(fid, 'K_dc = %.6f;     %% DC gain [rad/s per volt]\n', K_id);
 fprintf(fid, 'tau_est = %.6f;  %% Time constant [s]\n', tau_id);
 fprintf(fid, '\n%% First-order transfer function:\n');

--- a/matlab/system_id_template.m
+++ b/matlab/system_id_template.m
@@ -1,0 +1,275 @@
+%% system_id_template.m - System Identification from Motor Data
+% Template for identifying motor transfer function from experimental data.
+%
+% WORKFLOW:
+% 1. Collect step response data from ESP32 (encoder counts at 100 Hz)
+% 2. Import data into MATLAB
+% 3. Fit transfer function model
+% 4. Validate model
+% 5. Export parameters to motor_params.m
+%
+% STAR Project - Texas A&M University
+% December 2025
+
+%% Configuration
+clear; clc;
+fprintf('=== Motor System Identification ===\n');
+
+%% Step 1: Data Collection Instructions
+fprintf('\n=== STEP 1: DATA COLLECTION ===\n');
+fprintf('Run the following test on the ESP32:\n\n');
+fprintf('1. Start with motor at rest\n');
+fprintf('2. Apply step voltage (e.g., 50%% duty cycle = 3V)\n');
+fprintf('3. Log encoder counts at 100 Hz for 2 seconds\n');
+fprintf('4. Save as CSV: [time_ms, encoder_counts]\n');
+fprintf('\nESP32 code example:\n');
+fprintf('-------------------------------------------\n');
+fprintf('// In motor control task (100 Hz)\n');
+fprintf('static uint32_t start_time = 0;\n');
+fprintf('static bool logging = false;\n');
+fprintf('\n');
+fprintf('if (button_pressed && !logging) {\n');
+fprintf('    start_time = esp_timer_get_time() / 1000;\n');
+fprintf('    logging = true;\n');
+fprintf('    star_motor_set_duty(&motor, 50.0f);  // 50%% step\n');
+fprintf('}\n');
+fprintf('\n');
+fprintf('if (logging) {\n');
+fprintf('    uint32_t t = esp_timer_get_time() / 1000 - start_time;\n');
+fprintf('    int32_t counts;\n');
+fprintf('    star_encoder_get_count(&encoder, &counts);\n');
+fprintf('    printf("%%u,%%d\\n", t, counts);\n');
+fprintf('    if (t > 2000) logging = false;\n');
+fprintf('}\n');
+fprintf('-------------------------------------------\n');
+
+%% Step 2: Load Experimental Data
+fprintf('\n=== STEP 2: LOAD DATA ===\n');
+
+% Check if data file exists
+data_file = 'motor_step_data.csv';
+if exist(data_file, 'file')
+    fprintf('Loading data from %s...\n', data_file);
+    data = readmatrix(data_file);
+    t_exp = data(:,1) / 1000;  % Convert ms to seconds
+    counts_exp = data(:,2);
+    use_experimental = true;
+else
+    fprintf('No data file found (%s)\n', data_file);
+    fprintf('Using SIMULATED data for demonstration...\n\n');
+    use_experimental = false;
+
+    % Generate simulated step response data
+    motor_params;
+
+    % True plant (unknown to identification)
+    K_true = omega_no_load / V_rated;  % DC gain
+    tau_true = 0.05;  % 50ms time constant
+    G_true = tf(K_true, [tau_true 1]);
+
+    % Simulate step response at 50% duty = 3V
+    V_step = 3.0;  % 50% of 6V
+    Ts = 0.01;
+    t_exp = (0:Ts:2)';
+
+    % Add measurement noise
+    [y_ideal, ~] = step(G_true * V_step, t_exp);
+    noise = 0.5 * randn(size(y_ideal));  % 0.5 rad/s noise
+    omega_exp = y_ideal + noise;
+
+    % Convert to encoder counts
+    counts_per_rad = encoder_ppr / (2 * pi);
+    counts_exp = cumtrapz(t_exp, omega_exp) * counts_per_rad;
+end
+
+%% Step 3: Process Data
+fprintf('\n=== STEP 3: PROCESS DATA ===\n');
+
+% Load motor parameters for unit conversion
+motor_params;
+
+% Calculate velocity from encoder counts
+Ts = mean(diff(t_exp));
+fprintf('Detected sample time: %.1f ms\n', Ts * 1000);
+
+% Velocity = d(counts)/dt converted to rad/s
+velocity_counts_per_s = [0; diff(counts_exp)] / Ts;
+velocity_rads = velocity_counts_per_s / encoder_ppr * (2 * pi);
+velocity_rpm = velocity_rads * (60 / (2*pi));
+
+% Filter velocity (5-point moving average)
+velocity_rads_filt = movmean(velocity_rads, 5);
+velocity_rpm_filt = movmean(velocity_rpm, 5);
+
+fprintf('Max velocity: %.1f RPM\n', max(velocity_rpm_filt));
+fprintf('Final velocity: %.1f RPM\n', mean(velocity_rpm_filt(end-10:end)));
+
+%% Step 4: Fit First-Order Model
+fprintf('\n=== STEP 4: FIT FIRST-ORDER MODEL ===\n');
+
+% Input: step voltage (assume 50% duty = 3V)
+V_input = 3.0;
+u_exp = V_input * ones(size(t_exp));
+
+% Create iddata object
+data_id = iddata(velocity_rads_filt, u_exp, Ts);
+
+% Estimate first-order transfer function
+% G(s) = K / (tau*s + 1)
+sys_id_1 = tfest(data_id, 1, 0);  % 1 pole, 0 zeros
+
+fprintf('Identified First-Order Model:\n');
+sys_id_1
+
+% Extract parameters
+[num_id, den_id] = tfdata(sys_id_1, 'v');
+K_id = num_id(end) / den_id(end);  % DC gain
+tau_id = den_id(1) / den_id(2);     % Time constant
+
+fprintf('DC Gain K:       %.4f rad/s/V\n', K_id);
+fprintf('Time Constant:   %.1f ms\n', tau_id * 1000);
+
+%% Step 5: Fit Second-Order Model
+fprintf('\n=== STEP 5: FIT SECOND-ORDER MODEL ===\n');
+
+sys_id_2 = tfest(data_id, 2, 0);  % 2 poles, 0 zeros
+fprintf('Identified Second-Order Model:\n');
+sys_id_2
+
+%% Step 6: Model Validation
+fprintf('\n=== STEP 6: MODEL VALIDATION ===\n');
+
+% Simulate identified models
+[y_id_1, t_sim] = step(sys_id_1 * V_input, t_exp);
+[y_id_2, ~] = step(sys_id_2 * V_input, t_exp);
+
+% Calculate fit percentage
+fit_1 = 100 * (1 - norm(velocity_rads_filt - y_id_1) / norm(velocity_rads_filt - mean(velocity_rads_filt)));
+fit_2 = 100 * (1 - norm(velocity_rads_filt - y_id_2) / norm(velocity_rads_filt - mean(velocity_rads_filt)));
+
+fprintf('First-Order Model Fit:  %.1f%%\n', fit_1);
+fprintf('Second-Order Model Fit: %.1f%%\n', fit_2);
+
+if fit_1 > 85
+    fprintf('First-order model is adequate for PID design.\n');
+else
+    fprintf('Consider using second-order model for better accuracy.\n');
+end
+
+%% Step 7: Residual Analysis
+fprintf('\n=== STEP 7: RESIDUAL ANALYSIS ===\n');
+
+residual_1 = velocity_rads_filt - y_id_1;
+residual_2 = velocity_rads_filt - y_id_2;
+
+fprintf('First-Order Residual:\n');
+fprintf('  Mean:    %.4f rad/s\n', mean(residual_1));
+fprintf('  Std Dev: %.4f rad/s\n', std(residual_1));
+fprintf('  Max:     %.4f rad/s\n', max(abs(residual_1)));
+
+fprintf('\nSecond-Order Residual:\n');
+fprintf('  Mean:    %.4f rad/s\n', mean(residual_2));
+fprintf('  Std Dev: %.4f rad/s\n', std(residual_2));
+fprintf('  Max:     %.4f rad/s\n', max(abs(residual_2)));
+
+%% Visualization
+figure('Name', 'System Identification Results', 'Position', [100 100 1200 800]);
+
+% Raw data and velocity
+subplot(2,3,1);
+plot(t_exp, counts_exp, 'b-');
+xlabel('Time (s)');
+ylabel('Encoder Counts');
+title('Raw Encoder Data');
+grid on;
+
+subplot(2,3,2);
+plot(t_exp, velocity_rpm, 'b-', 'LineWidth', 0.5); hold on;
+plot(t_exp, velocity_rpm_filt, 'r-', 'LineWidth', 1.5);
+xlabel('Time (s)');
+ylabel('Velocity (RPM)');
+title('Calculated Velocity');
+legend('Raw', 'Filtered', 'Location', 'southeast');
+grid on;
+
+% Model comparison
+subplot(2,3,3);
+plot(t_exp, velocity_rads_filt, 'b-', 'LineWidth', 1.5); hold on;
+plot(t_exp, y_id_1, 'r--', 'LineWidth', 1.5);
+plot(t_exp, y_id_2, 'g:', 'LineWidth', 1.5);
+xlabel('Time (s)');
+ylabel('Velocity (rad/s)');
+title('Model Comparison');
+legend('Measured', sprintf('1st Order (%.1f%%)', fit_1), ...
+       sprintf('2nd Order (%.1f%%)', fit_2), 'Location', 'southeast');
+grid on;
+
+% Residuals
+subplot(2,3,4);
+plot(t_exp, residual_1, 'r-', t_exp, residual_2, 'g-');
+xlabel('Time (s)');
+ylabel('Residual (rad/s)');
+title('Model Residuals');
+legend('1st Order', '2nd Order');
+grid on;
+
+% Bode comparison
+subplot(2,3,5);
+bode(sys_id_1, sys_id_2);
+title('Frequency Response');
+legend('1st Order', '2nd Order');
+grid on;
+
+% Pole-zero map
+subplot(2,3,6);
+pzmap(sys_id_1, sys_id_2);
+title('Pole-Zero Map');
+legend('1st Order', '2nd Order');
+grid on;
+
+%% Step 8: Export Parameters
+fprintf('\n=== STEP 8: EXPORT PARAMETERS ===\n');
+fprintf('\nUpdate motor_params.m with:\n\n');
+fprintf('K_dc = %.4f;     %% DC gain [rad/s per volt]\n', K_id);
+fprintf('tau_est = %.4f;  %% Time constant [s]\n', tau_id);
+fprintf('\n');
+
+% Also save to file
+fid = fopen('identified_params.txt', 'w');
+fprintf(fid, '%% Identified Motor Parameters\n');
+fprintf(fid, '%% Generated: %s\n\n', datestr(now));
+fprintf(fid, 'K_dc = %.6f;     %% DC gain [rad/s per volt]\n', K_id);
+fprintf(fid, 'tau_est = %.6f;  %% Time constant [s]\n', tau_id);
+fprintf(fid, '\n%% First-order transfer function:\n');
+fprintf(fid, '%% G(s) = %.4f / (%.4f*s + 1)\n', K_id, tau_id);
+fclose(fid);
+fprintf('Parameters saved to identified_params.txt\n');
+
+%% Step 9: Design PID with Identified Model
+fprintf('\n=== STEP 9: PID DESIGN WITH IDENTIFIED MODEL ===\n');
+
+% Use identified model for PID tuning
+target_bw = 20;  % rad/s
+opts = pidtuneOptions('CrossoverFrequency', target_bw);
+[C_pid_id, info_id] = pidtune(sys_id_1, 'PID', opts);
+
+fprintf('PID Gains (from identified model):\n');
+fprintf('  Kp = %.6f\n', C_pid_id.Kp);
+fprintf('  Ki = %.6f\n', C_pid_id.Ki);
+fprintf('  Kd = %.6f\n', C_pid_id.Kd);
+fprintf('  Bandwidth: %.1f rad/s\n', info_id.CrossoverFrequency);
+fprintf('  Phase Margin: %.1f degrees\n', info_id.PhaseMargin);
+
+%% Summary
+fprintf('\n');
+fprintf('=======================================================\n');
+fprintf('    SYSTEM IDENTIFICATION COMPLETE\n');
+fprintf('=======================================================\n');
+fprintf('\n');
+fprintf('Identified Model: G(s) = %.4f / (%.4fs + 1)\n', K_id, tau_id);
+fprintf('Model Fit: %.1f%%\n', fit_1);
+fprintf('\n');
+fprintf('Recommended PID (for star_pid):\n');
+fprintf('  Kp = %.6f\n', C_pid_id.Kp);
+fprintf('  Ki = %.6f\n', C_pid_id.Ki);
+fprintf('  Kd = %.6f\n', C_pid_id.Kd);


### PR DESCRIPTION
## Summary
- Add MATLAB scripts for PID controller design based on DFRobot FIT0520 motor specs
- Motor transfer function model: G(s) = 3.665 / (0.05s + 1)
- Computed velocity PID gains: Kp=0.159, Ki=7.03, Kd=0
- Includes cascaded PID design for current→velocity→position control
- System identification template ready for real encoder data

## Motor Parameters (Verified)
| Parameter | Value |
|-----------|-------|
| Rated Voltage | 6V |
| No-load Speed | 210 RPM @ 0.13A |
| Stall Current | 3.2A |
| Stall Torque | 10 kg·cm |
| Encoder PPR | 341.2 (11 × 34.02) |

## Scripts Added
- `motor_params.m` - Motor specifications
- `motor_model_1st_order.m` - First-order TF model
- `motor_model_2nd_order.m` - Full second-order model
- `pid_design_velocity.m` - Auto-tuning with pidtune()
- `pid_discretize.m` - 100 Hz discretization for ESP32
- `simulate_step_response.m` - Closed-loop simulation
- `cascaded_pid_design.m` - Cascade control design
- `system_id_template.m` - System ID from encoder data

## Test Plan
- [x] All scripts verified working with MATLAB R2025a
- [ ] Integrate computed gains into ESP32 star_pid library
- [ ] Collect real encoder step response data
- [ ] Run system_id_template.m to refine time constant