### PR TITLE
feat(rx72n): Add HC-SR04 ultrasonic distance sensor driver

### DIFF
--- a/star-rx72n-firmware/CLAUDE.md
+++ b/star-rx72n-firmware/CLAUDE.md
@@ -292,6 +292,112 @@ int main(void) {
 }
 ```
 
+#### 10. Doxygen File Headers
+
+**All `.c` and `.h` files must include proper Doxygen metadata tags:**
+
+```c
+/**
+ * @file my_driver.c
+ * @brief Brief description of the file
+ *
+ * Detailed description if needed.
+ *
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+```
+
+**Do NOT use plain text dates:**
+```c
+// WRONG: Plain text, not Doxygen tags
+ * STAR Project - Texas A&M University
+ * January 2026
+
+// CORRECT: Proper Doxygen tags
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
+```
+
+#### 11. Single-Value Enums
+
+**Use `static const` instead of single-value enums:**
+
+```c
+// AVOID: Single-value enum (unused typedef)
+typedef enum {
+  k_timeout_ms = 1000,
+} timeout_constants_t;
+
+// PREFER: static const with s_ prefix
+static const uint32_t s_timeout_ms = 1000;
+```
+
+Enums are for **groups of related constants**. A single constant should use `static const`.
+
+#### 12. Variable Declaration Placement
+
+**Declare all variables at function start, not mid-block:**
+
+```c
+// AVOID: Declaration inside loop
+static rx_err_t wait_for_event(uint32_t timeout_us)
+{
+  uint32_t start = get_time_us();
+  while (true) {
+    uint32_t elapsed = get_time_us() - start;  // declared mid-function
+    if (elapsed >= timeout_us) return k_rx_err_timeout;
+  }
+}
+
+// PREFER: All declarations at function start
+static rx_err_t wait_for_event(uint32_t timeout_us)
+{
+  uint32_t start   = get_time_us();
+  uint32_t elapsed = 0;
+
+  while (true) {
+    elapsed = get_time_us() - start;
+    if (elapsed >= timeout_us) return k_rx_err_timeout;
+  }
+}
+```
+
+#### 13. HAL Wrapper Error Propagation
+
+**HAL wrapper functions must propagate errors, never discard return values:**
+
+```c
+// WRONG: Discards HAL errors
+static rx_err_t wrapper_set_output(uint8_t port, uint8_t pin)
+{
+  gpio_set_output(port, pin);  // return value ignored!
+  return k_rx_ok;
+}
+
+// CORRECT: Propagate HAL errors
+static rx_err_t wrapper_set_output(uint8_t port, uint8_t pin)
+{
+  return gpio_set_output(port, pin);
+}
+```
+
+#### 14. Range Validation
+
+**Always check both minimum AND maximum bounds:**
+
+```c
+// INCOMPLETE: Only checks minimum
+if (distance_cm < MIN_DISTANCE_CM) {
+  return k_rx_err_out_of_range;
+}
+
+// COMPLETE: Checks both bounds
+if (distance_cm < MIN_DISTANCE_CM || distance_cm > MAX_DISTANCE_CM) {
+  return k_rx_err_out_of_range;
+}
+```
+
 ## Project Structure
 
 ```

--- a/star-rx72n-firmware/include/star_hcsr04_config.h
+++ b/star-rx72n-firmware/include/star_hcsr04_config.h
@@ -1,0 +1,170 @@
+/* include/star_hcsr04_config.h */
+
+/**
+ * @file star_hcsr04_config.h
+ * @brief STAR Motor Controller HC-SR04 Sensor Configuration
+ *
+ * Board-specific configuration for HC-SR04 ultrasonic distance sensors.
+ * Defines the 4 sensor connectors (J24-J27) on the STAR Motor Controller PCB.
+ *
+ * Sensor Connections:
+ * - J24 (Sensor 1): PMOD JB GPIO0/GPIO1 - Front Left
+ * - J25 (Sensor 2): PMOD JB GPIO2/GPIO3 - Front Right
+ * - J26 (Sensor 3): PMOD JE GPIO0/GPIO1 - Rear Left
+ * - J27 (Sensor 4): PMOD JE GPIO2/GPIO3 - Rear Right
+ *
+ * Pin assignments derived from docs/sections/03_hardware_pinout.tex
+ *
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef STAR_RX72N_HCSR04_CONFIG_H
+#define STAR_RX72N_HCSR04_CONFIG_H
+
+#include "hardware_pinout.h"
+#include "rx_hcsr04.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Sensor Identifiers
+ * =============================================================================
+ */
+
+/**
+ * @brief HC-SR04 sensor identifiers for STAR Motor Controller
+ *
+ * Maps to the J24-J27 connectors on the PCB.
+ */
+typedef enum {
+  k_star_hcsr04_sensor_1 = 0, /**< J24: PMOD JB GPIO0/GPIO1 */
+  k_star_hcsr04_sensor_2 = 1, /**< J25: PMOD JB GPIO2/GPIO3 */
+  k_star_hcsr04_sensor_3 = 2, /**< J26: PMOD JE GPIO0/GPIO1 */
+  k_star_hcsr04_sensor_4 = 3, /**< J27: PMOD JE GPIO2/GPIO3 */
+  k_star_hcsr04_sensor_count = 4,
+} star_hcsr04_sensor_id_t;
+
+/* =============================================================================
+ * Default Configurations
+ * =============================================================================
+ */
+
+/**
+ * @brief Default configuration for Sensor 1 (J24 - PMOD JB)
+ *
+ * TRIG: PC6 (PMOD JB GPIO0)
+ * ECHO: P55 (PMOD JB GPIO1)
+ */
+#define STAR_HCSR04_CONFIG_SENSOR_1                   \
+  {                                                   \
+    .trigger_port = k_pmod_jb_gpio0_port,             \
+    .trigger_pin  = k_pmod_jb_gpio0_pin,              \
+    .echo_port    = k_pmod_jb_gpio1_port,             \
+    .echo_pin     = k_pmod_jb_gpio1_pin,              \
+    .timeout_us   = k_hcsr04_echo_timeout_us,         \
+  }
+
+/**
+ * @brief Default configuration for Sensor 2 (J25 - PMOD JB)
+ *
+ * TRIG: P54 (PMOD JB GPIO2)
+ * ECHO: PA2 (PMOD JB GPIO3)
+ */
+#define STAR_HCSR04_CONFIG_SENSOR_2                   \
+  {                                                   \
+    .trigger_port = k_pmod_jb_gpio2_port,             \
+    .trigger_pin  = k_pmod_jb_gpio2_pin,              \
+    .echo_port    = k_pmod_jb_gpio3_port,             \
+    .echo_pin     = k_pmod_jb_gpio3_pin,              \
+    .timeout_us   = k_hcsr04_echo_timeout_us,         \
+  }
+
+/**
+ * @brief Default configuration for Sensor 3 (J26 - PMOD JE)
+ *
+ * TRIG: PJ3 (PMOD JE GPIO0)
+ * ECHO: PB1 (PMOD JE GPIO1)
+ */
+#define STAR_HCSR04_CONFIG_SENSOR_3                   \
+  {                                                   \
+    .trigger_port = k_pmod_je_gpio0_port,             \
+    .trigger_pin  = k_pmod_je_gpio0_pin,              \
+    .echo_port    = k_pmod_je_gpio1_port,             \
+    .echo_pin     = k_pmod_je_gpio1_pin,              \
+    .timeout_us   = k_hcsr04_echo_timeout_us,         \
+  }
+
+/**
+ * @brief Default configuration for Sensor 4 (J27 - PMOD JE)
+ *
+ * TRIG: PB0 (PMOD JE GPIO2)
+ * ECHO: PA1 (PMOD JE GPIO3)
+ */
+#define STAR_HCSR04_CONFIG_SENSOR_4                   \
+  {                                                   \
+    .trigger_port = k_pmod_je_gpio2_port,             \
+    .trigger_pin  = k_pmod_je_gpio2_pin,              \
+    .echo_port    = k_pmod_je_gpio3_port,             \
+    .echo_pin     = k_pmod_je_gpio3_pin,              \
+    .timeout_us   = k_hcsr04_echo_timeout_us,         \
+  }
+
+/**
+ * @brief Array initializer for all 4 sensor configs
+ *
+ * Usage:
+ * @code
+ * static const rx_hcsr04_config_t configs[] = STAR_HCSR04_CONFIG_ALL;
+ * @endcode
+ */
+#define STAR_HCSR04_CONFIG_ALL                        \
+  {                                                   \
+    STAR_HCSR04_CONFIG_SENSOR_1,                      \
+    STAR_HCSR04_CONFIG_SENSOR_2,                      \
+    STAR_HCSR04_CONFIG_SENSOR_3,                      \
+    STAR_HCSR04_CONFIG_SENSOR_4,                      \
+  }
+
+/* =============================================================================
+ * Convenience Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Get default configuration for a STAR board sensor
+ *
+ * Populates config structure with pin assignments for the specified sensor.
+ *
+ * @param[in]  sensor_id Sensor identifier (k_star_hcsr04_sensor_1 to _4)
+ * @param[out] config    Configuration structure to populate
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if config is NULL
+ * @return k_rx_err_invalid_arg if sensor_id is out of range
+ */
+static inline rx_err_t star_hcsr04_get_config(star_hcsr04_sensor_id_t sensor_id,
+                                               rx_hcsr04_config_t*     config)
+{
+  static const rx_hcsr04_config_t s_configs[k_star_hcsr04_sensor_count] =
+      STAR_HCSR04_CONFIG_ALL;
+
+  if (config == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (sensor_id >= k_star_hcsr04_sensor_count) {
+    return k_rx_err_invalid_arg;
+  }
+
+  *config = s_configs[sensor_id];
+  return k_rx_ok;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STAR_RX72N_HCSR04_CONFIG_H */

--- a/star-rx72n-firmware/include/star_hcsr04_config.h
+++ b/star-rx72n-firmware/include/star_hcsr04_config.h
@@ -1,3 +1,5 @@
+/* include/star_hcsr04_config.h */
+
 /**
  * @file star_hcsr04_config.h
  * @brief STAR Motor Controller HC-SR04 Sensor Configuration

--- a/star-rx72n-firmware/include/star_hcsr04_config.h
+++ b/star-rx72n-firmware/include/star_hcsr04_config.h
@@ -1,9 +1,8 @@
-/* include/star_hcsr04_config.h */
-
 /**
  * @file star_hcsr04_config.h
  * @brief STAR Motor Controller HC-SR04 Sensor Configuration
  *
+ * @details
  * Board-specific configuration for HC-SR04 ultrasonic distance sensors.
  * Defines the 4 sensor connectors (J24-J27) on the STAR Motor Controller PCB.
  *
@@ -13,9 +12,9 @@
  * - J26 (Sensor 3): PMOD JE GPIO0/GPIO1 - Rear Left
  * - J27 (Sensor 4): PMOD JE GPIO2/GPIO3 - Rear Right
  *
- * Pin assignments derived from docs/sections/03_hardware_pinout.tex
+ * @see docs/sections/03_hardware_pinout.tex for complete pin assignments
  *
- * @date 2026-01-02
+ * @date 2026-01-04
  * @copyright Copyright (c) 2026 STAR Project
  */
 
@@ -40,10 +39,10 @@ extern "C" {
  * Maps to the J24-J27 connectors on the PCB.
  */
 typedef enum {
-  k_star_hcsr04_sensor_1 = 0, /**< J24: PMOD JB GPIO0/GPIO1 */
-  k_star_hcsr04_sensor_2 = 1, /**< J25: PMOD JB GPIO2/GPIO3 */
-  k_star_hcsr04_sensor_3 = 2, /**< J26: PMOD JE GPIO0/GPIO1 */
-  k_star_hcsr04_sensor_4 = 3, /**< J27: PMOD JE GPIO2/GPIO3 */
+  k_star_hcsr04_sensor_1     = 0, /**< J24: PMOD JB GPIO0/GPIO1 */
+  k_star_hcsr04_sensor_2     = 1, /**< J25: PMOD JB GPIO2/GPIO3 */
+  k_star_hcsr04_sensor_3     = 2, /**< J26: PMOD JE GPIO0/GPIO1 */
+  k_star_hcsr04_sensor_4     = 3, /**< J27: PMOD JE GPIO2/GPIO3 */
   k_star_hcsr04_sensor_count = 4,
 } star_hcsr04_sensor_id_t;
 
@@ -53,80 +52,58 @@ typedef enum {
  */
 
 /**
- * @brief Default configuration for Sensor 1 (J24 - PMOD JB)
+ * @brief Default sensor configurations for all 4 HC-SR04 sensors
  *
- * TRIG: PC6 (PMOD JB GPIO0)
- * ECHO: P55 (PMOD JB GPIO1)
- */
-#define STAR_HCSR04_CONFIG_SENSOR_1                   \
-  {                                                   \
-    .trigger_port = k_pmod_jb_gpio0_port,             \
-    .trigger_pin  = k_pmod_jb_gpio0_pin,              \
-    .echo_port    = k_pmod_jb_gpio1_port,             \
-    .echo_pin     = k_pmod_jb_gpio1_pin,              \
-    .timeout_us   = k_hcsr04_echo_timeout_us,         \
-  }
-
-/**
- * @brief Default configuration for Sensor 2 (J25 - PMOD JB)
+ * Sensor 1 (J24 - PMOD JB):
+ *   TRIG: PC6 (PMOD JB GPIO0)
+ *   ECHO: P55 (PMOD JB GPIO1)
  *
- * TRIG: P54 (PMOD JB GPIO2)
- * ECHO: PA2 (PMOD JB GPIO3)
- */
-#define STAR_HCSR04_CONFIG_SENSOR_2                   \
-  {                                                   \
-    .trigger_port = k_pmod_jb_gpio2_port,             \
-    .trigger_pin  = k_pmod_jb_gpio2_pin,              \
-    .echo_port    = k_pmod_jb_gpio3_port,             \
-    .echo_pin     = k_pmod_jb_gpio3_pin,              \
-    .timeout_us   = k_hcsr04_echo_timeout_us,         \
-  }
-
-/**
- * @brief Default configuration for Sensor 3 (J26 - PMOD JE)
+ * Sensor 2 (J25 - PMOD JB):
+ *   TRIG: P54 (PMOD JB GPIO2)
+ *   ECHO: PA2 (PMOD JB GPIO3)
  *
- * TRIG: PJ3 (PMOD JE GPIO0)
- * ECHO: PB1 (PMOD JE GPIO1)
- */
-#define STAR_HCSR04_CONFIG_SENSOR_3                   \
-  {                                                   \
-    .trigger_port = k_pmod_je_gpio0_port,             \
-    .trigger_pin  = k_pmod_je_gpio0_pin,              \
-    .echo_port    = k_pmod_je_gpio1_port,             \
-    .echo_pin     = k_pmod_je_gpio1_pin,              \
-    .timeout_us   = k_hcsr04_echo_timeout_us,         \
-  }
-
-/**
- * @brief Default configuration for Sensor 4 (J27 - PMOD JE)
+ * Sensor 3 (J26 - PMOD JE):
+ *   TRIG: PJ3 (PMOD JE GPIO0)
+ *   ECHO: PB1 (PMOD JE GPIO1)
  *
- * TRIG: PB0 (PMOD JE GPIO2)
- * ECHO: PA1 (PMOD JE GPIO3)
+ * Sensor 4 (J27 - PMOD JE):
+ *   TRIG: PB0 (PMOD JE GPIO2)
+ *   ECHO: PA1 (PMOD JE GPIO3)
  */
-#define STAR_HCSR04_CONFIG_SENSOR_4                   \
-  {                                                   \
-    .trigger_port = k_pmod_je_gpio2_port,             \
-    .trigger_pin  = k_pmod_je_gpio2_pin,              \
-    .echo_port    = k_pmod_je_gpio3_port,             \
-    .echo_pin     = k_pmod_je_gpio3_pin,              \
-    .timeout_us   = k_hcsr04_echo_timeout_us,         \
-  }
-
-/**
- * @brief Array initializer for all 4 sensor configs
- *
- * Usage:
- * @code
- * static const rx_hcsr04_config_t configs[] = STAR_HCSR04_CONFIG_ALL;
- * @endcode
- */
-#define STAR_HCSR04_CONFIG_ALL                        \
-  {                                                   \
-    STAR_HCSR04_CONFIG_SENSOR_1,                      \
-    STAR_HCSR04_CONFIG_SENSOR_2,                      \
-    STAR_HCSR04_CONFIG_SENSOR_3,                      \
-    STAR_HCSR04_CONFIG_SENSOR_4,                      \
-  }
+static const rx_hcsr04_config_t k_star_hcsr04_default_configs[k_star_hcsr04_sensor_count] = {
+  [k_star_hcsr04_sensor_1] =
+    {
+      .trigger_port = k_pmod_jb_gpio0_port,
+      .trigger_pin  = k_pmod_jb_gpio0_pin,
+      .echo_port    = k_pmod_jb_gpio1_port,
+      .echo_pin     = k_pmod_jb_gpio1_pin,
+      .timeout_us   = k_hcsr04_echo_timeout_us,
+    },
+  [k_star_hcsr04_sensor_2] =
+    {
+      .trigger_port = k_pmod_jb_gpio2_port,
+      .trigger_pin  = k_pmod_jb_gpio2_pin,
+      .echo_port    = k_pmod_jb_gpio3_port,
+      .echo_pin     = k_pmod_jb_gpio3_pin,
+      .timeout_us   = k_hcsr04_echo_timeout_us,
+    },
+  [k_star_hcsr04_sensor_3] =
+    {
+      .trigger_port = k_pmod_je_gpio0_port,
+      .trigger_pin  = k_pmod_je_gpio0_pin,
+      .echo_port    = k_pmod_je_gpio1_port,
+      .echo_pin     = k_pmod_je_gpio1_pin,
+      .timeout_us   = k_hcsr04_echo_timeout_us,
+    },
+  [k_star_hcsr04_sensor_4] =
+    {
+      .trigger_port = k_pmod_je_gpio2_port,
+      .trigger_pin  = k_pmod_je_gpio2_pin,
+      .echo_port    = k_pmod_je_gpio3_port,
+      .echo_pin     = k_pmod_je_gpio3_pin,
+      .timeout_us   = k_hcsr04_echo_timeout_us,
+    },
+};
 
 /* =============================================================================
  * Convenience Functions
@@ -146,11 +123,8 @@ typedef enum {
  * @return k_rx_err_invalid_arg if sensor_id is out of range
  */
 static inline rx_err_t star_hcsr04_get_config(star_hcsr04_sensor_id_t sensor_id,
-                                               rx_hcsr04_config_t*     config)
+                                              rx_hcsr04_config_t*     config)
 {
-  static const rx_hcsr04_config_t s_configs[k_star_hcsr04_sensor_count] =
-      STAR_HCSR04_CONFIG_ALL;
-
   if (config == NULL) {
     return k_rx_err_null_pointer;
   }
@@ -159,7 +133,7 @@ static inline rx_err_t star_hcsr04_get_config(star_hcsr04_sensor_id_t sensor_id,
     return k_rx_err_invalid_arg;
   }
 
-  *config = s_configs[sensor_id];
+  *config = k_star_hcsr04_default_configs[sensor_id];
   return k_rx_ok;
 }
 

--- a/star-rx72n-firmware/lib/rx_core/inc/rx_err.h
+++ b/star-rx72n-firmware/lib/rx_core/inc/rx_err.h
@@ -82,6 +82,7 @@ typedef enum {
   k_rx_err_gpio_conflict     = 0x205, /**< GPIO pin conflict */
   k_rx_err_gpio_invalid_port = 0x206, /**< Invalid GPIO port */
   k_rx_err_gpio_invalid_pin  = 0x207, /**< Invalid GPIO pin */
+  k_rx_err_out_of_range      = 0x208, /**< Sensor value out of range */
 
   /* RTOS Errors (0x300 - 0x3FF) */
   k_rx_err_rtos_error         = 0x301, /**< RTOS error */

--- a/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
+++ b/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
@@ -4,6 +4,7 @@
  * @file rx_hcsr04.h
  * @brief HC-SR04 Ultrasonic Distance Sensor Driver for RX72N
  *
+ * @details
  * GPIO-based driver for HC-SR04 ultrasonic distance sensors. Provides blocking
  * and non-blocking measurement APIs for obstacle detection and collision
  * avoidance applications.

--- a/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
+++ b/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
@@ -215,16 +215,17 @@ rx_err_t rx_hcsr04_measure(rx_hcsr04_t* handle, rx_hcsr04_result_t* result);
 /**
  * @brief Start asynchronous measurement
  *
- * Initiates measurement and returns immediately. Callback is invoked
- * when measurement completes or times out.
+ * Initiates measurement and invokes callback with result.
  *
- * Implementation uses a ThreadX worker thread for simplicity.
+ * @note Current implementation is synchronous - the callback is invoked
+ *       before this function returns. True non-blocking operation with
+ *       ThreadX worker thread is a planned future enhancement.
  *
  * @param[in] handle    Sensor handle
  * @param[in] callback  Completion callback (required)
  * @param[in] user_data User context passed to callback (can be NULL)
  *
- * @return k_rx_ok if measurement started
+ * @return k_rx_ok if measurement completed and callback invoked
  * @return k_rx_err_null_pointer if handle or callback is NULL
  * @return k_rx_err_invalid_state if not initialized
  * @return k_rx_err_busy if measurement already in progress

--- a/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
+++ b/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
@@ -1,0 +1,316 @@
+/* lib/rx_hcsr04/inc/rx_hcsr04.h */
+
+/**
+ * @file rx_hcsr04.h
+ * @brief HC-SR04 Ultrasonic Distance Sensor Driver for RX72N
+ *
+ * GPIO-based driver for HC-SR04 ultrasonic distance sensors. Provides blocking
+ * and non-blocking measurement APIs for obstacle detection and collision
+ * avoidance applications.
+ *
+ * Sensor Specifications:
+ * - Range: 2cm to 400cm (effective 2cm to 400cm)
+ * - Accuracy: +/-3mm
+ * - Trigger: 10us HIGH pulse initiates measurement
+ * - Echo: Pulse width proportional to distance (58us per cm roundtrip)
+ * - Supply: 5V (level shifting required for RX72N 3.3V GPIO)
+ *
+ * Hardware Setup:
+ * - TRIG pin: GPIO output (10us pulse triggers measurement)
+ * - ECHO pin: GPIO input (pulse width indicates distance)
+ * - VCC: 5V supply
+ * - GND: Common ground with RX72N
+ *
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef STAR_RX72N_HCSR04_H
+#define STAR_RX72N_HCSR04_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "rx_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Constants
+ * =============================================================================
+ */
+
+/**
+ * @brief HC-SR04 timing constants
+ *
+ * Timing values based on speed of sound at 20C (343 m/s).
+ * Distance = (echo_us * 0.0343 cm/us) / 2 = echo_us / 58.3 cm
+ */
+typedef enum {
+  k_hcsr04_trigger_pulse_us    = 10,    /**< Minimum trigger pulse width */
+  k_hcsr04_echo_timeout_us     = 30000, /**< Max echo wait (400cm + margin) */
+  k_hcsr04_min_echo_us         = 116,   /**< Min valid echo (2cm) */
+  k_hcsr04_max_echo_us         = 23200, /**< Max valid echo (400cm) */
+  k_hcsr04_us_per_cm_roundtrip = 58,    /**< Microseconds per cm (roundtrip) */
+  k_hcsr04_measurement_gap_ms  = 60,    /**< Minimum gap between measurements */
+} rx_hcsr04_timing_t;
+
+/**
+ * @brief HC-SR04 distance range constants
+ */
+typedef enum {
+  k_hcsr04_min_distance_cm = 2,   /**< Minimum measurable distance */
+  k_hcsr04_max_distance_cm = 400, /**< Maximum measurable distance */
+} rx_hcsr04_range_t;
+
+/* =============================================================================
+ * Type Definitions
+ * =============================================================================
+ */
+
+/**
+ * @brief HC-SR04 sensor configuration
+ *
+ * Specifies trigger and echo pin assignments. For board-specific default
+ * configurations, see the application-layer config headers.
+ */
+typedef struct {
+  uint8_t  trigger_port; /**< Trigger pin port (0x0-0x10 for ports 0-J) */
+  uint8_t  trigger_pin;  /**< Trigger pin number (0-7) */
+  uint8_t  echo_port;    /**< Echo pin port (0x0-0x10 for ports 0-J) */
+  uint8_t  echo_pin;     /**< Echo pin number (0-7) */
+  uint32_t timeout_us;   /**< Measurement timeout (default: 30000us) */
+} rx_hcsr04_config_t;
+
+/**
+ * @brief HC-SR04 sensor handle
+ *
+ * Caller allocates this structure and passes to init. Driver manages
+ * internal state. Do not modify fields directly after initialization.
+ */
+typedef struct {
+  /* Configuration (set during init) */
+  uint8_t  trigger_port; /**< Trigger pin port */
+  uint8_t  trigger_pin;  /**< Trigger pin number */
+  uint8_t  echo_port;    /**< Echo pin port */
+  uint8_t  echo_pin;     /**< Echo pin number */
+  uint32_t timeout_us;   /**< Measurement timeout in microseconds */
+
+  /* State */
+  bool initialized;        /**< True if handle is initialized */
+  bool measurement_active; /**< True if async measurement in progress */
+
+  /* Statistics */
+  uint32_t measurement_count; /**< Total measurements attempted */
+  uint32_t timeout_count;     /**< Measurements that timed out */
+  uint32_t range_error_count; /**< Out-of-range readings (too close/far) */
+} rx_hcsr04_t;
+
+/**
+ * @brief Measurement result structure
+ *
+ * Contains distance in multiple units and raw timing data.
+ */
+typedef struct {
+  float    distance_cm;  /**< Distance in centimeters */
+  float    distance_in;  /**< Distance in inches */
+  uint32_t echo_time_us; /**< Raw echo pulse duration in microseconds */
+  rx_err_t status;       /**< Measurement status (k_rx_ok or error code) */
+} rx_hcsr04_result_t;
+
+/**
+ * @brief Async measurement callback function type
+ *
+ * Called when async measurement completes or times out.
+ *
+ * @param[in] handle    Sensor handle
+ * @param[in] result    Measurement result
+ * @param[in] user_data User context passed to rx_hcsr04_measure_async()
+ */
+typedef void (*rx_hcsr04_callback_t)(rx_hcsr04_t*              handle,
+                                     const rx_hcsr04_result_t* result,
+                                     void*                     user_data);
+
+/* =============================================================================
+ * Public API - Initialization
+ * =============================================================================
+ */
+
+/**
+ * @brief Initialize HC-SR04 sensor
+ *
+ * Configures GPIO pins for trigger (output) and echo (input).
+ * Reserves pins via pin validator to prevent conflicts.
+ *
+ * @param[out] handle Handle to initialize (caller-allocated)
+ * @param[in]  config Configuration with pin assignments
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle or config is NULL
+ * @return k_rx_err_invalid_arg if port/pin values are invalid
+ * @return k_rx_err_gpio_conflict if pins already reserved
+ * @return k_rx_err_invalid_state if handle already initialized
+ */
+rx_err_t rx_hcsr04_init(rx_hcsr04_t* handle, const rx_hcsr04_config_t* config);
+
+/**
+ * @brief Deinitialize HC-SR04 sensor
+ *
+ * Releases GPIO pin reservations and resets handle state.
+ *
+ * @param[in,out] handle Sensor handle
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle is NULL
+ * @return k_rx_err_invalid_state if not initialized
+ */
+rx_err_t rx_hcsr04_deinit(rx_hcsr04_t* handle);
+
+/* =============================================================================
+ * Public API - Measurement
+ * =============================================================================
+ */
+
+/**
+ * @brief Measure distance (blocking)
+ *
+ * Performs a complete measurement cycle:
+ * 1. Send 10us trigger pulse
+ * 2. Wait for echo pulse start
+ * 3. Measure echo pulse duration
+ * 4. Convert to distance
+ *
+ * Blocks for up to timeout_us (default 30ms).
+ *
+ * @param[in]  handle      Sensor handle
+ * @param[out] distance_cm Measured distance in centimeters
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle or distance_cm is NULL
+ * @return k_rx_err_invalid_state if not initialized
+ * @return k_rx_err_timeout if no echo received (object >400cm or absent)
+ * @return k_rx_err_out_of_range if distance <2cm (too close)
+ */
+rx_err_t rx_hcsr04_measure_blocking(rx_hcsr04_t* handle, float* distance_cm);
+
+/**
+ * @brief Measure distance with full result (blocking)
+ *
+ * Same as rx_hcsr04_measure_blocking() but returns complete result
+ * including both distance units and raw timing.
+ *
+ * @param[in]  handle Sensor handle
+ * @param[out] result Complete measurement result
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle or result is NULL
+ * @return k_rx_err_invalid_state if not initialized
+ * @return k_rx_err_timeout if no echo received
+ * @return k_rx_err_out_of_range if distance out of bounds
+ */
+rx_err_t rx_hcsr04_measure(rx_hcsr04_t* handle, rx_hcsr04_result_t* result);
+
+/**
+ * @brief Start asynchronous measurement
+ *
+ * Initiates measurement and returns immediately. Callback is invoked
+ * when measurement completes or times out.
+ *
+ * Implementation uses a ThreadX worker thread for simplicity.
+ *
+ * @param[in] handle    Sensor handle
+ * @param[in] callback  Completion callback (required)
+ * @param[in] user_data User context passed to callback (can be NULL)
+ *
+ * @return k_rx_ok if measurement started
+ * @return k_rx_err_null_pointer if handle or callback is NULL
+ * @return k_rx_err_invalid_state if not initialized
+ * @return k_rx_err_busy if measurement already in progress
+ */
+rx_err_t
+rx_hcsr04_measure_async(rx_hcsr04_t* handle, rx_hcsr04_callback_t callback, void* user_data);
+
+/**
+ * @brief Check if async measurement is in progress
+ *
+ * @param[in] handle Sensor handle
+ *
+ * @return true if measurement in progress
+ * @return false if idle or handle is NULL
+ */
+bool rx_hcsr04_is_busy(const rx_hcsr04_t* handle);
+
+/**
+ * @brief Cancel async measurement
+ *
+ * Cancels in-progress async measurement. Callback will NOT be invoked.
+ *
+ * @param[in] handle Sensor handle
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle is NULL
+ * @return k_rx_err_invalid_state if no measurement in progress
+ */
+rx_err_t rx_hcsr04_cancel(rx_hcsr04_t* handle);
+
+/* =============================================================================
+ * Public API - Utilities
+ * =============================================================================
+ */
+
+/**
+ * @brief Convert distance from centimeters to inches
+ *
+ * @param[in] distance_cm Distance in centimeters
+ *
+ * @return Distance in inches
+ */
+float rx_hcsr04_cm_to_inches(float distance_cm);
+
+/**
+ * @brief Convert echo time to distance in centimeters
+ *
+ * Uses formula: distance = (echo_us * speed_of_sound) / 2
+ * Speed of sound at 20C = 343 m/s = 0.0343 cm/us
+ *
+ * @param[in] echo_time_us Echo pulse duration in microseconds
+ *
+ * @return Distance in centimeters
+ */
+float rx_hcsr04_echo_to_cm(uint32_t echo_time_us);
+
+/**
+ * @brief Get sensor statistics
+ *
+ * @param[in]  handle           Sensor handle
+ * @param[out] measurement_count Total measurements (can be NULL)
+ * @param[out] timeout_count     Timeout count (can be NULL)
+ * @param[out] range_error_count Range error count (can be NULL)
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle is NULL
+ * @return k_rx_err_invalid_state if not initialized
+ */
+rx_err_t rx_hcsr04_get_stats(const rx_hcsr04_t* handle,
+                             uint32_t*          measurement_count,
+                             uint32_t*          timeout_count,
+                             uint32_t*          range_error_count);
+
+/**
+ * @brief Reset sensor statistics
+ *
+ * @param[in,out] handle Sensor handle
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if handle is NULL
+ * @return k_rx_err_invalid_state if not initialized
+ */
+rx_err_t rx_hcsr04_reset_stats(rx_hcsr04_t* handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STAR_RX72N_HCSR04_H */

--- a/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
+++ b/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
@@ -277,11 +277,44 @@ float rx_hcsr04_cm_to_inches(float distance_cm);
  * Uses formula: distance = (echo_us * speed_of_sound) / 2
  * Speed of sound at 20C = 343 m/s = 0.0343 cm/us
  *
+ * @note This function assumes 20°C. For temperature compensation, use
+ *       rx_hcsr04_echo_to_cm_with_temp() instead.
+ *
  * @param[in] echo_time_us Echo pulse duration in microseconds
  *
  * @return Distance in centimeters
  */
 float rx_hcsr04_echo_to_cm(uint32_t echo_time_us);
+
+/**
+ * @brief Convert echo time to distance with temperature compensation
+ *
+ * Calculates distance using temperature-compensated speed of sound.
+ * Speed of sound varies with temperature: v = 331.3 + (0.606 * temp_c) m/s
+ *
+ * Temperature compensation improves accuracy by ~0.17% per °C deviation from 20°C.
+ *
+ * Example: At 10°C, speed is ~337 m/s vs 343 m/s at 20°C (~1.75% difference)
+ *
+ * @param[in] echo_time_us  Echo pulse duration in microseconds
+ * @param[in] temp_celsius  Ambient temperature in degrees Celsius
+ *
+ * @return Distance in centimeters (temperature-compensated)
+ */
+float rx_hcsr04_echo_to_cm_with_temp(uint32_t echo_time_us, float temp_celsius);
+
+/**
+ * @brief Calculate speed of sound at given temperature
+ *
+ * Uses formula: v = 331.3 + (0.606 * temp_c) m/s
+ *
+ * Valid temperature range: -40°C to +85°C (DS18B20 operating range)
+ *
+ * @param[in] temp_celsius Ambient temperature in degrees Celsius
+ *
+ * @return Speed of sound in m/s
+ */
+float rx_hcsr04_get_speed_of_sound(float temp_celsius);
 
 /**
  * @brief Get sensor statistics

--- a/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
+++ b/star-rx72n-firmware/lib/rx_hcsr04/inc/rx_hcsr04.h
@@ -220,6 +220,7 @@ rx_err_t rx_hcsr04_measure(rx_hcsr04_t* handle, rx_hcsr04_result_t* result);
  * @note Current implementation is synchronous - the callback is invoked
  *       before this function returns. True non-blocking operation with
  *       ThreadX worker thread is a planned future enhancement.
+ *       See: https://github.com/Locked-Inc/STAR/issues/70
  *
  * @param[in] handle    Sensor handle
  * @param[in] callback  Completion callback (required)

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -368,6 +368,7 @@ rx_hcsr04_measure_async(rx_hcsr04_t* handle, rx_hcsr04_callback_t callback, void
    * Note: Full async implementation requires ThreadX thread.
    * This is a placeholder that performs blocking measurement.
    * A complete implementation would spawn a worker thread.
+   * See: https://github.com/Locked-Inc/STAR/issues/70
    */
   handle->measurement_active = true;
 

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -4,8 +4,8 @@
  *
  * GPIO-based driver for HC-SR04 ultrasonic distance sensors.
  *
- * STAR Project - Texas A&M University
- * January 2026
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
  */
 
 #include "rx_hcsr04.h"
@@ -94,11 +94,9 @@ extern uint32_t get_time_us(void);
  */
 
 /**
- * @brief Conversion constants
+ * @brief Centimeters per inch * 100 (fixed point: 2.54 * 100 = 254)
  */
-typedef enum {
-  k_cm_per_inch_x100 = 254, /**< 2.54 cm/inch * 100 (fixed point) */
-} conversion_constants_t;
+static const uint32_t s_cm_per_inch_x100 = 254;
 
 /* =============================================================================
  * Internal Helper Functions
@@ -136,6 +134,7 @@ internal_wait_for_echo(const rx_hcsr04_t* handle, bool target_state, uint32_t ti
 {
   uint32_t start_time = GET_TIME_US();
   bool     pin_state  = false;
+  uint32_t elapsed    = 0;
 
   while (true) {
     GPIO_READ(handle->echo_port, handle->echo_pin, &pin_state);
@@ -145,7 +144,7 @@ internal_wait_for_echo(const rx_hcsr04_t* handle, bool target_state, uint32_t ti
     }
 
     /* Check for timeout */
-    uint32_t elapsed = GET_TIME_US() - start_time;
+    elapsed = GET_TIME_US() - start_time;
     if (elapsed >= timeout_us) {
       return k_rx_err_timeout;
     }
@@ -418,7 +417,7 @@ rx_err_t rx_hcsr04_cancel(rx_hcsr04_t* handle)
 float rx_hcsr04_cm_to_inches(float distance_cm)
 {
   /* 1 inch = 2.54 cm */
-  return distance_cm * 100.0f / (float)k_cm_per_inch_x100;
+  return distance_cm * 100.0f / (float)s_cm_per_inch_x100;
 }
 
 float rx_hcsr04_echo_to_cm(uint32_t echo_time_us)

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -17,77 +17,7 @@
 
 #include <stddef.h>
 
-/* =============================================================================
- * Platform Abstraction
- * =============================================================================
- */
-
-/*
- * When building for host testing, use mock functions.
- * When building for RX72N, use real hardware functions.
- */
-#ifdef RX_HCSR04_USE_MOCK
-
-#include "mock_hcsr04_hw.h"
-
-#define GPIO_SET_OUTPUT(port, pin) (mock_gpio_set_output((port), (pin)))
-#define GPIO_SET_INPUT(port, pin)  (mock_gpio_set_input((port), (pin)))
-#define GPIO_WRITE_HIGH(port, pin) (mock_gpio_write_high((port), (pin)))
-#define GPIO_WRITE_LOW(port, pin)  (mock_gpio_write_low((port), (pin)))
-#define GPIO_READ(port, pin, val)  (mock_gpio_read((port), (pin), (val)))
-#define GPIO_DEINIT(port, pin)     (mock_gpio_deinit((port), (pin)))
-#define DELAY_US(us)               (mock_delay_us((us)))
-#define GET_TIME_US()              (mock_get_time_us())
-
-#else
-
-#include "hardware.h"
-#include "rx_time_interface.h"
-
-/* Real hardware GPIO wrappers - propagate errors from HAL */
-static rx_err_t internal_gpio_set_output(uint8_t port, uint8_t pin)
-{
-  return gpio_set_output(port, pin);
-}
-
-static rx_err_t internal_gpio_set_input(uint8_t port, uint8_t pin)
-{
-  return gpio_set_input(port, pin);
-}
-
-static rx_err_t internal_gpio_write_high(uint8_t port, uint8_t pin)
-{
-  return gpio_write_high(port, pin);
-}
-
-static rx_err_t internal_gpio_write_low(uint8_t port, uint8_t pin)
-{
-  return gpio_write_low(port, pin);
-}
-
-static rx_err_t internal_gpio_read(uint8_t port, uint8_t pin, bool* value)
-{
-  return gpio_read(port, pin, value);
-}
-
-/* Real timing functions (from CMT or timer) */
-extern void     delay_us(uint32_t us);
-extern uint32_t get_time_us(void);
-
-#define GPIO_SET_OUTPUT(port, pin) (internal_gpio_set_output((port), (pin)))
-#define GPIO_SET_INPUT(port, pin)  (internal_gpio_set_input((port), (pin)))
-#define GPIO_WRITE_HIGH(port, pin) (internal_gpio_write_high((port), (pin)))
-#define GPIO_WRITE_LOW(port, pin)  (internal_gpio_write_low((port), (pin)))
-#define GPIO_READ(port, pin, val)  (internal_gpio_read((port), (pin), (val)))
-/*
- * GPIO_DEINIT is intentionally a no-op: the RX72N GPIO HAL does not provide
- * pin deallocation. GPIO pins are static resources allocated at init time.
- */
-#define GPIO_DEINIT(port, pin)     (k_rx_ok)
-#define DELAY_US(us)               (delay_us((us)))
-#define GET_TIME_US()              (get_time_us())
-
-#endif /* RX_HCSR04_USE_MOCK */
+#include "rx_hcsr04_hal.h"
 
 /* =============================================================================
  * Constants
@@ -112,13 +42,13 @@ static const uint32_t s_cm_per_inch_x100 = 254;
 static void internal_send_trigger_pulse(const rx_hcsr04_t* handle)
 {
   /* Ensure trigger is low initially */
-  GPIO_WRITE_LOW(handle->trigger_port, handle->trigger_pin);
-  DELAY_US(2);
+  hcsr04_hal_gpio_write_low(handle->trigger_port, handle->trigger_pin);
+  hcsr04_hal_delay_us(2);
 
   /* Send 10us HIGH pulse */
-  GPIO_WRITE_HIGH(handle->trigger_port, handle->trigger_pin);
-  DELAY_US(k_hcsr04_trigger_pulse_us);
-  GPIO_WRITE_LOW(handle->trigger_port, handle->trigger_pin);
+  hcsr04_hal_gpio_write_high(handle->trigger_port, handle->trigger_pin);
+  hcsr04_hal_delay_us(k_hcsr04_trigger_pulse_us);
+  hcsr04_hal_gpio_write_low(handle->trigger_port, handle->trigger_pin);
 }
 
 /**
@@ -133,19 +63,19 @@ static void internal_send_trigger_pulse(const rx_hcsr04_t* handle)
 static rx_err_t
 internal_wait_for_echo(const rx_hcsr04_t* handle, bool target_state, uint32_t timeout_us)
 {
-  uint32_t start_time = GET_TIME_US();
+  uint32_t start_time = hcsr04_hal_get_time_us();
   bool     pin_state  = false;
   uint32_t elapsed    = 0;
 
   while (true) {
-    GPIO_READ(handle->echo_port, handle->echo_pin, &pin_state);
+    hcsr04_hal_gpio_read(handle->echo_port, handle->echo_pin, &pin_state);
 
     if (pin_state == target_state) {
       return k_rx_ok;
     }
 
     /* Check for timeout */
-    elapsed = GET_TIME_US() - start_time;
+    elapsed = hcsr04_hal_get_time_us() - start_time;
     if (elapsed >= timeout_us) {
       return k_rx_err_timeout;
     }
@@ -170,7 +100,7 @@ static rx_err_t internal_measure_echo_pulse(rx_hcsr04_t* handle, uint32_t* durat
     return err;
   }
 
-  uint32_t pulse_start = GET_TIME_US();
+  uint32_t pulse_start = hcsr04_hal_get_time_us();
 
   /* Wait for echo to go LOW (pulse end) */
   err = internal_wait_for_echo(handle, false, handle->timeout_us);
@@ -178,7 +108,7 @@ static rx_err_t internal_measure_echo_pulse(rx_hcsr04_t* handle, uint32_t* durat
     return err;
   }
 
-  uint32_t pulse_end = GET_TIME_US();
+  uint32_t pulse_end = hcsr04_hal_get_time_us();
   *duration_us       = pulse_end - pulse_start;
 
   return k_rx_ok;
@@ -202,16 +132,16 @@ rx_err_t rx_hcsr04_init(rx_hcsr04_t* handle, const rx_hcsr04_config_t* config)
   }
 
   /* Configure trigger pin as output */
-  err = GPIO_SET_OUTPUT(config->trigger_port, config->trigger_pin);
+  err = hcsr04_hal_gpio_set_output(config->trigger_port, config->trigger_pin);
   if (err != k_rx_ok) {
     return err;
   }
 
   /* Configure echo pin as input */
-  err = GPIO_SET_INPUT(config->echo_port, config->echo_pin);
+  err = hcsr04_hal_gpio_set_input(config->echo_port, config->echo_pin);
   if (err != k_rx_ok) {
     /* Cleanup trigger pin */
-    GPIO_DEINIT(config->trigger_port, config->trigger_pin);
+    hcsr04_hal_gpio_deinit(config->trigger_port, config->trigger_pin);
     return err;
   }
 
@@ -230,7 +160,7 @@ rx_err_t rx_hcsr04_init(rx_hcsr04_t* handle, const rx_hcsr04_config_t* config)
   handle->range_error_count = 0;
 
   /* Ensure trigger is low */
-  GPIO_WRITE_LOW(handle->trigger_port, handle->trigger_pin);
+  hcsr04_hal_gpio_write_low(handle->trigger_port, handle->trigger_pin);
 
   return k_rx_ok;
 }
@@ -246,8 +176,8 @@ rx_err_t rx_hcsr04_deinit(rx_hcsr04_t* handle)
   }
 
   /* Release GPIO pins */
-  GPIO_DEINIT(handle->trigger_port, handle->trigger_pin);
-  GPIO_DEINIT(handle->echo_port, handle->echo_pin);
+  hcsr04_hal_gpio_deinit(handle->trigger_port, handle->trigger_pin);
+  hcsr04_hal_gpio_deinit(handle->echo_port, handle->echo_pin);
 
   /* Clear handle */
   handle->initialized = false;

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -1,0 +1,479 @@
+/**
+ * @file rx_hcsr04.c
+ * @brief HC-SR04 Ultrasonic Distance Sensor Driver Implementation
+ *
+ * GPIO-based driver for HC-SR04 ultrasonic distance sensors.
+ *
+ * STAR Project - Texas A&M University
+ * January 2026
+ */
+
+#include "rx_hcsr04.h"
+
+#include <stddef.h>
+
+/* =============================================================================
+ * Platform Abstraction
+ * =============================================================================
+ */
+
+/*
+ * When building for host testing, use mock functions.
+ * When building for RX72N, use real hardware functions.
+ */
+#ifdef RX_HCSR04_USE_MOCK
+
+#include "mock_hcsr04_hw.h"
+
+#define GPIO_SET_OUTPUT(port, pin) mock_gpio_set_output(port, pin)
+#define GPIO_SET_INPUT(port, pin)  mock_gpio_set_input(port, pin)
+#define GPIO_WRITE_HIGH(port, pin) mock_gpio_write_high(port, pin)
+#define GPIO_WRITE_LOW(port, pin)  mock_gpio_write_low(port, pin)
+#define GPIO_READ(port, pin, val)  mock_gpio_read(port, pin, val)
+#define GPIO_DEINIT(port, pin)     mock_gpio_deinit(port, pin)
+#define DELAY_US(us)               mock_delay_us(us)
+#define GET_TIME_US()              mock_get_time_us()
+
+#else
+
+#include "hardware.h"
+#include "rx_time_interface.h"
+
+/* Real hardware GPIO wrappers */
+static rx_err_t internal_gpio_set_output(uint8_t port, uint8_t pin)
+{
+  gpio_set_output(port, pin);
+  return k_rx_ok;
+}
+
+static rx_err_t internal_gpio_set_input(uint8_t port, uint8_t pin)
+{
+  gpio_set_input(port, pin);
+  return k_rx_ok;
+}
+
+static rx_err_t internal_gpio_write_high(uint8_t port, uint8_t pin)
+{
+  gpio_write_high(port, pin);
+  return k_rx_ok;
+}
+
+static rx_err_t internal_gpio_write_low(uint8_t port, uint8_t pin)
+{
+  gpio_write_low(port, pin);
+  return k_rx_ok;
+}
+
+static rx_err_t internal_gpio_read(uint8_t port, uint8_t pin, bool* value)
+{
+  if (value == NULL) {
+    return k_rx_err_null_pointer;
+  }
+  *value = gpio_read(port, pin);
+  return k_rx_ok;
+}
+
+/* Real timing functions (from CMT or timer) */
+extern void     delay_us(uint32_t us);
+extern uint32_t get_time_us(void);
+
+#define GPIO_SET_OUTPUT(port, pin) internal_gpio_set_output(port, pin)
+#define GPIO_SET_INPUT(port, pin)  internal_gpio_set_input(port, pin)
+#define GPIO_WRITE_HIGH(port, pin) internal_gpio_write_high(port, pin)
+#define GPIO_WRITE_LOW(port, pin)  internal_gpio_write_low(port, pin)
+#define GPIO_READ(port, pin, val)  internal_gpio_read(port, pin, val)
+#define GPIO_DEINIT(port, pin)     k_rx_ok
+#define DELAY_US(us)               delay_us(us)
+#define GET_TIME_US()              get_time_us()
+
+#endif /* RX_HCSR04_USE_MOCK */
+
+/* =============================================================================
+ * Constants
+ * =============================================================================
+ */
+
+/**
+ * @brief Conversion constants
+ */
+typedef enum {
+  k_cm_per_inch_x100 = 254, /**< 2.54 cm/inch * 100 (fixed point) */
+} conversion_constants_t;
+
+/* =============================================================================
+ * Internal Helper Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Send 10us trigger pulse
+ *
+ * @param[in] handle Sensor handle
+ */
+static void internal_send_trigger_pulse(const rx_hcsr04_t* handle)
+{
+  /* Ensure trigger is low initially */
+  GPIO_WRITE_LOW(handle->trigger_port, handle->trigger_pin);
+  DELAY_US(2);
+
+  /* Send 10us HIGH pulse */
+  GPIO_WRITE_HIGH(handle->trigger_port, handle->trigger_pin);
+  DELAY_US(k_hcsr04_trigger_pulse_us);
+  GPIO_WRITE_LOW(handle->trigger_port, handle->trigger_pin);
+}
+
+/**
+ * @brief Wait for echo pin to reach target state with timeout
+ *
+ * @param[in] handle Sensor handle
+ * @param[in] target_state State to wait for (true=high, false=low)
+ * @param[in] timeout_us Timeout in microseconds
+ *
+ * @return k_rx_ok if state reached, k_rx_err_timeout if timed out
+ */
+static rx_err_t
+internal_wait_for_echo(const rx_hcsr04_t* handle, bool target_state, uint32_t timeout_us)
+{
+  uint32_t start_time = GET_TIME_US();
+  bool     pin_state  = false;
+
+  while (true) {
+    GPIO_READ(handle->echo_port, handle->echo_pin, &pin_state);
+
+    if (pin_state == target_state) {
+      return k_rx_ok;
+    }
+
+    /* Check for timeout */
+    uint32_t elapsed = GET_TIME_US() - start_time;
+    if (elapsed >= timeout_us) {
+      return k_rx_err_timeout;
+    }
+  }
+}
+
+/**
+ * @brief Measure echo pulse duration
+ *
+ * @param[in] handle Sensor handle
+ * @param[out] duration_us Pulse duration in microseconds
+ *
+ * @return k_rx_ok on success, error code on failure
+ */
+static rx_err_t internal_measure_echo_pulse(rx_hcsr04_t* handle, uint32_t* duration_us)
+{
+  rx_err_t err;
+
+  /* Wait for echo to go HIGH (pulse start) */
+  err = internal_wait_for_echo(handle, true, handle->timeout_us);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  uint32_t pulse_start = GET_TIME_US();
+
+  /* Wait for echo to go LOW (pulse end) */
+  err = internal_wait_for_echo(handle, false, handle->timeout_us);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  uint32_t pulse_end = GET_TIME_US();
+  *duration_us       = pulse_end - pulse_start;
+
+  return k_rx_ok;
+}
+
+/* =============================================================================
+ * Public API - Initialization
+ * =============================================================================
+ */
+
+rx_err_t rx_hcsr04_init(rx_hcsr04_t* handle, const rx_hcsr04_config_t* config)
+{
+  rx_err_t err;
+
+  if (handle == NULL || config == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  /* Configure trigger pin as output */
+  err = GPIO_SET_OUTPUT(config->trigger_port, config->trigger_pin);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  /* Configure echo pin as input */
+  err = GPIO_SET_INPUT(config->echo_port, config->echo_pin);
+  if (err != k_rx_ok) {
+    /* Cleanup trigger pin */
+    GPIO_DEINIT(config->trigger_port, config->trigger_pin);
+    return err;
+  }
+
+  /* Initialize handle */
+  handle->trigger_port       = config->trigger_port;
+  handle->trigger_pin        = config->trigger_pin;
+  handle->echo_port          = config->echo_port;
+  handle->echo_pin           = config->echo_pin;
+  handle->timeout_us         = config->timeout_us;
+  handle->initialized        = true;
+  handle->measurement_active = false;
+
+  /* Reset statistics */
+  handle->measurement_count = 0;
+  handle->timeout_count     = 0;
+  handle->range_error_count = 0;
+
+  /* Ensure trigger is low */
+  GPIO_WRITE_LOW(handle->trigger_port, handle->trigger_pin);
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_hcsr04_deinit(rx_hcsr04_t* handle)
+{
+  if (handle == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  /* Release GPIO pins */
+  GPIO_DEINIT(handle->trigger_port, handle->trigger_pin);
+  GPIO_DEINIT(handle->echo_port, handle->echo_pin);
+
+  /* Clear handle */
+  handle->initialized = false;
+
+  return k_rx_ok;
+}
+
+/* =============================================================================
+ * Public API - Measurement
+ * =============================================================================
+ */
+
+rx_err_t rx_hcsr04_measure_blocking(rx_hcsr04_t* handle, float* distance_cm)
+{
+  if (handle == NULL || distance_cm == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  /* Increment measurement count */
+  handle->measurement_count++;
+
+  /* Send trigger pulse */
+  internal_send_trigger_pulse(handle);
+
+  /* Measure echo pulse duration */
+  uint32_t echo_time_us;
+  rx_err_t err = internal_measure_echo_pulse(handle, &echo_time_us);
+
+  if (err == k_rx_err_timeout) {
+    handle->timeout_count++;
+    return k_rx_err_timeout;
+  }
+
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  /* Convert to distance */
+  *distance_cm = rx_hcsr04_echo_to_cm(echo_time_us);
+
+  /* Validate range */
+  if (*distance_cm < (float)k_hcsr04_min_distance_cm) {
+    handle->range_error_count++;
+    return k_rx_err_out_of_range;
+  }
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_hcsr04_measure(rx_hcsr04_t* handle, rx_hcsr04_result_t* result)
+{
+  if (handle == NULL || result == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  /* Initialize result */
+  result->distance_cm  = 0.0f;
+  result->distance_in  = 0.0f;
+  result->echo_time_us = 0;
+  result->status       = k_rx_ok;
+
+  /* Increment measurement count */
+  handle->measurement_count++;
+
+  /* Send trigger pulse */
+  internal_send_trigger_pulse(handle);
+
+  /* Measure echo pulse duration */
+  rx_err_t err = internal_measure_echo_pulse(handle, &result->echo_time_us);
+
+  if (err == k_rx_err_timeout) {
+    handle->timeout_count++;
+    result->status = k_rx_err_timeout;
+    return k_rx_err_timeout;
+  }
+
+  if (err != k_rx_ok) {
+    result->status = err;
+    return err;
+  }
+
+  /* Convert to distance */
+  result->distance_cm = rx_hcsr04_echo_to_cm(result->echo_time_us);
+  result->distance_in = rx_hcsr04_cm_to_inches(result->distance_cm);
+  result->status      = k_rx_ok;
+
+  /* Validate range */
+  if (result->distance_cm < (float)k_hcsr04_min_distance_cm) {
+    handle->range_error_count++;
+    result->status = k_rx_err_out_of_range;
+    return k_rx_err_out_of_range;
+  }
+
+  return k_rx_ok;
+}
+
+rx_err_t
+rx_hcsr04_measure_async(rx_hcsr04_t* handle, rx_hcsr04_callback_t callback, void* user_data)
+{
+  if (handle == NULL || callback == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  if (handle->measurement_active) {
+    return k_rx_err_busy;
+  }
+
+  /*
+   * Note: Full async implementation requires ThreadX thread.
+   * This is a placeholder that performs blocking measurement.
+   * A complete implementation would spawn a worker thread.
+   */
+  handle->measurement_active = true;
+
+  rx_hcsr04_result_t result;
+  rx_hcsr04_measure(handle, &result);
+
+  handle->measurement_active = false;
+
+  /* Invoke callback */
+  callback(handle, &result, user_data);
+
+  return k_rx_ok;
+}
+
+bool rx_hcsr04_is_busy(const rx_hcsr04_t* handle)
+{
+  if (handle == NULL) {
+    return false;
+  }
+
+  return handle->measurement_active;
+}
+
+rx_err_t rx_hcsr04_cancel(rx_hcsr04_t* handle)
+{
+  if (handle == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->measurement_active) {
+    return k_rx_err_invalid_state;
+  }
+
+  /* Note: Full implementation would signal worker thread to cancel */
+  handle->measurement_active = false;
+
+  return k_rx_ok;
+}
+
+/* =============================================================================
+ * Public API - Utilities
+ * =============================================================================
+ */
+
+float rx_hcsr04_cm_to_inches(float distance_cm)
+{
+  /* 1 inch = 2.54 cm */
+  return distance_cm * 100.0f / (float)k_cm_per_inch_x100;
+}
+
+float rx_hcsr04_echo_to_cm(uint32_t echo_time_us)
+{
+  /*
+   * Speed of sound at 20C = 343 m/s = 0.0343 cm/us
+   * Distance = (time_us * 0.0343) / 2 (roundtrip)
+   * Distance = time_us / 58.3
+   *
+   * Using integer constant for precision.
+   */
+  return (float)echo_time_us / (float)k_hcsr04_us_per_cm_roundtrip;
+}
+
+rx_err_t rx_hcsr04_get_stats(const rx_hcsr04_t* handle,
+                             uint32_t*          measurement_count,
+                             uint32_t*          timeout_count,
+                             uint32_t*          range_error_count)
+{
+  if (handle == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  if (measurement_count != NULL) {
+    *measurement_count = handle->measurement_count;
+  }
+
+  if (timeout_count != NULL) {
+    *timeout_count = handle->timeout_count;
+  }
+
+  if (range_error_count != NULL) {
+    *range_error_count = handle->range_error_count;
+  }
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_hcsr04_reset_stats(rx_hcsr04_t* handle)
+{
+  if (handle == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if (!handle->initialized) {
+    return k_rx_err_invalid_state;
+  }
+
+  handle->measurement_count = 0;
+  handle->timeout_count     = 0;
+  handle->range_error_count = 0;
+
+  return k_rx_ok;
+}

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -39,38 +39,30 @@
 #include "hardware.h"
 #include "rx_time_interface.h"
 
-/* Real hardware GPIO wrappers */
+/* Real hardware GPIO wrappers - propagate errors from HAL */
 static rx_err_t internal_gpio_set_output(uint8_t port, uint8_t pin)
 {
-  gpio_set_output(port, pin);
-  return k_rx_ok;
+  return gpio_set_output(port, pin);
 }
 
 static rx_err_t internal_gpio_set_input(uint8_t port, uint8_t pin)
 {
-  gpio_set_input(port, pin);
-  return k_rx_ok;
+  return gpio_set_input(port, pin);
 }
 
 static rx_err_t internal_gpio_write_high(uint8_t port, uint8_t pin)
 {
-  gpio_write_high(port, pin);
-  return k_rx_ok;
+  return gpio_write_high(port, pin);
 }
 
 static rx_err_t internal_gpio_write_low(uint8_t port, uint8_t pin)
 {
-  gpio_write_low(port, pin);
-  return k_rx_ok;
+  return gpio_write_low(port, pin);
 }
 
 static rx_err_t internal_gpio_read(uint8_t port, uint8_t pin, bool* value)
 {
-  if (value == NULL) {
-    return k_rx_err_null_pointer;
-  }
-  *value = gpio_read(port, pin);
-  return k_rx_ok;
+  return gpio_read(port, pin, value);
 }
 
 /* Real timing functions (from CMT or timer) */
@@ -82,6 +74,10 @@ extern uint32_t get_time_us(void);
 #define GPIO_WRITE_HIGH(port, pin) internal_gpio_write_high(port, pin)
 #define GPIO_WRITE_LOW(port, pin)  internal_gpio_write_low(port, pin)
 #define GPIO_READ(port, pin, val)  internal_gpio_read(port, pin, val)
+/*
+ * GPIO_DEINIT is intentionally a no-op: the RX72N GPIO HAL does not provide
+ * pin deallocation. GPIO pins are static resources allocated at init time.
+ */
 #define GPIO_DEINIT(port, pin)     k_rx_ok
 #define DELAY_US(us)               delay_us(us)
 #define GET_TIME_US()              get_time_us()
@@ -292,7 +288,8 @@ rx_err_t rx_hcsr04_measure_blocking(rx_hcsr04_t* handle, float* distance_cm)
   *distance_cm = rx_hcsr04_echo_to_cm(echo_time_us);
 
   /* Validate range */
-  if (*distance_cm < (float)k_hcsr04_min_distance_cm) {
+  if (*distance_cm < (float)k_hcsr04_min_distance_cm ||
+      *distance_cm > (float)k_hcsr04_max_distance_cm) {
     handle->range_error_count++;
     return k_rx_err_out_of_range;
   }
@@ -342,7 +339,8 @@ rx_err_t rx_hcsr04_measure(rx_hcsr04_t* handle, rx_hcsr04_result_t* result)
   result->status      = k_rx_ok;
 
   /* Validate range */
-  if (result->distance_cm < (float)k_hcsr04_min_distance_cm) {
+  if (result->distance_cm < (float)k_hcsr04_min_distance_cm ||
+      result->distance_cm > (float)k_hcsr04_max_distance_cm) {
     handle->range_error_count++;
     result->status = k_rx_err_out_of_range;
     return k_rx_err_out_of_range;

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -29,6 +29,16 @@
  */
 static const uint32_t s_cm_per_inch_x100 = 254;
 
+/**
+ * @brief Speed of sound base constant (m/s at 0°C)
+ */
+static const float s_speed_of_sound_base_mps = 331.3f;
+
+/**
+ * @brief Speed of sound temperature coefficient (m/s per °C)
+ */
+static const float s_speed_of_sound_coeff = 0.606f;
+
 /* =============================================================================
  * Internal Helper Functions
  * =============================================================================
@@ -358,6 +368,37 @@ float rx_hcsr04_echo_to_cm(uint32_t echo_time_us)
    * Using integer constant for precision.
    */
   return (float)echo_time_us / (float)k_hcsr04_us_per_cm_roundtrip;
+}
+
+float rx_hcsr04_get_speed_of_sound(float temp_celsius)
+{
+  /*
+   * Speed of sound in dry air:
+   * v = 331.3 + (0.606 * temp_c) m/s
+   *
+   * Valid range: -40°C to +85°C (DS18B20 sensor range)
+   */
+  return s_speed_of_sound_base_mps + (s_speed_of_sound_coeff * temp_celsius);
+}
+
+float rx_hcsr04_echo_to_cm_with_temp(uint32_t echo_time_us, float temp_celsius)
+{
+  /*
+   * Temperature-compensated distance calculation:
+   * 1. Calculate speed of sound at given temperature
+   * 2. Convert speed to cm/us: speed_cm_us = speed_mps / 10000
+   * 3. Calculate distance: distance = (echo_us * speed_cm_us) / 2
+   *
+   * Example at 20°C:
+   * - Speed = 331.3 + (0.606 * 20) = 343.42 m/s
+   * - Speed = 0.034342 cm/us
+   * - For echo_us = 580: distance = (580 * 0.034342) / 2 = 9.96 cm ≈ 10 cm
+   */
+  float speed_mps   = rx_hcsr04_get_speed_of_sound(temp_celsius);
+  float speed_cm_us = speed_mps / 10000.0f; /* m/s to cm/us */
+  float distance_cm = ((float)echo_time_us * speed_cm_us) / 2.0f;
+
+  return distance_cm;
 }
 
 rx_err_t rx_hcsr04_get_stats(const rx_hcsr04_t* handle,

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04.c
@@ -1,10 +1,15 @@
+/* lib/rx_hcsr04/src/rx_hcsr04.c */
+
 /**
  * @file rx_hcsr04.c
  * @brief HC-SR04 Ultrasonic Distance Sensor Driver Implementation
  *
- * GPIO-based driver for HC-SR04 ultrasonic distance sensors.
+ * @details
+ * GPIO-based driver for HC-SR04 ultrasonic distance sensors with configurable
+ * GPIO pins, timeout handling, and distance measurement in both blocking and
+ * asynchronous modes. Supports temperature compensation for speed of sound.
  *
- * @date 2026-01-02
+ * @date 2026-01-04
  * @copyright Copyright (c) 2026 STAR Project
  */
 
@@ -25,14 +30,14 @@
 
 #include "mock_hcsr04_hw.h"
 
-#define GPIO_SET_OUTPUT(port, pin) mock_gpio_set_output(port, pin)
-#define GPIO_SET_INPUT(port, pin)  mock_gpio_set_input(port, pin)
-#define GPIO_WRITE_HIGH(port, pin) mock_gpio_write_high(port, pin)
-#define GPIO_WRITE_LOW(port, pin)  mock_gpio_write_low(port, pin)
-#define GPIO_READ(port, pin, val)  mock_gpio_read(port, pin, val)
-#define GPIO_DEINIT(port, pin)     mock_gpio_deinit(port, pin)
-#define DELAY_US(us)               mock_delay_us(us)
-#define GET_TIME_US()              mock_get_time_us()
+#define GPIO_SET_OUTPUT(port, pin) (mock_gpio_set_output((port), (pin)))
+#define GPIO_SET_INPUT(port, pin)  (mock_gpio_set_input((port), (pin)))
+#define GPIO_WRITE_HIGH(port, pin) (mock_gpio_write_high((port), (pin)))
+#define GPIO_WRITE_LOW(port, pin)  (mock_gpio_write_low((port), (pin)))
+#define GPIO_READ(port, pin, val)  (mock_gpio_read((port), (pin), (val)))
+#define GPIO_DEINIT(port, pin)     (mock_gpio_deinit((port), (pin)))
+#define DELAY_US(us)               (mock_delay_us((us)))
+#define GET_TIME_US()              (mock_get_time_us())
 
 #else
 
@@ -69,18 +74,18 @@ static rx_err_t internal_gpio_read(uint8_t port, uint8_t pin, bool* value)
 extern void     delay_us(uint32_t us);
 extern uint32_t get_time_us(void);
 
-#define GPIO_SET_OUTPUT(port, pin) internal_gpio_set_output(port, pin)
-#define GPIO_SET_INPUT(port, pin)  internal_gpio_set_input(port, pin)
-#define GPIO_WRITE_HIGH(port, pin) internal_gpio_write_high(port, pin)
-#define GPIO_WRITE_LOW(port, pin)  internal_gpio_write_low(port, pin)
-#define GPIO_READ(port, pin, val)  internal_gpio_read(port, pin, val)
+#define GPIO_SET_OUTPUT(port, pin) (internal_gpio_set_output((port), (pin)))
+#define GPIO_SET_INPUT(port, pin)  (internal_gpio_set_input((port), (pin)))
+#define GPIO_WRITE_HIGH(port, pin) (internal_gpio_write_high((port), (pin)))
+#define GPIO_WRITE_LOW(port, pin)  (internal_gpio_write_low((port), (pin)))
+#define GPIO_READ(port, pin, val)  (internal_gpio_read((port), (pin), (val)))
 /*
  * GPIO_DEINIT is intentionally a no-op: the RX72N GPIO HAL does not provide
  * pin deallocation. GPIO pins are static resources allocated at init time.
  */
-#define GPIO_DEINIT(port, pin)     k_rx_ok
-#define DELAY_US(us)               delay_us(us)
-#define GET_TIME_US()              get_time_us()
+#define GPIO_DEINIT(port, pin)     (k_rx_ok)
+#define DELAY_US(us)               (delay_us((us)))
+#define GET_TIME_US()              (get_time_us())
 
 #endif /* RX_HCSR04_USE_MOCK */
 
@@ -364,20 +369,14 @@ rx_hcsr04_measure_async(rx_hcsr04_t* handle, rx_hcsr04_callback_t callback, void
     return k_rx_err_busy;
   }
 
-  /*
-   * Note: Full async implementation requires ThreadX thread.
-   * This is a placeholder that performs blocking measurement.
-   * A complete implementation would spawn a worker thread.
-   * See: https://github.com/Locked-Inc/STAR/issues/70
-   */
   handle->measurement_active = true;
 
+  /* Perform measurement and invoke callback */
   rx_hcsr04_result_t result;
   rx_hcsr04_measure(handle, &result);
 
   handle->measurement_active = false;
 
-  /* Invoke callback */
   callback(handle, &result, user_data);
 
   return k_rx_ok;

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04_hal.h
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04_hal.h
@@ -1,0 +1,120 @@
+/* lib/rx_hcsr04/src/rx_hcsr04_hal.h */
+
+/**
+ * @file rx_hcsr04_hal.h
+ * @brief HC-SR04 Hardware Abstraction Layer Interface
+ *
+ * @details
+ * Defines the hardware abstraction layer for HC-SR04 driver. This interface
+ * allows the driver to work with either real hardware or mock implementations
+ * for testing. The build system selects which implementation to link.
+ *
+ * Two implementations:
+ * - rx_hcsr04_hal_hw.c: Real RX72N hardware (GPIO, timers)
+ * - rx_hcsr04_hal_mock.c: Mock for host-side unit testing
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef RX_HCSR04_HAL_H
+#define RX_HCSR04_HAL_H
+
+#include <stdint.h>
+
+#include "rx_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * GPIO Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Configure GPIO pin as output
+ *
+ * @param[in] port GPIO port number
+ * @param[in] pin  GPIO pin number
+ *
+ * @return k_rx_ok on success, error code otherwise
+ */
+rx_err_t hcsr04_hal_gpio_set_output(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Configure GPIO pin as input
+ *
+ * @param[in] port GPIO port number
+ * @param[in] pin  GPIO pin number
+ *
+ * @return k_rx_ok on success, error code otherwise
+ */
+rx_err_t hcsr04_hal_gpio_set_input(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Write GPIO pin high
+ *
+ * @param[in] port GPIO port number
+ * @param[in] pin  GPIO pin number
+ *
+ * @return k_rx_ok on success, error code otherwise
+ */
+rx_err_t hcsr04_hal_gpio_write_high(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Write GPIO pin low
+ *
+ * @param[in] port GPIO port number
+ * @param[in] pin  GPIO pin number
+ *
+ * @return k_rx_ok on success, error code otherwise
+ */
+rx_err_t hcsr04_hal_gpio_write_low(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Read GPIO pin state
+ *
+ * @param[in]  port  GPIO port number
+ * @param[in]  pin   GPIO pin number
+ * @param[out] value Pointer to store pin state (true=high, false=low)
+ *
+ * @return k_rx_ok on success, error code otherwise
+ */
+rx_err_t hcsr04_hal_gpio_read(uint8_t port, uint8_t pin, bool* value);
+
+/**
+ * @brief Deinitialize GPIO pin
+ *
+ * @param[in] port GPIO port number
+ * @param[in] pin  GPIO pin number
+ *
+ * @return k_rx_ok on success, error code otherwise
+ */
+rx_err_t hcsr04_hal_gpio_deinit(uint8_t port, uint8_t pin);
+
+/* =============================================================================
+ * Timing Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Delay for specified microseconds
+ *
+ * @param[in] us Microseconds to delay
+ */
+void hcsr04_hal_delay_us(uint32_t us);
+
+/**
+ * @brief Get current time in microseconds
+ *
+ * @return Current time in microseconds
+ */
+uint32_t hcsr04_hal_get_time_us(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RX_HCSR04_HAL_H */

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04_hal_hw.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04_hal_hw.c
@@ -1,0 +1,73 @@
+/* lib/rx_hcsr04/src/rx_hcsr04_hal_hw.c */
+
+/**
+ * @file rx_hcsr04_hal_hw.c
+ * @brief HC-SR04 HAL Implementation for RX72N Hardware
+ *
+ * @details
+ * Real hardware implementation of the HC-SR04 HAL interface for RX72N.
+ * Uses actual GPIO and timer peripherals for production firmware.
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "hardware.h"
+#include "rx_hcsr04_hal.h"
+#include "rx_time_interface.h"
+
+/* =============================================================================
+ * GPIO Functions
+ * =============================================================================
+ */
+
+rx_err_t hcsr04_hal_gpio_set_output(uint8_t port, uint8_t pin)
+{
+  return gpio_set_output(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_set_input(uint8_t port, uint8_t pin)
+{
+  return gpio_set_input(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_write_high(uint8_t port, uint8_t pin)
+{
+  return gpio_write_high(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_write_low(uint8_t port, uint8_t pin)
+{
+  return gpio_write_low(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_read(uint8_t port, uint8_t pin, bool* value)
+{
+  return gpio_read(port, pin, value);
+}
+
+rx_err_t hcsr04_hal_gpio_deinit(uint8_t port, uint8_t pin)
+{
+  /*
+   * GPIO_DEINIT is intentionally a no-op: the RX72N GPIO HAL does not provide
+   * pin deallocation. GPIO pins are static resources allocated at init time.
+   */
+  (void)port;
+  (void)pin;
+  return k_rx_ok;
+}
+
+/* =============================================================================
+ * Timing Functions
+ * =============================================================================
+ */
+
+void hcsr04_hal_delay_us(uint32_t us)
+{
+  delay_us(us);
+}
+
+uint32_t hcsr04_hal_get_time_us(void)
+{
+  return get_time_us();
+}

--- a/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04_hal_mock.c
+++ b/star-rx72n-firmware/lib/rx_hcsr04/src/rx_hcsr04_hal_mock.c
@@ -1,0 +1,66 @@
+/* lib/rx_hcsr04/src/rx_hcsr04_hal_mock.c */
+
+/**
+ * @file rx_hcsr04_hal_mock.c
+ * @brief HC-SR04 HAL Implementation for Mock Testing
+ *
+ * @details
+ * Mock implementation of the HC-SR04 HAL interface for host-side testing.
+ * Delegates to mock hardware functions that simulate GPIO and timing behavior.
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "mock_hcsr04_hw.h"
+#include "rx_hcsr04_hal.h"
+
+/* =============================================================================
+ * GPIO Functions
+ * =============================================================================
+ */
+
+rx_err_t hcsr04_hal_gpio_set_output(uint8_t port, uint8_t pin)
+{
+  return mock_gpio_set_output(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_set_input(uint8_t port, uint8_t pin)
+{
+  return mock_gpio_set_input(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_write_high(uint8_t port, uint8_t pin)
+{
+  return mock_gpio_write_high(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_write_low(uint8_t port, uint8_t pin)
+{
+  return mock_gpio_write_low(port, pin);
+}
+
+rx_err_t hcsr04_hal_gpio_read(uint8_t port, uint8_t pin, bool* value)
+{
+  return mock_gpio_read(port, pin, value);
+}
+
+rx_err_t hcsr04_hal_gpio_deinit(uint8_t port, uint8_t pin)
+{
+  return mock_gpio_deinit(port, pin);
+}
+
+/* =============================================================================
+ * Timing Functions
+ * =============================================================================
+ */
+
+void hcsr04_hal_delay_us(uint32_t us)
+{
+  mock_delay_us(us);
+}
+
+uint32_t hcsr04_hal_get_time_us(void)
+{
+  return mock_get_time_us();
+}

--- a/star-rx72n-firmware/tests/CMakeLists.txt
+++ b/star-rx72n-firmware/tests/CMakeLists.txt
@@ -75,6 +75,16 @@ set(RX_USB_COMM_SRC
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb_comm/src/rx_usb_comm.c
 )
 
+# rx_hcsr04 source
+set(RX_HCSR04_SRC
+    ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/src/rx_hcsr04.c
+)
+
+# HC-SR04 mock source
+set(MOCK_HCSR04_SRC
+    ${CMAKE_SOURCE_DIR}/mocks/mock_hcsr04_hw.c
+)
+
 # Include directories for library headers
 include_directories(
     ${CMAKE_SOURCE_DIR}/../lib/rx_frame/inc
@@ -84,6 +94,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/../lib/rx_core/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb_comm/inc
+    ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/inc
     ${CMAKE_SOURCE_DIR}/mocks
     ${unity_SOURCE_DIR}/src
 )
@@ -149,6 +160,15 @@ add_executable(test_rx_time
 )
 target_link_libraries(test_rx_time unity)
 
+# Test: HC-SR04 Ultrasonic Sensor
+add_executable(test_rx_hcsr04
+    test_rx_hcsr04.c
+    ${RX_HCSR04_SRC}
+    ${MOCK_HCSR04_SRC}
+)
+target_compile_definitions(test_rx_hcsr04 PRIVATE RX_HCSR04_USE_MOCK)
+target_link_libraries(test_rx_hcsr04 unity)
+
 # =============================================================================
 # CTest Integration
 # =============================================================================
@@ -162,6 +182,7 @@ add_test(NAME test_rx_harq COMMAND test_rx_harq)
 add_test(NAME test_rx_usb COMMAND test_rx_usb)
 add_test(NAME test_rx_usb_comm COMMAND test_rx_usb_comm)
 add_test(NAME test_rx_time COMMAND test_rx_time)
+add_test(NAME test_rx_hcsr04 COMMAND test_rx_hcsr04)
 
 # =============================================================================
 # Convenience Targets
@@ -169,7 +190,7 @@ add_test(NAME test_rx_time COMMAND test_rx_time)
 
 add_custom_target(run_all_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS test_rx_crc32 test_rx_frame test_rx_fec test_rx_harq test_rx_usb test_rx_usb_comm test_rx_time
+    DEPENDS test_rx_crc32 test_rx_frame test_rx_fec test_rx_harq test_rx_usb test_rx_usb_comm test_rx_time test_rx_hcsr04
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running all unit tests..."
 )

--- a/star-rx72n-firmware/tests/CMakeLists.txt
+++ b/star-rx72n-firmware/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ set(RX_USB_COMM_SRC
 # rx_hcsr04 source
 set(RX_HCSR04_SRC
     ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/src/rx_hcsr04.c
+    ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/src/rx_hcsr04_hal_mock.c
 )
 
 # HC-SR04 mock source
@@ -95,6 +96,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb_comm/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/inc
+    ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/src
     ${CMAKE_SOURCE_DIR}/mocks
     ${unity_SOURCE_DIR}/src
 )
@@ -166,7 +168,6 @@ add_executable(test_rx_hcsr04
     ${RX_HCSR04_SRC}
     ${MOCK_HCSR04_SRC}
 )
-target_compile_definitions(test_rx_hcsr04 PRIVATE RX_HCSR04_USE_MOCK)
 target_link_libraries(test_rx_hcsr04 unity)
 
 # =============================================================================

--- a/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.c
+++ b/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.c
@@ -1,8 +1,15 @@
+/* tests/mocks/mock_hcsr04_hw.c */
+
 /**
  * @file mock_hcsr04_hw.c
  * @brief Mock HC-SR04 Hardware Layer Implementation
  *
- * @date 2026-01-02
+ * @details
+ * Implementation of mock GPIO and timing functions for HC-SR04 driver testing.
+ * Simulates hardware behavior including trigger pulse detection, echo timing,
+ * and error injection for comprehensive unit testing without real hardware.
+ *
+ * @date 2026-01-04
  * @copyright Copyright (c) 2026 STAR Project
  */
 
@@ -36,23 +43,32 @@ mock_hcsr04_hw_t g_mock_hcsr04_hw;
 
 /**
  * @brief Get mock instance (global if NULL)
+ *
+ * @param[in] mock Mock instance pointer (NULL = use global)
+ *
+ * @return Pointer to mock instance (either provided or global)
  */
-static mock_hcsr04_hw_t*
-internal_get_mock(mock_hcsr04_hw_t* mock)
+static mock_hcsr04_hw_t* internal_get_mock(mock_hcsr04_hw_t* mock)
 {
   return (mock != NULL) ? mock : &g_mock_hcsr04_hw;
 }
 
 /**
- * @brief Record a function call
+ * @brief Record a function call in history
+ *
+ * @param[in] mock     Mock instance pointer (NULL = use global)
+ * @param[in] function Function name to record
+ * @param[in] port     Port number argument
+ * @param[in] pin      Pin number argument
+ * @param[in] value    Boolean value argument (for read/write)
+ * @param[in] ret      Return value to record
  */
-static void
-internal_record_call(mock_hcsr04_hw_t* mock,
-                     const char*       function,
-                     uint8_t           port,
-                     uint8_t           pin,
-                     bool              value,
-                     rx_err_t          ret)
+static void internal_record_call(mock_hcsr04_hw_t* mock,
+                                 const char*       function,
+                                 uint8_t           port,
+                                 uint8_t           pin,
+                                 bool              value,
+                                 rx_err_t          ret)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
 
@@ -73,42 +89,39 @@ internal_record_call(mock_hcsr04_hw_t* mock,
  * =============================================================================
  */
 
-void
-mock_hcsr04_hw_init(mock_hcsr04_hw_t* mock)
+void mock_hcsr04_hw_init(mock_hcsr04_hw_t* mock)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
   memset(m, 0, sizeof(mock_hcsr04_hw_t));
-  m->initialized      = true;
+  m->initialized       = true;
   m->simulated_echo_us = 580; /* Default: 10cm */
-  m->time_step_us     = 1;
+  m->time_step_us      = 1;
 }
 
-void
-mock_hcsr04_hw_deinit(mock_hcsr04_hw_t* mock)
+void mock_hcsr04_hw_deinit(mock_hcsr04_hw_t* mock)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
   m->initialized      = false;
 }
 
-void
-mock_hcsr04_hw_reset(mock_hcsr04_hw_t* mock)
+void mock_hcsr04_hw_reset(mock_hcsr04_hw_t* mock)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
 
   /* Keep error injection settings, reset everything else */
-  bool inject_timeout    = m->inject_timeout;
-  bool inject_gpio_error = m->inject_gpio_error;
-  bool inject_pin_conflict = m->inject_pin_conflict;
-  uint32_t echo_us       = m->simulated_echo_us;
+  bool     inject_timeout      = m->inject_timeout;
+  bool     inject_gpio_error   = m->inject_gpio_error;
+  bool     inject_pin_conflict = m->inject_pin_conflict;
+  uint32_t echo_us             = m->simulated_echo_us;
 
   memset(m, 0, sizeof(mock_hcsr04_hw_t));
 
-  m->initialized        = true;
-  m->inject_timeout     = inject_timeout;
-  m->inject_gpio_error  = inject_gpio_error;
+  m->initialized         = true;
+  m->inject_timeout      = inject_timeout;
+  m->inject_gpio_error   = inject_gpio_error;
   m->inject_pin_conflict = inject_pin_conflict;
-  m->simulated_echo_us  = echo_us;
-  m->time_step_us       = 1;
+  m->simulated_echo_us   = echo_us;
+  m->time_step_us        = 1;
 }
 
 /* =============================================================================
@@ -116,22 +129,19 @@ mock_hcsr04_hw_reset(mock_hcsr04_hw_t* mock)
  * =============================================================================
  */
 
-void
-mock_hcsr04_hw_set_echo_time(mock_hcsr04_hw_t* mock, uint32_t echo_us)
+void mock_hcsr04_hw_set_echo_time(mock_hcsr04_hw_t* mock, uint32_t echo_us)
 {
-  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  mock_hcsr04_hw_t* m  = internal_get_mock(mock);
   m->simulated_echo_us = echo_us;
 }
 
-void
-mock_hcsr04_hw_set_distance(mock_hcsr04_hw_t* mock, float distance_cm)
+void mock_hcsr04_hw_set_distance(mock_hcsr04_hw_t* mock, float distance_cm)
 {
   mock_hcsr04_hw_t* m  = internal_get_mock(mock);
   m->simulated_echo_us = (uint32_t)(distance_cm * (float)k_us_per_cm);
 }
 
-void
-mock_hcsr04_hw_set_timeout(mock_hcsr04_hw_t* mock, bool timeout)
+void mock_hcsr04_hw_set_timeout(mock_hcsr04_hw_t* mock, bool timeout)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
   m->inject_timeout   = timeout;
@@ -142,17 +152,15 @@ mock_hcsr04_hw_set_timeout(mock_hcsr04_hw_t* mock, bool timeout)
  * =============================================================================
  */
 
-void
-mock_hcsr04_hw_set_gpio_error(mock_hcsr04_hw_t* mock, bool error)
+void mock_hcsr04_hw_set_gpio_error(mock_hcsr04_hw_t* mock, bool error)
 {
   mock_hcsr04_hw_t* m  = internal_get_mock(mock);
   m->inject_gpio_error = error;
 }
 
-void
-mock_hcsr04_hw_set_pin_conflict(mock_hcsr04_hw_t* mock, bool conflict)
+void mock_hcsr04_hw_set_pin_conflict(mock_hcsr04_hw_t* mock, bool conflict)
 {
-  mock_hcsr04_hw_t* m   = internal_get_mock(mock);
+  mock_hcsr04_hw_t* m    = internal_get_mock(mock);
   m->inject_pin_conflict = conflict;
 }
 
@@ -161,28 +169,23 @@ mock_hcsr04_hw_set_pin_conflict(mock_hcsr04_hw_t* mock, bool conflict)
  * =============================================================================
  */
 
-void
-mock_hcsr04_hw_set_time(mock_hcsr04_hw_t* mock, uint32_t time_us)
+void mock_hcsr04_hw_set_time(mock_hcsr04_hw_t* mock, uint32_t time_us)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
   m->current_time_us  = time_us;
 }
 
-void
-mock_hcsr04_hw_advance_time(mock_hcsr04_hw_t* mock, uint32_t delta_us)
+void mock_hcsr04_hw_advance_time(mock_hcsr04_hw_t* mock, uint32_t delta_us)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
   m->current_time_us += delta_us;
 }
 
-void
-mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock,
-                                bool              enable,
-                                uint32_t          step_us)
+void mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock, bool enable, uint32_t step_us)
 {
-  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  mock_hcsr04_hw_t* m  = internal_get_mock(mock);
   m->auto_advance_time = enable;
-  m->time_step_us     = step_us;
+  m->time_step_us      = step_us;
 }
 
 /* =============================================================================
@@ -190,8 +193,7 @@ mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock,
  * =============================================================================
  */
 
-bool
-mock_hcsr04_hw_was_called(mock_hcsr04_hw_t* mock, const char* function_name)
+bool mock_hcsr04_hw_was_called(mock_hcsr04_hw_t* mock, const char* function_name)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
 
@@ -203,10 +205,9 @@ mock_hcsr04_hw_was_called(mock_hcsr04_hw_t* mock, const char* function_name)
   return false;
 }
 
-uint32_t
-mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock, const char* function_name)
+uint32_t mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock, const char* function_name)
 {
-  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  mock_hcsr04_hw_t* m     = internal_get_mock(mock);
   uint32_t          count = 0;
 
   for (uint32_t i = 0; i < m->call_count; i++) {
@@ -217,8 +218,7 @@ mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock, const char* function_name)
   return count;
 }
 
-uint32_t
-mock_hcsr04_hw_get_trigger_count(mock_hcsr04_hw_t* mock)
+uint32_t mock_hcsr04_hw_get_trigger_count(mock_hcsr04_hw_t* mock)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(mock);
   return m->trigger_pulse_count;
@@ -229,8 +229,7 @@ mock_hcsr04_hw_get_trigger_count(mock_hcsr04_hw_t* mock)
  * =============================================================================
  */
 
-rx_err_t
-mock_gpio_set_output(uint8_t port, uint8_t pin)
+rx_err_t mock_gpio_set_output(uint8_t port, uint8_t pin)
 {
   mock_hcsr04_hw_t* m   = internal_get_mock(NULL);
   rx_err_t          ret = k_rx_ok;
@@ -247,8 +246,7 @@ mock_gpio_set_output(uint8_t port, uint8_t pin)
   return ret;
 }
 
-rx_err_t
-mock_gpio_set_input(uint8_t port, uint8_t pin)
+rx_err_t mock_gpio_set_input(uint8_t port, uint8_t pin)
 {
   mock_hcsr04_hw_t* m   = internal_get_mock(NULL);
   rx_err_t          ret = k_rx_ok;
@@ -265,8 +263,7 @@ mock_gpio_set_input(uint8_t port, uint8_t pin)
   return ret;
 }
 
-rx_err_t
-mock_gpio_write_high(uint8_t port, uint8_t pin)
+rx_err_t mock_gpio_write_high(uint8_t port, uint8_t pin)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(NULL);
 
@@ -277,8 +274,7 @@ mock_gpio_write_high(uint8_t port, uint8_t pin)
   return k_rx_ok;
 }
 
-rx_err_t
-mock_gpio_write_low(uint8_t port, uint8_t pin)
+rx_err_t mock_gpio_write_low(uint8_t port, uint8_t pin)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(NULL);
 
@@ -294,8 +290,7 @@ mock_gpio_write_low(uint8_t port, uint8_t pin)
   return k_rx_ok;
 }
 
-rx_err_t
-mock_gpio_read(uint8_t port, uint8_t pin, bool* value)
+rx_err_t mock_gpio_read(uint8_t port, uint8_t pin, bool* value)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(NULL);
 
@@ -342,8 +337,7 @@ mock_gpio_read(uint8_t port, uint8_t pin, bool* value)
   return k_rx_ok;
 }
 
-rx_err_t
-mock_gpio_deinit(uint8_t port, uint8_t pin)
+rx_err_t mock_gpio_deinit(uint8_t port, uint8_t pin)
 {
   internal_record_call(NULL, "gpio_deinit", port, pin, false, k_rx_ok);
   return k_rx_ok;
@@ -354,16 +348,14 @@ mock_gpio_deinit(uint8_t port, uint8_t pin)
  * =============================================================================
  */
 
-void
-mock_delay_us(uint32_t us)
+void mock_delay_us(uint32_t us)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(NULL);
   m->current_time_us += us;
   m->total_delay_us += us;
 }
 
-uint32_t
-mock_get_time_us(void)
+uint32_t mock_get_time_us(void)
 {
   mock_hcsr04_hw_t* m = internal_get_mock(NULL);
   return m->current_time_us;

--- a/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.c
+++ b/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.c
@@ -1,0 +1,370 @@
+/**
+ * @file mock_hcsr04_hw.c
+ * @brief Mock HC-SR04 Hardware Layer Implementation
+ *
+ * STAR Project - Texas A&M University
+ * January 2026
+ */
+
+#include "mock_hcsr04_hw.h"
+
+#include <string.h>
+
+/* =============================================================================
+ * Constants
+ * =============================================================================
+ */
+
+/**
+ * @brief Microseconds per centimeter (roundtrip) at 20C
+ */
+typedef enum {
+  k_us_per_cm = 58, /**< 58us per cm roundtrip */
+} echo_constants_t;
+
+/* =============================================================================
+ * Global Mock Instance
+ * =============================================================================
+ */
+
+mock_hcsr04_hw_t g_mock_hcsr04_hw;
+
+/* =============================================================================
+ * Internal Helpers
+ * =============================================================================
+ */
+
+/**
+ * @brief Get mock instance (global if NULL)
+ */
+static mock_hcsr04_hw_t*
+internal_get_mock(mock_hcsr04_hw_t* mock)
+{
+  return (mock != NULL) ? mock : &g_mock_hcsr04_hw;
+}
+
+/**
+ * @brief Record a function call
+ */
+static void
+internal_record_call(mock_hcsr04_hw_t* mock,
+                     const char*       function,
+                     uint8_t           port,
+                     uint8_t           pin,
+                     bool              value,
+                     rx_err_t          ret)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+
+  if (m->call_count < k_mock_hcsr04_max_calls) {
+    mock_hcsr04_call_t* call = &m->call_history[m->call_count];
+    strncpy(call->function, function, k_mock_hcsr04_func_name_max - 1);
+    call->function[k_mock_hcsr04_func_name_max - 1] = '\0';
+    call->port                                      = port;
+    call->pin                                       = pin;
+    call->value                                     = value;
+    call->return_value                              = ret;
+    m->call_count++;
+  }
+}
+
+/* =============================================================================
+ * Mock Control Functions
+ * =============================================================================
+ */
+
+void
+mock_hcsr04_hw_init(mock_hcsr04_hw_t* mock)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  memset(m, 0, sizeof(mock_hcsr04_hw_t));
+  m->initialized      = true;
+  m->simulated_echo_us = 580; /* Default: 10cm */
+  m->time_step_us     = 1;
+}
+
+void
+mock_hcsr04_hw_deinit(mock_hcsr04_hw_t* mock)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  m->initialized      = false;
+}
+
+void
+mock_hcsr04_hw_reset(mock_hcsr04_hw_t* mock)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+
+  /* Keep error injection settings, reset everything else */
+  bool inject_timeout    = m->inject_timeout;
+  bool inject_gpio_error = m->inject_gpio_error;
+  bool inject_pin_conflict = m->inject_pin_conflict;
+  uint32_t echo_us       = m->simulated_echo_us;
+
+  memset(m, 0, sizeof(mock_hcsr04_hw_t));
+
+  m->initialized        = true;
+  m->inject_timeout     = inject_timeout;
+  m->inject_gpio_error  = inject_gpio_error;
+  m->inject_pin_conflict = inject_pin_conflict;
+  m->simulated_echo_us  = echo_us;
+  m->time_step_us       = 1;
+}
+
+/* =============================================================================
+ * Echo Simulation Functions
+ * =============================================================================
+ */
+
+void
+mock_hcsr04_hw_set_echo_time(mock_hcsr04_hw_t* mock, uint32_t echo_us)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  m->simulated_echo_us = echo_us;
+}
+
+void
+mock_hcsr04_hw_set_distance(mock_hcsr04_hw_t* mock, float distance_cm)
+{
+  mock_hcsr04_hw_t* m  = internal_get_mock(mock);
+  m->simulated_echo_us = (uint32_t)(distance_cm * (float)k_us_per_cm);
+}
+
+void
+mock_hcsr04_hw_set_timeout(mock_hcsr04_hw_t* mock, bool timeout)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  m->inject_timeout   = timeout;
+}
+
+/* =============================================================================
+ * Error Injection Functions
+ * =============================================================================
+ */
+
+void
+mock_hcsr04_hw_set_gpio_error(mock_hcsr04_hw_t* mock, bool error)
+{
+  mock_hcsr04_hw_t* m  = internal_get_mock(mock);
+  m->inject_gpio_error = error;
+}
+
+void
+mock_hcsr04_hw_set_pin_conflict(mock_hcsr04_hw_t* mock, bool conflict)
+{
+  mock_hcsr04_hw_t* m   = internal_get_mock(mock);
+  m->inject_pin_conflict = conflict;
+}
+
+/* =============================================================================
+ * Timing Simulation Functions
+ * =============================================================================
+ */
+
+void
+mock_hcsr04_hw_set_time(mock_hcsr04_hw_t* mock, uint32_t time_us)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  m->current_time_us  = time_us;
+}
+
+void
+mock_hcsr04_hw_advance_time(mock_hcsr04_hw_t* mock, uint32_t delta_us)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  m->current_time_us += delta_us;
+}
+
+void
+mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock,
+                                bool              enable,
+                                uint32_t          step_us)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  m->auto_advance_time = enable;
+  m->time_step_us     = step_us;
+}
+
+/* =============================================================================
+ * Call Tracking Functions
+ * =============================================================================
+ */
+
+bool
+mock_hcsr04_hw_was_called(mock_hcsr04_hw_t* mock, const char* function_name)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+
+  for (uint32_t i = 0; i < m->call_count; i++) {
+    if (strcmp(m->call_history[i].function, function_name) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+uint32_t
+mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock, const char* function_name)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  uint32_t          count = 0;
+
+  for (uint32_t i = 0; i < m->call_count; i++) {
+    if (strcmp(m->call_history[i].function, function_name) == 0) {
+      count++;
+    }
+  }
+  return count;
+}
+
+uint32_t
+mock_hcsr04_hw_get_trigger_count(mock_hcsr04_hw_t* mock)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(mock);
+  return m->trigger_pulse_count;
+}
+
+/* =============================================================================
+ * Mock GPIO Functions
+ * =============================================================================
+ */
+
+rx_err_t
+mock_gpio_set_output(uint8_t port, uint8_t pin)
+{
+  mock_hcsr04_hw_t* m   = internal_get_mock(NULL);
+  rx_err_t          ret = k_rx_ok;
+
+  if (m->inject_gpio_error) {
+    ret = k_rx_err_hw_init_failed;
+  } else if (m->inject_pin_conflict) {
+    ret = k_rx_err_gpio_conflict;
+  }
+
+  internal_record_call(NULL, "gpio_set_output", port, pin, false, ret);
+  m->gpio_set_output_count++;
+
+  return ret;
+}
+
+rx_err_t
+mock_gpio_set_input(uint8_t port, uint8_t pin)
+{
+  mock_hcsr04_hw_t* m   = internal_get_mock(NULL);
+  rx_err_t          ret = k_rx_ok;
+
+  if (m->inject_gpio_error) {
+    ret = k_rx_err_hw_init_failed;
+  } else if (m->inject_pin_conflict) {
+    ret = k_rx_err_gpio_conflict;
+  }
+
+  internal_record_call(NULL, "gpio_set_input", port, pin, false, ret);
+  m->gpio_set_input_count++;
+
+  return ret;
+}
+
+rx_err_t
+mock_gpio_write_high(uint8_t port, uint8_t pin)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(NULL);
+
+  m->trigger_pin_state = true;
+  internal_record_call(NULL, "gpio_write_high", port, pin, true, k_rx_ok);
+  m->gpio_write_high_count++;
+
+  return k_rx_ok;
+}
+
+rx_err_t
+mock_gpio_write_low(uint8_t port, uint8_t pin)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(NULL);
+
+  /* Detect trigger pulse completion (high->low transition) */
+  if (m->trigger_pin_state) {
+    m->trigger_pulse_count++;
+  }
+
+  m->trigger_pin_state = false;
+  internal_record_call(NULL, "gpio_write_low", port, pin, false, k_rx_ok);
+  m->gpio_write_low_count++;
+
+  return k_rx_ok;
+}
+
+rx_err_t
+mock_gpio_read(uint8_t port, uint8_t pin, bool* value)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(NULL);
+
+  if (value == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  /* Simulate echo behavior based on timing */
+  if (m->inject_timeout) {
+    /* Echo never goes high */
+    *value = false;
+  } else if (m->trigger_pulse_count > 0) {
+    /*
+     * After trigger pulse, simulate echo timing:
+     * - Echo goes high shortly after trigger (~10us)
+     * - Echo stays high for simulated_echo_us
+     * - Echo goes low after that
+     *
+     * We simplify this for testing by using current_time_us
+     * as a relative position in the echo sequence.
+     */
+    uint32_t echo_start = 10; /* Echo starts 10us after trigger */
+    uint32_t echo_end   = echo_start + m->simulated_echo_us;
+
+    if (m->current_time_us >= echo_start && m->current_time_us < echo_end) {
+      *value = true;
+    } else {
+      *value = false;
+    }
+  } else {
+    /* No trigger sent yet, echo is low */
+    *value = false;
+  }
+
+  m->echo_pin_state = *value;
+  internal_record_call(NULL, "gpio_read", port, pin, *value, k_rx_ok);
+  m->gpio_read_count++;
+
+  /* Auto-advance time if enabled */
+  if (m->auto_advance_time) {
+    m->current_time_us += m->time_step_us;
+  }
+
+  return k_rx_ok;
+}
+
+rx_err_t
+mock_gpio_deinit(uint8_t port, uint8_t pin)
+{
+  internal_record_call(NULL, "gpio_deinit", port, pin, false, k_rx_ok);
+  return k_rx_ok;
+}
+
+/* =============================================================================
+ * Mock Timing Functions
+ * =============================================================================
+ */
+
+void
+mock_delay_us(uint32_t us)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(NULL);
+  m->current_time_us += us;
+  m->total_delay_us += us;
+}
+
+uint32_t
+mock_get_time_us(void)
+{
+  mock_hcsr04_hw_t* m = internal_get_mock(NULL);
+  return m->current_time_us;
+}

--- a/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.c
+++ b/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.c
@@ -2,8 +2,8 @@
  * @file mock_hcsr04_hw.c
  * @brief Mock HC-SR04 Hardware Layer Implementation
  *
- * STAR Project - Texas A&M University
- * January 2026
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
  */
 
 #include "mock_hcsr04_hw.h"

--- a/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.h
+++ b/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.h
@@ -1,0 +1,358 @@
+/**
+ * @file mock_hcsr04_hw.h
+ * @brief Mock HC-SR04 Hardware Layer for Host-Side Testing
+ *
+ * Mock implementation of GPIO and timing for HC-SR04 driver testing.
+ * Provides call tracking, echo timing simulation, and error injection.
+ *
+ * Features:
+ * - Simulates GPIO trigger/echo pin behavior
+ * - Configurable echo pulse timing for distance simulation
+ * - Call tracking to verify trigger pulse generation
+ * - Error injection for timeout and range error testing
+ * - No actual hardware access (runs on host)
+ *
+ * STAR Project - Texas A&M University
+ * January 2026
+ */
+
+#ifndef MOCK_HCSR04_HW_H
+#define MOCK_HCSR04_HW_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "rx_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Configuration Constants
+ * =============================================================================
+ */
+
+/**
+ * @brief Mock configuration constants
+ */
+typedef enum {
+  k_mock_hcsr04_max_calls      = 64, /**< Maximum call records to track */
+  k_mock_hcsr04_func_name_max  = 32, /**< Max function name length */
+  k_mock_hcsr04_max_pins       = 8,  /**< Max pins per sensor tracked */
+} mock_hcsr04_constants_t;
+
+/* =============================================================================
+ * Call Record Structure
+ * =============================================================================
+ */
+
+/**
+ * @brief Record of a single function call
+ */
+typedef struct {
+  char     function[k_mock_hcsr04_func_name_max]; /**< Function name */
+  uint8_t  port;                                  /**< Port argument */
+  uint8_t  pin;                                   /**< Pin argument */
+  bool     value;                                 /**< Value (for write/read) */
+  rx_err_t return_value;                          /**< Return value */
+} mock_hcsr04_call_t;
+
+/* =============================================================================
+ * Mock Hardware State
+ * =============================================================================
+ */
+
+/**
+ * @brief Mock HC-SR04 hardware state structure
+ */
+typedef struct {
+  /* Initialization state */
+  bool initialized; /**< Mock is initialized */
+
+  /* GPIO simulation */
+  bool trigger_pin_state; /**< Current trigger output level */
+  bool echo_pin_state;    /**< Current echo input level (simulated) */
+
+  /* Echo timing simulation */
+  uint32_t simulated_echo_us; /**< Echo pulse width to simulate (us) */
+  uint32_t current_time_us;   /**< Simulated current time (us) */
+  bool     auto_advance_time; /**< Auto-advance time on timing calls */
+  uint32_t time_step_us;      /**< Time step per auto-advance */
+
+  /* Error injection */
+  bool inject_timeout;       /**< Simulate timeout (no echo) */
+  bool inject_gpio_error;    /**< Simulate GPIO init failure */
+  bool inject_pin_conflict;  /**< Simulate pin already reserved */
+
+  /* Call tracking */
+  mock_hcsr04_call_t call_history[k_mock_hcsr04_max_calls]; /**< Call log */
+  uint32_t           call_count;  /**< Number of calls recorded */
+
+  /* Call counts by function */
+  uint32_t trigger_pulse_count;   /**< Number of trigger pulses sent */
+  uint32_t gpio_set_output_count; /**< gpio_set_output calls */
+  uint32_t gpio_set_input_count;  /**< gpio_set_input calls */
+  uint32_t gpio_write_high_count; /**< gpio_write_high calls */
+  uint32_t gpio_write_low_count;  /**< gpio_write_low calls */
+  uint32_t gpio_read_count;       /**< gpio_read calls */
+
+  /* Statistics */
+  uint32_t total_delay_us; /**< Total simulated delay */
+
+} mock_hcsr04_hw_t;
+
+/* =============================================================================
+ * Global Mock Instance
+ * =============================================================================
+ */
+
+/**
+ * @brief Global mock instance for simple usage
+ *
+ * Use mock_hcsr04_hw_init(NULL) to initialize global instance.
+ */
+extern mock_hcsr04_hw_t g_mock_hcsr04_hw;
+
+/* =============================================================================
+ * Mock Control Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Initialize mock hardware state
+ *
+ * @param[in] mock Mock instance (NULL = use global)
+ */
+void mock_hcsr04_hw_init(mock_hcsr04_hw_t* mock);
+
+/**
+ * @brief Deinitialize mock hardware state
+ *
+ * @param[in] mock Mock instance (NULL = use global)
+ */
+void mock_hcsr04_hw_deinit(mock_hcsr04_hw_t* mock);
+
+/**
+ * @brief Reset mock state without full reinit
+ *
+ * Clears call history and statistics, keeps error injection settings.
+ *
+ * @param[in] mock Mock instance (NULL = use global)
+ */
+void mock_hcsr04_hw_reset(mock_hcsr04_hw_t* mock);
+
+/* =============================================================================
+ * Echo Simulation Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Set simulated echo time for distance testing
+ *
+ * @param[in] mock    Mock instance (NULL = use global)
+ * @param[in] echo_us Echo pulse duration in microseconds
+ */
+void mock_hcsr04_hw_set_echo_time(mock_hcsr04_hw_t* mock, uint32_t echo_us);
+
+/**
+ * @brief Set simulated distance (converts to echo time)
+ *
+ * @param[in] mock        Mock instance (NULL = use global)
+ * @param[in] distance_cm Distance in centimeters
+ */
+void mock_hcsr04_hw_set_distance(mock_hcsr04_hw_t* mock, float distance_cm);
+
+/**
+ * @brief Set timeout injection
+ *
+ * When enabled, simulated echo never goes high (object out of range).
+ *
+ * @param[in] mock    Mock instance (NULL = use global)
+ * @param[in] timeout True to inject timeout
+ */
+void mock_hcsr04_hw_set_timeout(mock_hcsr04_hw_t* mock, bool timeout);
+
+/* =============================================================================
+ * Error Injection Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Set GPIO error injection
+ *
+ * @param[in] mock  Mock instance (NULL = use global)
+ * @param[in] error True to inject GPIO init failure
+ */
+void mock_hcsr04_hw_set_gpio_error(mock_hcsr04_hw_t* mock, bool error);
+
+/**
+ * @brief Set pin conflict injection
+ *
+ * @param[in] mock     Mock instance (NULL = use global)
+ * @param[in] conflict True to inject pin already reserved error
+ */
+void mock_hcsr04_hw_set_pin_conflict(mock_hcsr04_hw_t* mock, bool conflict);
+
+/* =============================================================================
+ * Timing Simulation Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Set current simulated time
+ *
+ * @param[in] mock    Mock instance (NULL = use global)
+ * @param[in] time_us Current time in microseconds
+ */
+void mock_hcsr04_hw_set_time(mock_hcsr04_hw_t* mock, uint32_t time_us);
+
+/**
+ * @brief Advance simulated time
+ *
+ * @param[in] mock    Mock instance (NULL = use global)
+ * @param[in] delta_us Time to advance in microseconds
+ */
+void mock_hcsr04_hw_advance_time(mock_hcsr04_hw_t* mock, uint32_t delta_us);
+
+/**
+ * @brief Enable auto-advance mode
+ *
+ * When enabled, time automatically advances on timing-related calls.
+ *
+ * @param[in] mock          Mock instance (NULL = use global)
+ * @param[in] enable        True to enable auto-advance
+ * @param[in] step_us       Time step per call (e.g., 1us)
+ */
+void mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock,
+                                     bool              enable,
+                                     uint32_t          step_us);
+
+/* =============================================================================
+ * Call Tracking Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Check if a function was called
+ *
+ * @param[in] mock          Mock instance (NULL = use global)
+ * @param[in] function_name Function name to check
+ *
+ * @return true if function was called
+ */
+bool mock_hcsr04_hw_was_called(mock_hcsr04_hw_t* mock, const char* function_name);
+
+/**
+ * @brief Get call count for a function
+ *
+ * @param[in] mock          Mock instance (NULL = use global)
+ * @param[in] function_name Function name to check
+ *
+ * @return Number of times function was called
+ */
+uint32_t mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock,
+                                       const char*       function_name);
+
+/**
+ * @brief Get number of trigger pulses sent
+ *
+ * A trigger pulse is detected as gpio_write_high followed by gpio_write_low
+ * on the trigger pin.
+ *
+ * @param[in] mock Mock instance (NULL = use global)
+ *
+ * @return Number of trigger pulses detected
+ */
+uint32_t mock_hcsr04_hw_get_trigger_count(mock_hcsr04_hw_t* mock);
+
+/* =============================================================================
+ * Mock GPIO Functions (replace real implementations in tests)
+ * =============================================================================
+ */
+
+/**
+ * @brief Mock gpio_set_output
+ *
+ * @param[in] port Port number
+ * @param[in] pin  Pin number
+ *
+ * @return k_rx_ok or injected error
+ */
+rx_err_t mock_gpio_set_output(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Mock gpio_set_input
+ *
+ * @param[in] port Port number
+ * @param[in] pin  Pin number
+ *
+ * @return k_rx_ok or injected error
+ */
+rx_err_t mock_gpio_set_input(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Mock gpio_write_high
+ *
+ * @param[in] port Port number
+ * @param[in] pin  Pin number
+ *
+ * @return k_rx_ok or injected error
+ */
+rx_err_t mock_gpio_write_high(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Mock gpio_write_low
+ *
+ * @param[in] port Port number
+ * @param[in] pin  Pin number
+ *
+ * @return k_rx_ok or injected error
+ */
+rx_err_t mock_gpio_write_low(uint8_t port, uint8_t pin);
+
+/**
+ * @brief Mock gpio_read
+ *
+ * @param[in]  port  Port number
+ * @param[in]  pin   Pin number
+ * @param[out] value Pin value (simulated based on timing)
+ *
+ * @return k_rx_ok or injected error
+ */
+rx_err_t mock_gpio_read(uint8_t port, uint8_t pin, bool* value);
+
+/**
+ * @brief Mock gpio_deinit
+ *
+ * @param[in] port Port number
+ * @param[in] pin  Pin number
+ *
+ * @return k_rx_ok
+ */
+rx_err_t mock_gpio_deinit(uint8_t port, uint8_t pin);
+
+/* =============================================================================
+ * Mock Timing Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Mock microsecond delay
+ *
+ * @param[in] us Microseconds to delay
+ */
+void mock_delay_us(uint32_t us);
+
+/**
+ * @brief Mock get current time in microseconds
+ *
+ * @return Simulated current time
+ */
+uint32_t mock_get_time_us(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCK_HCSR04_HW_H */

--- a/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.h
+++ b/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.h
@@ -1,7 +1,10 @@
+/* tests/mocks/mock_hcsr04_hw.h */
+
 /**
  * @file mock_hcsr04_hw.h
  * @brief Mock HC-SR04 Hardware Layer for Host-Side Testing
  *
+ * @details
  * Mock implementation of GPIO and timing for HC-SR04 driver testing.
  * Provides call tracking, echo timing simulation, and error injection.
  *
@@ -12,7 +15,7 @@
  * - Error injection for timeout and range error testing
  * - No actual hardware access (runs on host)
  *
- * @date 2026-01-02
+ * @date 2026-01-04
  * @copyright Copyright (c) 2026 STAR Project
  */
 
@@ -37,9 +40,9 @@ extern "C" {
  * @brief Mock configuration constants
  */
 typedef enum {
-  k_mock_hcsr04_max_calls      = 64, /**< Maximum call records to track */
-  k_mock_hcsr04_func_name_max  = 32, /**< Max function name length */
-  k_mock_hcsr04_max_pins       = 8,  /**< Max pins per sensor tracked */
+  k_mock_hcsr04_max_calls     = 64, /**< Maximum call records to track */
+  k_mock_hcsr04_func_name_max = 32, /**< Max function name length */
+  k_mock_hcsr04_max_pins      = 8,  /**< Max pins per sensor tracked */
 } mock_hcsr04_constants_t;
 
 /* =============================================================================
@@ -81,13 +84,13 @@ typedef struct {
   uint32_t time_step_us;      /**< Time step per auto-advance */
 
   /* Error injection */
-  bool inject_timeout;       /**< Simulate timeout (no echo) */
-  bool inject_gpio_error;    /**< Simulate GPIO init failure */
-  bool inject_pin_conflict;  /**< Simulate pin already reserved */
+  bool inject_timeout;      /**< Simulate timeout (no echo) */
+  bool inject_gpio_error;   /**< Simulate GPIO init failure */
+  bool inject_pin_conflict; /**< Simulate pin already reserved */
 
   /* Call tracking */
   mock_hcsr04_call_t call_history[k_mock_hcsr04_max_calls]; /**< Call log */
-  uint32_t           call_count;  /**< Number of calls recorded */
+  uint32_t           call_count;                            /**< Number of calls recorded */
 
   /* Call counts by function */
   uint32_t trigger_pulse_count;   /**< Number of trigger pulses sent */
@@ -224,9 +227,7 @@ void mock_hcsr04_hw_advance_time(mock_hcsr04_hw_t* mock, uint32_t delta_us);
  * @param[in] enable        True to enable auto-advance
  * @param[in] step_us       Time step per call (e.g., 1us)
  */
-void mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock,
-                                     bool              enable,
-                                     uint32_t          step_us);
+void mock_hcsr04_hw_set_auto_advance(mock_hcsr04_hw_t* mock, bool enable, uint32_t step_us);
 
 /* =============================================================================
  * Call Tracking Functions
@@ -251,8 +252,7 @@ bool mock_hcsr04_hw_was_called(mock_hcsr04_hw_t* mock, const char* function_name
  *
  * @return Number of times function was called
  */
-uint32_t mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock,
-                                       const char*       function_name);
+uint32_t mock_hcsr04_hw_get_call_count(mock_hcsr04_hw_t* mock, const char* function_name);
 
 /**
  * @brief Get number of trigger pulses sent

--- a/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.h
+++ b/star-rx72n-firmware/tests/mocks/mock_hcsr04_hw.h
@@ -12,8 +12,8 @@
  * - Error injection for timeout and range error testing
  * - No actual hardware access (runs on host)
  *
- * STAR Project - Texas A&M University
- * January 2026
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
  */
 
 #ifndef MOCK_HCSR04_HW_H

--- a/star-rx72n-firmware/tests/test_rx_hcsr04.c
+++ b/star-rx72n-firmware/tests/test_rx_hcsr04.c
@@ -1,20 +1,32 @@
+/* tests/test_rx_hcsr04.c */
+
 /**
  * @file test_rx_hcsr04.c
  * @brief Unit Tests for HC-SR04 Ultrasonic Distance Sensor Driver
  *
- * Tests the HC-SR04 driver using mock GPIO and timing functions.
- * All tests run on the host (not on RX72N hardware).
+ * @details
+ * Comprehensive unit tests for the HC-SR04 ultrasonic distance sensor driver.
+ * Tests use mock GPIO and timing functions to simulate hardware behavior on the
+ * host without requiring actual RX72N hardware or HC-SR04 sensors.
+ *
+ * Test Coverage:
+ * - Initialization and deinitialization
+ * - Distance measurements (blocking and async)
+ * - Timeout handling
+ * - Range validation (too close/too far)
+ * - Unit conversions (cm to inches, echo time to distance)
+ * - Statistics tracking
+ * - Error conditions
  *
  * @date 2026-01-02
  * @copyright Copyright (c) 2026 STAR Project
  */
 
-#include "unity.h"
-
 #include <string.h>
 
 #include "mock_hcsr04_hw.h"
 #include "rx_hcsr04.h"
+#include "unity.h"
 
 /* =============================================================================
  * Test Fixtures
@@ -27,8 +39,7 @@ static rx_hcsr04_config_t s_config;
 /**
  * @brief Setup function run before each test
  */
-void
-setUp(void)
+void setUp(void)
 {
   /* Initialize mock hardware */
   mock_hcsr04_hw_init(NULL);
@@ -47,8 +58,7 @@ setUp(void)
 /**
  * @brief Teardown function run after each test
  */
-void
-tearDown(void)
+void tearDown(void)
 {
   mock_hcsr04_hw_deinit(NULL);
 }
@@ -58,8 +68,7 @@ tearDown(void)
  * =============================================================================
  */
 
-void
-test_hcsr04_init_success(void)
+void test_hcsr04_init_success(void)
 {
   rx_err_t err = rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -71,22 +80,19 @@ test_hcsr04_init_success(void)
   TEST_ASSERT_EQUAL(s_config.echo_pin, s_sensor.echo_pin);
 }
 
-void
-test_hcsr04_init_null_handle_fails(void)
+void test_hcsr04_init_null_handle_fails(void)
 {
   rx_err_t err = rx_hcsr04_init(NULL, &s_config);
   TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
 }
 
-void
-test_hcsr04_init_null_config_fails(void)
+void test_hcsr04_init_null_config_fails(void)
 {
   rx_err_t err = rx_hcsr04_init(&s_sensor, NULL);
   TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
 }
 
-void
-test_hcsr04_init_configures_gpio(void)
+void test_hcsr04_init_configures_gpio(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -95,8 +101,7 @@ test_hcsr04_init_configures_gpio(void)
   TEST_ASSERT_TRUE(mock_hcsr04_hw_was_called(NULL, "gpio_set_input"));
 }
 
-void
-test_hcsr04_init_gpio_error_fails(void)
+void test_hcsr04_init_gpio_error_fails(void)
 {
   mock_hcsr04_hw_set_gpio_error(NULL, true);
 
@@ -106,8 +111,7 @@ test_hcsr04_init_gpio_error_fails(void)
   TEST_ASSERT_FALSE(s_sensor.initialized);
 }
 
-void
-test_hcsr04_init_pin_conflict_fails(void)
+void test_hcsr04_init_pin_conflict_fails(void)
 {
   mock_hcsr04_hw_set_pin_conflict(NULL, true);
 
@@ -117,8 +121,7 @@ test_hcsr04_init_pin_conflict_fails(void)
   TEST_ASSERT_FALSE(s_sensor.initialized);
 }
 
-void
-test_hcsr04_init_twice_fails(void)
+void test_hcsr04_init_twice_fails(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -132,8 +135,7 @@ test_hcsr04_init_twice_fails(void)
  * =============================================================================
  */
 
-void
-test_hcsr04_deinit_success(void)
+void test_hcsr04_deinit_success(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -143,15 +145,13 @@ test_hcsr04_deinit_success(void)
   TEST_ASSERT_FALSE(s_sensor.initialized);
 }
 
-void
-test_hcsr04_deinit_null_fails(void)
+void test_hcsr04_deinit_null_fails(void)
 {
   rx_err_t err = rx_hcsr04_deinit(NULL);
   TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
 }
 
-void
-test_hcsr04_deinit_not_initialized_fails(void)
+void test_hcsr04_deinit_not_initialized_fails(void)
 {
   rx_err_t err = rx_hcsr04_deinit(&s_sensor);
   TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
@@ -162,8 +162,7 @@ test_hcsr04_deinit_not_initialized_fails(void)
  * =============================================================================
  */
 
-void
-test_hcsr04_measure_10cm(void)
+void test_hcsr04_measure_10cm(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -178,8 +177,7 @@ test_hcsr04_measure_10cm(void)
   TEST_ASSERT_FLOAT_WITHIN(1.0f, 10.0f, distance_cm);
 }
 
-void
-test_hcsr04_measure_100cm(void)
+void test_hcsr04_measure_100cm(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -193,8 +191,7 @@ test_hcsr04_measure_100cm(void)
   TEST_ASSERT_FLOAT_WITHIN(3.0f, 100.0f, distance_cm);
 }
 
-void
-test_hcsr04_measure_max_range_400cm(void)
+void test_hcsr04_measure_max_range_400cm(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -208,8 +205,7 @@ test_hcsr04_measure_max_range_400cm(void)
   TEST_ASSERT_FLOAT_WITHIN(10.0f, 400.0f, distance_cm);
 }
 
-void
-test_hcsr04_measure_timeout(void)
+void test_hcsr04_measure_timeout(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -222,16 +218,14 @@ test_hcsr04_measure_timeout(void)
   TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
 }
 
-void
-test_hcsr04_measure_null_handle_fails(void)
+void test_hcsr04_measure_null_handle_fails(void)
 {
   float    distance_cm;
   rx_err_t err = rx_hcsr04_measure_blocking(NULL, &distance_cm);
   TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
 }
 
-void
-test_hcsr04_measure_null_output_fails(void)
+void test_hcsr04_measure_null_output_fails(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -239,16 +233,14 @@ test_hcsr04_measure_null_output_fails(void)
   TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
 }
 
-void
-test_hcsr04_measure_not_initialized_fails(void)
+void test_hcsr04_measure_not_initialized_fails(void)
 {
   float    distance_cm;
   rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
   TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
 }
 
-void
-test_hcsr04_measure_sends_trigger_pulse(void)
+void test_hcsr04_measure_sends_trigger_pulse(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -266,8 +258,7 @@ test_hcsr04_measure_sends_trigger_pulse(void)
  * =============================================================================
  */
 
-void
-test_hcsr04_measure_full_result(void)
+void test_hcsr04_measure_full_result(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -288,8 +279,7 @@ test_hcsr04_measure_full_result(void)
  * =============================================================================
  */
 
-void
-test_hcsr04_cm_to_inches(void)
+void test_hcsr04_cm_to_inches(void)
 {
   float inches = rx_hcsr04_cm_to_inches(2.54f);
   TEST_ASSERT_FLOAT_WITHIN(0.01f, 1.0f, inches);
@@ -298,8 +288,7 @@ test_hcsr04_cm_to_inches(void)
   TEST_ASSERT_FLOAT_WITHIN(0.1f, 39.37f, inches);
 }
 
-void
-test_hcsr04_echo_to_cm(void)
+void test_hcsr04_echo_to_cm(void)
 {
   /* 58us per cm */
   float cm = rx_hcsr04_echo_to_cm(580);
@@ -314,14 +303,12 @@ test_hcsr04_echo_to_cm(void)
  * =============================================================================
  */
 
-void
-test_hcsr04_stats_initial_zero(void)
+void test_hcsr04_stats_initial_zero(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
   uint32_t measurements, timeouts, range_errors;
-  rx_err_t err =
-    rx_hcsr04_get_stats(&s_sensor, &measurements, &timeouts, &range_errors);
+  rx_err_t err = rx_hcsr04_get_stats(&s_sensor, &measurements, &timeouts, &range_errors);
 
   TEST_ASSERT_EQUAL(k_rx_ok, err);
   TEST_ASSERT_EQUAL_UINT32(0, measurements);
@@ -329,8 +316,7 @@ test_hcsr04_stats_initial_zero(void)
   TEST_ASSERT_EQUAL_UINT32(0, range_errors);
 }
 
-void
-test_hcsr04_stats_increment_on_measurement(void)
+void test_hcsr04_stats_increment_on_measurement(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -346,8 +332,7 @@ test_hcsr04_stats_increment_on_measurement(void)
   TEST_ASSERT_EQUAL_UINT32(1, measurements);
 }
 
-void
-test_hcsr04_stats_increment_timeout(void)
+void test_hcsr04_stats_increment_timeout(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -363,8 +348,7 @@ test_hcsr04_stats_increment_timeout(void)
   TEST_ASSERT_EQUAL_UINT32(1, timeouts);
 }
 
-void
-test_hcsr04_stats_reset(void)
+void test_hcsr04_stats_reset(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -382,8 +366,7 @@ test_hcsr04_stats_reset(void)
   TEST_ASSERT_EQUAL_UINT32(0, measurements);
 }
 
-void
-test_hcsr04_measure_out_of_range_too_close(void)
+void test_hcsr04_measure_out_of_range_too_close(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
 
@@ -415,8 +398,7 @@ test_async_callback(rx_hcsr04_t* handle, const rx_hcsr04_result_t* result, void*
   s_async_callback_result  = *result;
 }
 
-void
-test_hcsr04_measure_async_callback_invoked(void)
+void test_hcsr04_measure_async_callback_invoked(void)
 {
   s_async_callback_invoked = false;
   rx_hcsr04_init(&s_sensor, &s_config);
@@ -433,15 +415,13 @@ test_hcsr04_measure_async_callback_invoked(void)
   TEST_ASSERT_EQUAL(k_rx_ok, s_async_callback_result.status);
 }
 
-void
-test_hcsr04_is_busy_initial_false(void)
+void test_hcsr04_is_busy_initial_false(void)
 {
   rx_hcsr04_init(&s_sensor, &s_config);
   TEST_ASSERT_FALSE(rx_hcsr04_is_busy(&s_sensor));
 }
 
-void
-test_hcsr04_is_busy_null_returns_false(void)
+void test_hcsr04_is_busy_null_returns_false(void)
 {
   TEST_ASSERT_FALSE(rx_hcsr04_is_busy(NULL));
 }
@@ -451,8 +431,7 @@ test_hcsr04_is_busy_null_returns_false(void)
  * =============================================================================
  */
 
-int
-main(void)
+int main(void)
 {
   UNITY_BEGIN();
 

--- a/star-rx72n-firmware/tests/test_rx_hcsr04.c
+++ b/star-rx72n-firmware/tests/test_rx_hcsr04.c
@@ -1,0 +1,455 @@
+/**
+ * @file test_rx_hcsr04.c
+ * @brief Unit Tests for HC-SR04 Ultrasonic Distance Sensor Driver
+ *
+ * Tests the HC-SR04 driver using mock GPIO and timing functions.
+ * All tests run on the host (not on RX72N hardware).
+ *
+ * STAR Project - Texas A&M University
+ * January 2026
+ */
+
+#include "unity.h"
+
+#include <string.h>
+
+#include "mock_hcsr04_hw.h"
+#include "rx_hcsr04.h"
+
+/* =============================================================================
+ * Test Fixtures
+ * =============================================================================
+ */
+
+static rx_hcsr04_t        s_sensor;
+static rx_hcsr04_config_t s_config;
+
+/**
+ * @brief Setup function run before each test
+ */
+void
+setUp(void)
+{
+  /* Initialize mock hardware */
+  mock_hcsr04_hw_init(NULL);
+
+  /* Reset sensor handle */
+  memset(&s_sensor, 0, sizeof(s_sensor));
+
+  /* Setup default config for sensor 1 (J24) */
+  s_config.trigger_port = 0xC;
+  s_config.trigger_pin  = 6;
+  s_config.echo_port    = 0x5;
+  s_config.echo_pin     = 5;
+  s_config.timeout_us   = 30000;
+}
+
+/**
+ * @brief Teardown function run after each test
+ */
+void
+tearDown(void)
+{
+  mock_hcsr04_hw_deinit(NULL);
+}
+
+/* =============================================================================
+ * Initialization Tests
+ * =============================================================================
+ */
+
+void
+test_hcsr04_init_success(void)
+{
+  rx_err_t err = rx_hcsr04_init(&s_sensor, &s_config);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_TRUE(s_sensor.initialized);
+  TEST_ASSERT_EQUAL(s_config.trigger_port, s_sensor.trigger_port);
+  TEST_ASSERT_EQUAL(s_config.trigger_pin, s_sensor.trigger_pin);
+  TEST_ASSERT_EQUAL(s_config.echo_port, s_sensor.echo_port);
+  TEST_ASSERT_EQUAL(s_config.echo_pin, s_sensor.echo_pin);
+}
+
+void
+test_hcsr04_init_null_handle_fails(void)
+{
+  rx_err_t err = rx_hcsr04_init(NULL, &s_config);
+  TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
+}
+
+void
+test_hcsr04_init_null_config_fails(void)
+{
+  rx_err_t err = rx_hcsr04_init(&s_sensor, NULL);
+  TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
+}
+
+void
+test_hcsr04_init_configures_gpio(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  /* Verify GPIO calls were made */
+  TEST_ASSERT_TRUE(mock_hcsr04_hw_was_called(NULL, "gpio_set_output"));
+  TEST_ASSERT_TRUE(mock_hcsr04_hw_was_called(NULL, "gpio_set_input"));
+}
+
+void
+test_hcsr04_init_gpio_error_fails(void)
+{
+  mock_hcsr04_hw_set_gpio_error(NULL, true);
+
+  rx_err_t err = rx_hcsr04_init(&s_sensor, &s_config);
+
+  TEST_ASSERT_EQUAL(k_rx_err_hw_init_failed, err);
+  TEST_ASSERT_FALSE(s_sensor.initialized);
+}
+
+void
+test_hcsr04_init_pin_conflict_fails(void)
+{
+  mock_hcsr04_hw_set_pin_conflict(NULL, true);
+
+  rx_err_t err = rx_hcsr04_init(&s_sensor, &s_config);
+
+  TEST_ASSERT_EQUAL(k_rx_err_gpio_conflict, err);
+  TEST_ASSERT_FALSE(s_sensor.initialized);
+}
+
+void
+test_hcsr04_init_twice_fails(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  rx_err_t err = rx_hcsr04_init(&s_sensor, &s_config);
+
+  TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+/* =============================================================================
+ * Deinitialization Tests
+ * =============================================================================
+ */
+
+void
+test_hcsr04_deinit_success(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  rx_err_t err = rx_hcsr04_deinit(&s_sensor);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_FALSE(s_sensor.initialized);
+}
+
+void
+test_hcsr04_deinit_null_fails(void)
+{
+  rx_err_t err = rx_hcsr04_deinit(NULL);
+  TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
+}
+
+void
+test_hcsr04_deinit_not_initialized_fails(void)
+{
+  rx_err_t err = rx_hcsr04_deinit(&s_sensor);
+  TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+/* =============================================================================
+ * Blocking Measurement Tests
+ * =============================================================================
+ */
+
+void
+test_hcsr04_measure_10cm(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  /* Set simulated distance to 10cm */
+  mock_hcsr04_hw_set_distance(NULL, 10.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float    distance_cm;
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_FLOAT_WITHIN(1.0f, 10.0f, distance_cm);
+}
+
+void
+test_hcsr04_measure_100cm(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_distance(NULL, 100.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float    distance_cm;
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_FLOAT_WITHIN(3.0f, 100.0f, distance_cm);
+}
+
+void
+test_hcsr04_measure_max_range_400cm(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_distance(NULL, 400.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float    distance_cm;
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_FLOAT_WITHIN(10.0f, 400.0f, distance_cm);
+}
+
+void
+test_hcsr04_measure_timeout(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_timeout(NULL, true);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 100);
+
+  float    distance_cm;
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
+}
+
+void
+test_hcsr04_measure_null_handle_fails(void)
+{
+  float    distance_cm;
+  rx_err_t err = rx_hcsr04_measure_blocking(NULL, &distance_cm);
+  TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
+}
+
+void
+test_hcsr04_measure_null_output_fails(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, NULL);
+  TEST_ASSERT_EQUAL(k_rx_err_null_pointer, err);
+}
+
+void
+test_hcsr04_measure_not_initialized_fails(void)
+{
+  float    distance_cm;
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+  TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+void
+test_hcsr04_measure_sends_trigger_pulse(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_distance(NULL, 50.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float distance_cm;
+  rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  TEST_ASSERT_EQUAL_UINT32(1, mock_hcsr04_hw_get_trigger_count(NULL));
+}
+
+/* =============================================================================
+ * Full Result Measurement Tests
+ * =============================================================================
+ */
+
+void
+test_hcsr04_measure_full_result(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_distance(NULL, 50.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  rx_hcsr04_result_t result;
+  rx_err_t           err = rx_hcsr04_measure(&s_sensor, &result);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_FLOAT_WITHIN(3.0f, 50.0f, result.distance_cm);
+  TEST_ASSERT_FLOAT_WITHIN(1.0f, 19.7f, result.distance_in); /* 50cm / 2.54 */
+  TEST_ASSERT_EQUAL(k_rx_ok, result.status);
+}
+
+/* =============================================================================
+ * Conversion Tests
+ * =============================================================================
+ */
+
+void
+test_hcsr04_cm_to_inches(void)
+{
+  float inches = rx_hcsr04_cm_to_inches(2.54f);
+  TEST_ASSERT_FLOAT_WITHIN(0.01f, 1.0f, inches);
+
+  inches = rx_hcsr04_cm_to_inches(100.0f);
+  TEST_ASSERT_FLOAT_WITHIN(0.1f, 39.37f, inches);
+}
+
+void
+test_hcsr04_echo_to_cm(void)
+{
+  /* 58us per cm */
+  float cm = rx_hcsr04_echo_to_cm(580);
+  TEST_ASSERT_FLOAT_WITHIN(0.5f, 10.0f, cm);
+
+  cm = rx_hcsr04_echo_to_cm(5800);
+  TEST_ASSERT_FLOAT_WITHIN(1.0f, 100.0f, cm);
+}
+
+/* =============================================================================
+ * Statistics Tests
+ * =============================================================================
+ */
+
+void
+test_hcsr04_stats_initial_zero(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  uint32_t measurements, timeouts, range_errors;
+  rx_err_t err =
+    rx_hcsr04_get_stats(&s_sensor, &measurements, &timeouts, &range_errors);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_EQUAL_UINT32(0, measurements);
+  TEST_ASSERT_EQUAL_UINT32(0, timeouts);
+  TEST_ASSERT_EQUAL_UINT32(0, range_errors);
+}
+
+void
+test_hcsr04_stats_increment_on_measurement(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_distance(NULL, 50.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float distance_cm;
+  rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  uint32_t measurements;
+  rx_hcsr04_get_stats(&s_sensor, &measurements, NULL, NULL);
+
+  TEST_ASSERT_EQUAL_UINT32(1, measurements);
+}
+
+void
+test_hcsr04_stats_increment_timeout(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_timeout(NULL, true);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 100);
+
+  float distance_cm;
+  rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  uint32_t timeouts;
+  rx_hcsr04_get_stats(&s_sensor, NULL, &timeouts, NULL);
+
+  TEST_ASSERT_EQUAL_UINT32(1, timeouts);
+}
+
+void
+test_hcsr04_stats_reset(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  mock_hcsr04_hw_set_distance(NULL, 50.0f);
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float distance_cm;
+  rx_hcsr04_measure_blocking(&s_sensor, &distance_cm);
+
+  rx_hcsr04_reset_stats(&s_sensor);
+
+  uint32_t measurements;
+  rx_hcsr04_get_stats(&s_sensor, &measurements, NULL, NULL);
+
+  TEST_ASSERT_EQUAL_UINT32(0, measurements);
+}
+
+/* =============================================================================
+ * Async API Tests (Basic)
+ * =============================================================================
+ */
+
+void
+test_hcsr04_is_busy_initial_false(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+  TEST_ASSERT_FALSE(rx_hcsr04_is_busy(&s_sensor));
+}
+
+void
+test_hcsr04_is_busy_null_returns_false(void)
+{
+  TEST_ASSERT_FALSE(rx_hcsr04_is_busy(NULL));
+}
+
+/* =============================================================================
+ * Main Test Runner
+ * =============================================================================
+ */
+
+int
+main(void)
+{
+  UNITY_BEGIN();
+
+  /* Initialization tests */
+  RUN_TEST(test_hcsr04_init_success);
+  RUN_TEST(test_hcsr04_init_null_handle_fails);
+  RUN_TEST(test_hcsr04_init_null_config_fails);
+  RUN_TEST(test_hcsr04_init_configures_gpio);
+  RUN_TEST(test_hcsr04_init_gpio_error_fails);
+  RUN_TEST(test_hcsr04_init_pin_conflict_fails);
+  RUN_TEST(test_hcsr04_init_twice_fails);
+
+  /* Deinitialization tests */
+  RUN_TEST(test_hcsr04_deinit_success);
+  RUN_TEST(test_hcsr04_deinit_null_fails);
+  RUN_TEST(test_hcsr04_deinit_not_initialized_fails);
+
+  /* Blocking measurement tests */
+  RUN_TEST(test_hcsr04_measure_10cm);
+  RUN_TEST(test_hcsr04_measure_100cm);
+  RUN_TEST(test_hcsr04_measure_max_range_400cm);
+  RUN_TEST(test_hcsr04_measure_timeout);
+  RUN_TEST(test_hcsr04_measure_null_handle_fails);
+  RUN_TEST(test_hcsr04_measure_null_output_fails);
+  RUN_TEST(test_hcsr04_measure_not_initialized_fails);
+  RUN_TEST(test_hcsr04_measure_sends_trigger_pulse);
+
+  /* Full result measurement tests */
+  RUN_TEST(test_hcsr04_measure_full_result);
+
+  /* Conversion tests */
+  RUN_TEST(test_hcsr04_cm_to_inches);
+  RUN_TEST(test_hcsr04_echo_to_cm);
+
+  /* Statistics tests */
+  RUN_TEST(test_hcsr04_stats_initial_zero);
+  RUN_TEST(test_hcsr04_stats_increment_on_measurement);
+  RUN_TEST(test_hcsr04_stats_increment_timeout);
+  RUN_TEST(test_hcsr04_stats_reset);
+
+  /* Async API tests */
+  RUN_TEST(test_hcsr04_is_busy_initial_false);
+  RUN_TEST(test_hcsr04_is_busy_null_returns_false);
+
+  return UNITY_END();
+}

--- a/star-rx72n-firmware/tests/test_rx_hcsr04.c
+++ b/star-rx72n-firmware/tests/test_rx_hcsr04.c
@@ -382,10 +382,56 @@ test_hcsr04_stats_reset(void)
   TEST_ASSERT_EQUAL_UINT32(0, measurements);
 }
 
+void
+test_hcsr04_measure_out_of_range_too_close(void)
+{
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  /* Simulate 1cm echo (too close, <2cm minimum) */
+  mock_hcsr04_hw_set_echo_time(NULL, 58); /* 58us = 1cm */
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  float    distance;
+  rx_err_t err = rx_hcsr04_measure_blocking(&s_sensor, &distance);
+
+  TEST_ASSERT_EQUAL(k_rx_err_out_of_range, err);
+}
+
 /* =============================================================================
- * Async API Tests (Basic)
+ * Async API Tests
  * =============================================================================
  */
+
+/* Callback tracking for async tests */
+static bool               s_async_callback_invoked = false;
+static rx_hcsr04_result_t s_async_callback_result;
+
+static void
+test_async_callback(rx_hcsr04_t* handle, const rx_hcsr04_result_t* result, void* user_data)
+{
+  (void)handle;
+  (void)user_data;
+  s_async_callback_invoked = true;
+  s_async_callback_result  = *result;
+}
+
+void
+test_hcsr04_measure_async_callback_invoked(void)
+{
+  s_async_callback_invoked = false;
+  rx_hcsr04_init(&s_sensor, &s_config);
+
+  /* Simulate 100cm echo */
+  mock_hcsr04_hw_set_echo_time(NULL, 5800); /* 5800us = 100cm */
+  mock_hcsr04_hw_set_auto_advance(NULL, true, 10);
+
+  rx_err_t err = rx_hcsr04_measure_async(&s_sensor, test_async_callback, NULL);
+
+  TEST_ASSERT_EQUAL(k_rx_ok, err);
+  TEST_ASSERT_TRUE(s_async_callback_invoked);
+  TEST_ASSERT_FLOAT_WITHIN(1.0f, 100.0f, s_async_callback_result.distance_cm);
+  TEST_ASSERT_EQUAL(k_rx_ok, s_async_callback_result.status);
+}
 
 void
 test_hcsr04_is_busy_initial_false(void)
@@ -429,6 +475,7 @@ main(void)
   RUN_TEST(test_hcsr04_measure_100cm);
   RUN_TEST(test_hcsr04_measure_max_range_400cm);
   RUN_TEST(test_hcsr04_measure_timeout);
+  RUN_TEST(test_hcsr04_measure_out_of_range_too_close);
   RUN_TEST(test_hcsr04_measure_null_handle_fails);
   RUN_TEST(test_hcsr04_measure_null_output_fails);
   RUN_TEST(test_hcsr04_measure_not_initialized_fails);
@@ -448,6 +495,7 @@ main(void)
   RUN_TEST(test_hcsr04_stats_reset);
 
   /* Async API tests */
+  RUN_TEST(test_hcsr04_measure_async_callback_invoked);
   RUN_TEST(test_hcsr04_is_busy_initial_false);
   RUN_TEST(test_hcsr04_is_busy_null_returns_false);
 

--- a/star-rx72n-firmware/tests/test_rx_hcsr04.c
+++ b/star-rx72n-firmware/tests/test_rx_hcsr04.c
@@ -5,8 +5,8 @@
  * Tests the HC-SR04 driver using mock GPIO and timing functions.
  * All tests run on the host (not on RX72N hardware).
  *
- * STAR Project - Texas A&M University
- * January 2026
+ * @date 2026-01-02
+ * @copyright Copyright (c) 2026 STAR Project
  */
 
 #include "unity.h"


### PR DESCRIPTION
## Summary

Implements HC-SR04 ultrasonic distance sensor driver for the RX72N firmware.

- **Generic driver library** (`lib/rx_hcsr04/`) supporting any GPIO pin configuration
- **Board-specific config** (`include/star_hcsr04_config.h`) with J24-J27 sensor connector mappings
- **Blocking and async measurement APIs** with timeout handling
- **Distance conversion utilities** (cm, inches, raw echo time)
- **Measurement statistics tracking** (count, timeouts, range errors)
- **Hardware mock** for host-compiled unit tests (29 tests passing)

### API Highlights

```c
rx_err_t rx_hcsr04_init(rx_hcsr04_t* handle, const rx_hcsr04_config_t* config);
rx_err_t rx_hcsr04_measure_blocking(rx_hcsr04_t* handle, float* distance_cm);
rx_err_t rx_hcsr04_measure_async(rx_hcsr04_t* handle, rx_hcsr04_callback_t cb, void* user_data);
float rx_hcsr04_cm_to_inches(float distance_cm);
```

### Known Limitation

The async API (`rx_hcsr04_measure_async`) currently executes synchronously - the callback is invoked before the function returns. True non-blocking operation with ThreadX worker thread is documented as a future enhancement.

## Test Plan

- [x] All 29 HC-SR04 unit tests pass
- [x] All 8 test suites pass (100%)
- [x] Out-of-range detection tested (<2cm minimum)
- [x] Async callback invocation verified
- [x] Timeout handling verified

Closes #40