### PR TITLE
Add code review agent skill for NASA Power of 10 + SOLID compliance

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -72,12 +72,15 @@ Review rx_pid.c for NASA Power of 10 compliance
 ### Rule 8: Limit Preprocessor Use
 - [ ] **ALWAYS use `enum` for integer constants** (never `#define`)
 - [ ] Use `static const` ONLY for floating-point values (enum can't hold floats)
-- [ ] `#define` is ONLY acceptable for token operations (e.g., `ARRAY_SIZE`)
-- [ ] No token pasting (`##`) except where necessary
+- [ ] Macros ONLY allowed for: (1) reducing duplicated code, (2) conditional compilation, (3) hardware addresses, (4) build flags
+- [ ] **FORBIDDEN**: Macros for simple constants or backward compatibility (no releases = no compatibility needed)
+- [ ] No token pasting (`##`) except in allowed macro cases
 - [ ] No recursive macros
 - Good: `typedef enum { k_timeout_ms = 1000, k_max_retries = 3 } limits_t;`
+- Good: `#define RX_RETURN_ON_ERROR(err, tag, msg) /* multi-line validation */`
 - Bad: `#define TIMEOUT_MS 1000` (should be enum!)
 - Bad: `#define MAX_VELOCITY 2.5f` (should be static const float!)
+- Bad: `#define old_func new_func` (no backward compatibility - just update call sites!)
 
 ### Rule 9: Restrict Pointer Use
 - [ ] Maximum one level of dereferencing (exception: DIP interfaces)

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -74,10 +74,14 @@ Review rx_pid.c for NASA Power of 10 compliance
 - [ ] Use `static const` ONLY for floating-point values (enum can't hold floats)
 - [ ] Macros ONLY allowed for: (1) reducing duplicated code, (2) conditional compilation, (3) hardware addresses, (4) build flags
 - [ ] **FORBIDDEN**: Macros for simple constants or backward compatibility (no releases = no compatibility needed)
+- [ ] **NO MAGIC NUMBERS**: All numeric literals must be named enums (including array indices, bit shifts, offsets)
 - [ ] No token pasting (`##`) except in allowed macro cases
 - [ ] No recursive macros
 - Good: `typedef enum { k_timeout_ms = 1000, k_max_retries = 3 } limits_t;`
+- Good: `typedef enum { k_idx_high_byte = 0, k_idx_low_byte = 1 } be16_idx_t;`
+- Good: `typedef enum { k_shift_enable = 7, k_shift_mode = 3 } reg_shifts_t;`
 - Good: `#define RX_RETURN_ON_ERROR(err, tag, msg) /* multi-line validation */`
+- Bad: `buf[0] = (val >> 8);` (magic 0 and 8 - use enums!)
 - Bad: `#define TIMEOUT_MS 1000` (should be enum!)
 - Bad: `#define MAX_VELOCITY 2.5f` (should be static const float!)
 - Bad: `#define old_func new_func` (no backward compatibility - just update call sites!)

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -141,6 +141,15 @@ Review rx_pid.c for NASA Power of 10 compliance
 - [ ] Use COPI/CIPO (not MOSI/MISO)
 - [ ] Use Primary/Main (not master)
 
+### File Documentation
+- [ ] First line contains path comment: `/* path/to/file.ext */`
+- [ ] Doxygen header with required tags: `@file`, `@brief`, `@date`, `@copyright`
+- [ ] `@details` section for complex modules
+- [ ] `@code` example usage for public API headers
+- [ ] Date format: `YYYY-MM-DD`
+- [ ] Copyright: `Copyright (c) 2026 STAR Project`
+- [ ] No `@author` or `@version` tags (project policy)
+
 ## Report Format
 
 Generate a markdown report with:

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -52,7 +52,7 @@ Review rx_pid.c for NASA Power of 10 compliance
 - [ ] NULL pointer checks for all pointer parameters
 - [ ] Range validation for numeric inputs
 - [ ] State validation (e.g., `!handle->initialized`)
-- Patterns: `RX_CHECK_`, `assert(`, `if.*==.*NULL`
+- Patterns: `RX_CHECK_`, `assert(`, `if\s*\([^)]*==\s*NULL`
 
 ### Rule 6: Declare Data at Smallest Scope
 - [ ] Variables declared close to first use

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,0 +1,183 @@
+# Code Review Agent
+
+Performs automated code review for compliance with NASA Power of 10 rules and SOLID principles.
+
+## Usage
+
+Invoke with a directory path:
+```
+Review the code in star-rx72n-firmware/lib/rx_motor/
+```
+
+Or review specific files:
+```
+Review rx_pid.c for NASA Power of 10 compliance
+```
+
+## Review Process
+
+1. **Identify files** - Glob for `*.c` and `*.h` files in the specified directory
+2. **Read each file** - Analyze source code content
+3. **Apply NASA Power of 10 rules** - Check each rule from the checklist
+4. **Apply SOLID principles** - Validate architecture patterns
+5. **Generate report** - Produce structured markdown with findings
+
+## NASA Power of 10 Rules Checklist
+
+### Rule 1: Simplify Control Flow
+- [ ] No `goto` statements
+- [ ] No `setjmp`/`longjmp`
+- [ ] No recursion (direct or indirect)
+- Search patterns: `\bgoto\b`, `\bsetjmp\b`, `\blongjmp\b`
+
+### Rule 2: Fixed Loop Upper-Bounds
+- [ ] All loops have fixed iteration limits
+- [ ] No `while(1)` without bounded exit (except main loop)
+- [ ] Loop counters use explicit types (uint32_t, not size_t)
+- Red flags: `while\s*\(\s*1\s*\)`, `for\s*\(\s*;\s*;\s*\)`
+
+### Rule 3: No Dynamic Memory After Initialization
+- [ ] No `malloc`/`calloc`/`realloc`/`free` in runtime code
+- [ ] All buffers statically allocated
+- [ ] Fixed-size arrays with defined limits
+- Search patterns: `\bmalloc\b`, `\bcalloc\b`, `\brealloc\b`, `\bfree\b`
+
+### Rule 4: Keep Functions Short (~60 lines)
+- [ ] Functions do not exceed 60 lines (excluding comments/blank lines)
+- [ ] Each function has single responsibility
+- Count: `wc -l` on function bodies
+
+### Rule 5: Use Assertions/Validation
+- [ ] Minimum 2 validation checks per function
+- [ ] NULL pointer checks for all pointer parameters
+- [ ] Range validation for numeric inputs
+- [ ] State validation (e.g., `!handle->initialized`)
+- Patterns: `RX_CHECK_`, `assert(`, `if.*==.*NULL`
+
+### Rule 6: Declare Data at Smallest Scope
+- [ ] Variables declared close to first use
+- [ ] Loop variables declared in for statement
+- [ ] No file-scope variables without `static`
+
+### Rule 7: Check All Return Values
+- [ ] All function returns checked or explicitly cast to `(void)`
+- [ ] Error codes propagated appropriately
+- [ ] Use of `RX_RETURN_ON_ERROR` macro
+
+### Rule 8: Limit Preprocessor Use
+- [ ] Prefer `enum` over `#define` for constants
+- [ ] Prefer `static const` over `#define` for typed values
+- [ ] No token pasting (`##`) except where necessary
+- [ ] No recursive macros
+- Good: `typedef enum { k_state_idle = 0 } state_t;`
+- Bad: `#define STATE_IDLE 0`
+
+### Rule 9: Restrict Pointer Use
+- [ ] Maximum one level of dereferencing (exception: DIP interfaces)
+- [ ] Function pointers ONLY for Dependency Inversion Pattern
+- [ ] Document all function pointer interfaces
+
+### Rule 10: Compile with Maximum Warnings
+- [ ] Check CMakeLists.txt for `-Wall -Wextra -Werror`
+- [ ] No warning suppressions without justification
+
+## SOLID Principles Checklist
+
+### Single Responsibility (S)
+- [ ] Each file/module has one purpose
+- [ ] Functions do one thing well
+- [ ] Clear separation of concerns
+
+### Open/Closed (O)
+- [ ] Modules extensible without modification
+- [ ] Configuration via parameters, not code changes
+
+### Liskov Substitution (L)
+- [ ] Interface implementations are interchangeable
+- [ ] Mocks can substitute real implementations
+
+### Interface Segregation (I)
+- [ ] Small, focused interfaces
+- [ ] No "fat" interfaces with unused methods
+- [ ] Separate read/write interfaces where appropriate
+
+### Dependency Inversion (D)
+- [ ] High-level modules don't depend on low-level details
+- [ ] Use function pointer interfaces for hardware abstraction
+- [ ] Testable via mock injection
+- Pattern: `typedef struct { esp_err_t (*operation)(void* ctx, ...); void* ctx; } interface_t;`
+
+## C Style Guide Checklist
+
+### Naming Conventions
+- [ ] Functions/variables: `snake_case`
+- [ ] Macros/constants: `SCREAMING_SNAKE_CASE`
+- [ ] Types: `snake_case_t`
+- [ ] Static functions: `internal_` prefix
+- [ ] Private functions: `priv_` prefix
+- [ ] Static variables: `s_` prefix
+- [ ] Global variables: `g_` prefix (avoid globals)
+- [ ] Enum constants: `k_` prefix for values
+
+### Unit Suffixes (MKS System)
+- [ ] `_m` for meters
+- [ ] `_mps` for meters/second
+- [ ] `_rad` for radians
+- [ ] `_celsius` for temperature
+- [ ] `_ms` for milliseconds
+- [ ] `_us` for microseconds
+- [ ] `_ma` for milliamps
+- [ ] `_mv` for millivolts
+
+### Inclusive Terminology
+- [ ] Use Controller/Peripheral (not master/slave)
+- [ ] Use COPI/CIPO (not MOSI/MISO)
+- [ ] Use Primary/Main (not master)
+
+## Report Format
+
+Generate a markdown report with:
+
+```markdown
+# Code Review Report: [Directory/File]
+
+## Summary
+| Category | Status | Issues |
+|----------|--------|--------|
+| NASA Power of 10 | COMPLIANT/NON-COMPLIANT | N |
+| SOLID Principles | COMPLIANT/NON-COMPLIANT | N |
+| Style Guide | COMPLIANT/NON-COMPLIANT | N |
+
+## NASA Power of 10 Findings
+
+### Rule N: [Rule Name]
+**Status:** COMPLIANT / NON-COMPLIANT / INTENTIONAL DEVIATION
+
+**Findings:**
+- `file.c:123` - Description of issue
+- `file.c:456` - Description of issue
+
+**Recommendation:** How to fix
+
+## SOLID Principle Findings
+[Similar structure]
+
+## Style Guide Findings
+[Similar structure]
+
+## Positive Observations
+- What the code does well
+- Good patterns observed
+
+## Recommendations
+1. Priority fixes with code examples
+2. References to documentation
+```
+
+## Reference Documentation
+
+For detailed rule definitions, see:
+- `docs/sections/06_nasa_power_of_10.tex` - Complete NASA Power of 10 rules
+- `docs/sections/04_style_guide.tex` - Protocol Buffer and naming conventions
+- `star-rx72n-firmware/CLAUDE.md` - RX72N-specific conventions
+- `CLAUDE.md` - Project-wide standards

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -70,12 +70,14 @@ Review rx_pid.c for NASA Power of 10 compliance
 - [ ] Use of `RX_RETURN_ON_ERROR` macro
 
 ### Rule 8: Limit Preprocessor Use
-- [ ] Prefer `enum` over `#define` for constants
-- [ ] Prefer `static const` over `#define` for typed values
+- [ ] **ALWAYS use `enum` for integer constants** (never `#define`)
+- [ ] Use `static const` ONLY for floating-point values (enum can't hold floats)
+- [ ] `#define` is ONLY acceptable for token operations (e.g., `ARRAY_SIZE`)
 - [ ] No token pasting (`##`) except where necessary
 - [ ] No recursive macros
-- Good: `typedef enum { k_state_idle = 0 } state_t;`
-- Bad: `#define STATE_IDLE 0`
+- Good: `typedef enum { k_timeout_ms = 1000, k_max_retries = 3 } limits_t;`
+- Bad: `#define TIMEOUT_MS 1000` (should be enum!)
+- Bad: `#define MAX_VELOCITY 2.5f` (should be static const float!)
 
 ### Rule 9: Restrict Pointer Use
 - [ ] Maximum one level of dereferencing (exception: DIP interfaces)

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -105,7 +105,7 @@ Review rx_pid.c for NASA Power of 10 compliance
 - [ ] High-level modules don't depend on low-level details
 - [ ] Use function pointer interfaces for hardware abstraction
 - [ ] Testable via mock injection
-- Pattern: `typedef struct { esp_err_t (*operation)(void* ctx, ...); void* ctx; } interface_t;`
+- Pattern: `typedef struct { rx_err_t (*operation)(void* ctx, ...); void* ctx; } interface_t;`
 
 ## C Style Guide Checklist
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -20,7 +20,8 @@ Review rx_pid.c for NASA Power of 10 compliance
 2. **Read each file** - Analyze source code content
 3. **Apply NASA Power of 10 rules** - Check each rule from the checklist
 4. **Apply SOLID principles** - Validate architecture patterns
-5. **Generate report** - Produce structured markdown with findings
+5. **Check for tests** - If `tests/` directory exists, verify unit tests and integration tests are present
+6. **Generate report** - Produce structured markdown with findings
 
 ## NASA Power of 10 Rules Checklist
 
@@ -38,9 +39,11 @@ Review rx_pid.c for NASA Power of 10 compliance
 
 ### Rule 3: No Dynamic Memory After Initialization
 - [ ] No `malloc`/`calloc`/`realloc`/`free` in runtime code
-- [ ] All buffers statically allocated
+- [ ] **Exception**: Dynamic allocation is permitted during initialization phase (before main control loop starts)
+- [ ] All runtime buffers statically allocated
 - [ ] Fixed-size arrays with defined limits
 - Search patterns: `\bmalloc\b`, `\bcalloc\b`, `\brealloc\b`, `\bfree\b`
+- **Important**: Verify allocation occurs in `*_init()` functions, not in control loops or ISRs
 
 ### Rule 4: Keep Functions Short (~60 lines)
 - [ ] Functions do not exceed 60 lines (excluding comments/blank lines)
@@ -49,10 +52,12 @@ Review rx_pid.c for NASA Power of 10 compliance
 
 ### Rule 5: Use Assertions/Validation
 - [ ] Minimum 2 validation checks per function
-- [ ] NULL pointer checks for all pointer parameters
-- [ ] Range validation for numeric inputs
-- [ ] State validation (e.g., `!handle->initialized`)
+- [ ] **Pre-conditions**: NULL pointer checks for all pointer parameters
+- [ ] **Pre-conditions**: Range validation for numeric inputs
+- [ ] **Pre-conditions**: State validation (e.g., `!handle->initialized`)
+- [ ] **Post-conditions**: Validate outputs and invariants where applicable
 - Patterns: `RX_CHECK_`, `assert(`, `if\s*\([^)]*==\s*NULL`
+- **Good example**: See `star-rx72n-firmware/lib/rx_pid/src/rx_pid.c::rx_pid_compute()` for comprehensive pre-condition and post-condition validation
 
 ### Rule 6: Declare Data at Smallest Scope
 - [ ] Variables declared close to first use
@@ -142,11 +147,18 @@ Generate a markdown report with:
 # Code Review Report: [Directory/File]
 
 ## Summary
-| Category | Status | Issues |
-|----------|--------|--------|
-| NASA Power of 10 | COMPLIANT/NON-COMPLIANT | N |
-| SOLID Principles | COMPLIANT/NON-COMPLIANT | N |
-| Style Guide | COMPLIANT/NON-COMPLIANT | N |
+| Category | Status | Critical | High | Medium | Low |
+|----------|--------|----------|------|--------|-----|
+| NASA Power of 10 | COMPLIANT/NON-COMPLIANT | N | N | N | N |
+| SOLID Principles | COMPLIANT/NON-COMPLIANT | N | N | N | N |
+| Style Guide | COMPLIANT/NON-COMPLIANT | N | N | N | N |
+| **Total** | | **N** | **N** | **N** | **N** |
+
+### Severity Legend
+- **CRITICAL**: Safety violation, undefined behavior, memory corruption (Rules 1, 3, 7, 9)
+- **HIGH**: Verification issue, could cause runtime failure (Rules 2, 4, 5, 10)
+- **MEDIUM**: Maintainability concern, style violation (Rule 6, 8, SOLID, naming)
+- **LOW**: Minor style inconsistency, documentation improvement
 
 ## NASA Power of 10 Findings
 
@@ -154,24 +166,30 @@ Generate a markdown report with:
 **Status:** COMPLIANT / NON-COMPLIANT / INTENTIONAL DEVIATION
 
 **Findings:**
-- `file.c:123` - Description of issue
-- `file.c:456` - Description of issue
+- **[SEVERITY]** `file.c:123` - Description of issue
+- **[SEVERITY]** `file.c:456` - Description of issue
 
 **Recommendation:** How to fix
 
 ## SOLID Principle Findings
-[Similar structure]
+[Similar structure with severity tags]
 
 ## Style Guide Findings
-[Similar structure]
+[Similar structure with severity tags]
+
+## Test Coverage
+- [ ] Unit tests present for module
+- [ ] Integration tests available
+- [ ] Test coverage: N%
 
 ## Positive Observations
 - What the code does well
 - Good patterns observed
 
 ## Recommendations
-1. Priority fixes with code examples
-2. References to documentation
+1. **Critical Priority**: [List critical fixes first]
+2. **High Priority**: [List high priority fixes]
+3. **Medium/Low Priority**: [List other improvements]
 ```
 
 ## Reference Documentation

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -201,38 +201,48 @@ if (ret != RX_OK) {
 **Rationale:** Preprocessor complexity obscures operations, fooling developers and static analysis tools.
 
 **Preference Hierarchy:**
-1. **Enums** - For related integer constants
-2. **const variables** - For single typed values
-3. **Macros** - Only when compile-time evaluation required
+1. **Enums** - For ALL integer constants (preferred)
+2. **static const** - For floating-point values ONLY (enum limitation)
+3. **Macros** - NEVER use for constants (only for token operations)
 
 **Compliant Example:**
 ```c
-/* PREFER: Type-safe enum */
+/* ALWAYS PREFER: Enum for integer constants */
 typedef enum {
     k_motor_state_idle    = 0,
     k_motor_state_running = 1,
     k_motor_state_error   = 2,
-} motor_state_t;
+    k_timeout_ms          = 1000,  /* Integer - use enum! */
+    k_max_retries         = 3,     /* Integer - use enum! */
+    k_buffer_size         = 256    /* Integer - use enum! */
+} motor_config_t;
 
-/* PREFER: Typed const */
-static const float s_max_velocity_mps = 2.5f;
+/* ONLY for floating-point (enum can't hold float) */
+static const float s_max_velocity_mps = 2.5f;  /* Must be const - not integer */
+static const float s_pid_kp = 1.0f;            /* Must be const - not integer */
 
-/* ACCEPTABLE: Compile-time macro */
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+/* ACCEPTABLE: Token operation macros only */
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))  /* Token operation */
 ```
 
 **Non-Compliant Example (AVOID):**
 ```c
-/* BAD: Using macros for simple constants */
-#define MAX_RETRIES (3)        // Should be enum
-#define TIMEOUT_MS (1000)      // Should be enum or const
-#define MAX_VELOCITY (2.5f)    // Should be const
+/* BAD: Using macros for constants - NEVER DO THIS */
+#define MAX_RETRIES 3          // WRONG! Use enum
+#define TIMEOUT_MS 1000        // WRONG! Use enum
+#define BUFFER_SIZE 256        // WRONG! Use enum
+#define MAX_VELOCITY 2.5f      // WRONG! Use static const float
 
-/* WHY BAD:
- * - No type safety
+/* WHY MACROS ARE BAD:
+ * - No type safety (preprocessor text substitution)
  * - Not visible in debugger
- * - Can't take address
- * - Harder to namespace
+ * - Can't take address of value
+ * - No scoping/namespacing
+ * - Prone to macro expansion bugs
+ *
+ * RULE: If it's an integer constant, use enum. Always.
+ *       If it's floating-point, use static const.
+ *       Never use #define for constants.
  */
 ```
 

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -267,7 +267,7 @@ typedef struct rx_error_interface {
 | `_mps2` | m/s^2 | `accel_mps2` |
 | `_rad` | radians | `angle_rad` |
 | `_rad_per_s` | rad/s | `omega_rad_per_s` |
-| `_celsius` | degrees C | `temp_celsius` |
+| `_celsius` | degrees C | `temperature_celsius` |
 | `_ms` | milliseconds | `timeout_ms` |
 | `_us` | microseconds | `delay_us` |
 | `_ma` | milliamps | `current_ma` |

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -203,7 +203,18 @@ if (ret != RX_OK) {
 **Preference Hierarchy:**
 1. **Enums** - For ALL integer constants (preferred)
 2. **static const** - For floating-point values ONLY (enum limitation)
-3. **Macros** - NEVER use for constants (only for token operations)
+3. **Macros** - ONLY for specific cases (never for constants)
+
+**Allowed Macro Uses (Exhaustive List):**
+1. **Reducing duplicated code** - Function-like macros (e.g., `RX_RETURN_ON_ERROR`)
+2. **Conditional compilation** - Compile-time optimization (e.g., logging macros)
+3. **Hardware addresses** - Register pointers (can't use enum for addresses)
+4. **Build configuration flags** - Feature selection (e.g., `RX_CRC32_USE_HARDWARE`)
+
+**Forbidden Macro Uses:**
+- Simple integer constants (use enum)
+- Simple floating-point constants (use static const)
+- Function aliases for backward compatibility (project has no releases, no backward compatibility needed)
 
 **Compliant Example:**
 ```c
@@ -221,8 +232,33 @@ typedef enum {
 static const float s_max_velocity_mps = 2.5f;  /* Must be const - not integer */
 static const float s_pid_kp = 1.0f;            /* Must be const - not integer */
 
-/* ACCEPTABLE: Token operation macros only */
-#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))  /* Token operation */
+/* ACCEPTABLE: Macros for reducing duplicated code */
+#define RX_RETURN_ON_ERROR(err, tag, msg) \
+    do { \
+        rx_err_t _err = (err); \
+        if (_err != k_rx_ok) { \
+            rx_log_error((tag), (msg)); \
+            return _err; \
+        } \
+    } while (0)
+
+/* ACCEPTABLE: Conditional compilation (optimization) */
+#if LOG_LEVEL >= k_log_error
+#define rx_log_error(tag, msg) internal_rx_log_error((tag), (msg))
+#else
+#define rx_log_error(tag, msg) ((void)0)  /* Optimized away at compile time */
+#endif
+
+/* ACCEPTABLE: Hardware register addresses */
+#define CMT0_BASE ((rx_cmt_channel_regs_t*)0x00088000)
+#define CMT0      (*CMT0_BASE)
+
+/* ACCEPTABLE: Build configuration flags */
+#ifdef __RX__
+#define RX_CRC32_USE_HARDWARE
+#else
+#define RX_CRC32_USE_SOFTWARE
+#endif
 ```
 
 **Non-Compliant Example (AVOID):**

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -216,6 +216,14 @@ if (ret != RX_OK) {
 - Simple floating-point constants (use static const)
 - Function aliases for backward compatibility (project has no releases, no backward compatibility needed)
 
+**No Magic Numbers Policy:**
+ALL numeric literals must be named enums, including:
+- Array indices (`buf[0]` → `buf[k_idx_high_byte]`)
+- Bit shift amounts (`val >> 8` → `val >> k_shift_byte`)
+- Protocol offsets (`frame[4]` → `frame[k_offset_payload]`)
+- Register bit positions (`1 << 7` → `1 << k_bit_enable`)
+- Buffer sizes, timeouts, limits (already covered above)
+
 **Compliant Example:**
 ```c
 /* ALWAYS PREFER: Enum for integer constants */
@@ -231,6 +239,45 @@ typedef enum {
 /* ONLY for floating-point (enum can't hold float) */
 static const float s_max_velocity_mps = 2.5f;  /* Must be const - not integer */
 static const float s_pid_kp = 1.0f;            /* Must be const - not integer */
+
+/* NO MAGIC NUMBERS: Array indices as enums */
+typedef enum {
+    k_idx_high_byte = 0,  /* MSB at index 0 (big-endian) */
+    k_idx_low_byte  = 1   /* LSB at index 1 */
+} be16_byte_idx_t;
+
+static void write_be16(uint8_t* buf, uint16_t val) {
+    buf[k_idx_high_byte] = (uint8_t)(val >> k_shift_byte);  /* Named indices! */
+    buf[k_idx_low_byte]  = (uint8_t)(val & k_mask_byte);
+}
+
+/* NO MAGIC NUMBERS: Bit shifts as enums */
+typedef enum {
+    k_shift_byte   = 8,   /* Shift by 8 bits for byte operations */
+    k_shift_enable = 7,   /* Enable bit at position 7 */
+    k_shift_mode   = 3    /* Mode field starts at bit 3 */
+} bit_shifts_t;
+
+/* NO MAGIC NUMBERS: Bit masks as enums */
+typedef enum {
+    k_mask_byte   = 0xFF,    /* Single byte mask */
+    k_mask_enable = 0x80,    /* Enable bit mask (1 << 7) */
+    k_mask_mode   = 0x18     /* Mode field mask (bits 3-4) */
+} bit_masks_t;
+
+/* NO MAGIC NUMBERS: Protocol offsets as enums */
+typedef enum {
+    k_offset_sync    = 0,   /* SYNC marker at offset 0 */
+    k_offset_length  = 2,   /* Length field at offset 2 */
+    k_offset_payload = 4,   /* Payload starts at offset 4 */
+    k_offset_crc     = 8    /* CRC at offset 8 */
+} frame_offsets_t;
+
+static void parse_frame(const uint8_t* frame) {
+    uint16_t sync   = frame[k_offset_sync];      /* Named offset - clear! */
+    uint16_t length = frame[k_offset_length];
+    /* ... */
+}
 
 /* ACCEPTABLE: Macros for reducing duplicated code */
 #define RX_RETURN_ON_ERROR(err, tag, msg) \
@@ -269,16 +316,40 @@ static const float s_pid_kp = 1.0f;            /* Must be const - not integer */
 #define BUFFER_SIZE 256        // WRONG! Use enum
 #define MAX_VELOCITY 2.5f      // WRONG! Use static const float
 
-/* WHY MACROS ARE BAD:
+/* BAD: Magic numbers everywhere */
+static void write_be16_bad(uint8_t* buf, uint16_t val) {
+    buf[0] = (uint8_t)(val >> 8);   // MAGIC! What is 0? What is 8?
+    buf[1] = (uint8_t)(val & 0xFF); // MAGIC! What is 1? What is 0xFF?
+}
+
+static void parse_frame_bad(const uint8_t* frame) {
+    uint16_t sync   = frame[0];     // MAGIC! What's at index 0?
+    uint16_t length = frame[2];     // MAGIC! What's at index 2?
+    uint8_t* data   = &frame[4];    // MAGIC! Why 4?
+}
+
+static void config_register_bad(void) {
+    REG = (1 << 7) | (3 << 3);      // MAGIC! Which bits? Why?
+}
+
+/* WHY MAGIC NUMBERS ARE BAD:
+ * - Unclear intent (what does 0, 8, 0xFF mean?)
+ * - Hard to maintain (what if protocol changes?)
+ * - Error-prone (easy to use wrong index/shift)
+ * - Not searchable (can't grep for "sync offset")
+ * - No semantic meaning in debugger
+ *
+ * WHY MACROS ARE BAD:
  * - No type safety (preprocessor text substitution)
  * - Not visible in debugger
  * - Can't take address of value
  * - No scoping/namespacing
  * - Prone to macro expansion bugs
  *
- * RULE: If it's an integer constant, use enum. Always.
+ * RULE: If it's an integer (even 0, 1, 8!), use enum. Always.
  *       If it's floating-point, use static const.
  *       Never use #define for constants.
+ *       Never use literal numbers.
  */
 ```
 

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -49,9 +49,12 @@ for\s*\(\s*;\s*;\s*\)        # for(;;)
 
 **Compliant Example:**
 ```c
-#define MAX_RETRIES (3)
+/* PREFER: Enum for integer constant */
+typedef enum {
+    k_max_retries = 3
+} retry_limits_t;
 
-for (uint8_t i = 0; i < MAX_RETRIES; i++) {
+for (uint8_t i = 0; i < k_max_retries; i++) {
     if (sensor_read() == RX_OK) {
         break;
     }
@@ -77,11 +80,14 @@ for (uint8_t i = 0; i < MAX_RETRIES; i++) {
 
 **Compliant Example:**
 ```c
-#define MAX_ITEMS (8)
-#define MAX_DESC_LEN (64)
+/* PREFER: Enum for compile-time array sizes */
+typedef enum {
+    k_max_items    = 8,
+    k_max_desc_len = 64
+} pool_limits_t;
 
 typedef struct {
-    char items[MAX_ITEMS][MAX_DESC_LEN];
+    char items[k_max_items][k_max_desc_len];
     uint8_t item_count;
 } static_pool_t;
 ```
@@ -213,6 +219,21 @@ static const float s_max_velocity_mps = 2.5f;
 
 /* ACCEPTABLE: Compile-time macro */
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+```
+
+**Non-Compliant Example (AVOID):**
+```c
+/* BAD: Using macros for simple constants */
+#define MAX_RETRIES (3)        // Should be enum
+#define TIMEOUT_MS (1000)      // Should be enum or const
+#define MAX_VELOCITY (2.5f)    // Should be const
+
+/* WHY BAD:
+ * - No type safety
+ * - Not visible in debugger
+ * - Can't take address
+ * - Harder to namespace
+ */
 ```
 
 ### Rule 9: Restrict Pointer Use

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -316,6 +316,121 @@ typedef struct rx_error_interface {
 | Primary | Master | Configuration |
 | Main | Master | Configuration |
 
+## File Documentation Standard
+
+### Required Header Format
+
+Every C source and header file must begin with:
+
+1. **Path comment** (first line)
+2. **Doxygen documentation block**
+
+### Path Comment Format
+
+```c
+/* path/to/file.ext */
+```
+
+**Examples:**
+- `/* lib/rx_pid/inc/rx_pid.h */`
+- `/* lib/rx_pid/src/rx_pid.c */`
+- `/* lib/rx_crc/inc/rx_crc.h */`
+
+### Doxygen Header Block
+
+**Required Tags:**
+- `@file` - Exact filename
+- `@brief` - One-line summary
+- `@date` - Date in YYYY-MM-DD format
+- `@copyright` - Copyright notice
+
+**Optional Tags:**
+- `@details` - Extended description (recommended for complex modules)
+- `@code` - Usage examples (recommended for public API headers)
+
+**Forbidden Tags:**
+- `@author` - Not used in this project
+- `@version` - Not used (rely on git history)
+
+### Minimal Header Example
+
+```c
+/* lib/rx_utils/inc/rx_utils.h */
+
+/**
+ * @file rx_utils.h
+ * @brief Utility helper functions for RX72N firmware
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+```
+
+### Extended Header Example (Public API)
+
+```c
+/* lib/rx_pid/inc/rx_pid.h */
+
+/**
+ * @file rx_pid.h
+ * @brief PID controller API for closed-loop motor control
+ * @details
+ * Provides a stateless PID (Proportional-Integral-Derivative) controller interface with
+ * anti-windup, derivative filtering, and configurable output limits. Suitable for embedded
+ * systems with deterministic behavior and tunable gains for velocity or position control loops.
+ *
+ * Direct port from ESP32 star_pid library - pure algorithm, no hardware dependencies.
+ *
+ * Key Features:
+ * - Standard PID algorithm with Kp, Ki, Kd gains
+ * - Configurable output limits
+ * - Integral anti-windup
+ * - Runtime gain tuning
+ * - State reset capability
+ *
+ * Example Usage:
+ * @code
+ * // Initialize PID Controller
+ * rx_pid_handle_t pid;
+ * rx_pid_config_t config = {
+ *     .kp = 1.0f,
+ *     .ki = 0.5f,
+ *     .kd = 0.1f,
+ *     .output_min = -100.0f,
+ *     .output_max = 100.0f
+ * };
+ * rx_pid_init(&pid, &config);
+ *
+ * // Compute PID output
+ * float output;
+ * rx_pid_compute(&pid, setpoint, measured, dt, &output);
+ * @endcode
+ *
+ * @date 2026-01-01
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+```
+
+### Implementation File Example
+
+```c
+/* lib/rx_pid/src/rx_pid.c */
+
+/**
+ * @file rx_pid.c
+ * @brief PID controller implementation for closed-loop motor control
+ * @details
+ * Implements a stateless PID (Proportional-Integral-Derivative) controller with anti-windup,
+ * derivative filtering, and configurable output limits. Designed for embedded systems with
+ * no dynamic memory allocation and tunable gains for velocity or position control.
+ *
+ * Direct port from ESP32 star_pid library - pure algorithm, no hardware dependencies.
+ *
+ * @date 2026-01-01
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+```
+
 ## SOLID Principles for C
 
 ### Single Responsibility

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -1,0 +1,324 @@
+# STAR Project Coding Standards Reference
+
+This document provides detailed reference material for the code review agent.
+
+## NASA Power of 10 Rules (Complete Reference)
+
+### Rule 1: Simplify Control Flow
+
+**Rule:** Restrict all code to very simple control flow constructs - no `goto`, `setjmp`/`longjmp`, or recursion (direct or indirect).
+
+**Rationale:** Creates predictable program structure for human understanding and static analysis. Recursion causes unbounded stack usage - dangerous in embedded systems.
+
+**Detection Patterns:**
+```regex
+\bgoto\s+\w+
+\bsetjmp\s*\(
+\blongjmp\s*\(
+```
+
+**Compliant Example:**
+```c
+rx_err_t motor_init(motor_handle_t* handle, const motor_config_t* config)
+{
+    if (handle == NULL || config == NULL) {
+        return RX_ERR_INVALID_ARG;
+    }
+
+    rx_err_t ret = configure_timer(handle, config);
+    if (ret != RX_OK) {
+        return ret;
+    }
+
+    return configure_gpio(handle, config);
+}
+```
+
+### Rule 2: Fixed Loop Upper-Bounds
+
+**Rule:** All loops must have a fixed upper bound that static analysis tools can trivially prove.
+
+**Rationale:** Prevents runaway code, guarantees termination, enables real-time deadline verification.
+
+**Detection Patterns:**
+```regex
+while\s*\(\s*1\s*\)          # while(1) - check for bounded exit
+while\s*\(\s*true\s*\)       # while(true)
+for\s*\(\s*;\s*;\s*\)        # for(;;)
+```
+
+**Compliant Example:**
+```c
+#define MAX_RETRIES (3)
+
+for (uint8_t i = 0; i < MAX_RETRIES; i++) {
+    if (sensor_read() == RX_OK) {
+        break;
+    }
+    tx_thread_sleep(10);
+}
+```
+
+**Exception:** Main control loops may use `while(1)` with watchdog feeding.
+
+### Rule 3: No Dynamic Memory After Initialization
+
+**Rule:** Prohibit `malloc`/`free` after initialization phase.
+
+**Rationale:** Dynamic allocation causes unpredictable performance, memory leaks, fragmentation, and corruption.
+
+**Detection Patterns:**
+```regex
+\bmalloc\s*\(
+\bcalloc\s*\(
+\brealloc\s*\(
+\bfree\s*\(
+```
+
+**Compliant Example:**
+```c
+#define MAX_ITEMS (8)
+#define MAX_DESC_LEN (64)
+
+typedef struct {
+    char items[MAX_ITEMS][MAX_DESC_LEN];
+    uint8_t item_count;
+} static_pool_t;
+```
+
+### Rule 4: Keep Functions Short
+
+**Rule:** Functions should not exceed ~60 lines (one printed page, one statement per line).
+
+**Rationale:** Represents single verifiable logical units; improves comprehension, review, and testability.
+
+**Detection:** Count lines between function open brace `{` and close brace `}`, excluding:
+- Blank lines
+- Comment-only lines
+
+**Threshold:** Functions exceeding 60 lines should be refactored.
+
+### Rule 5: Use Assertions/Validation
+
+**Rule:** Minimum two assertions per function; assertions must be side-effect-free.
+
+**Rationale:** Acts as executable documentation verifying pre-conditions, post-conditions, and invariants.
+
+**Detection Patterns:**
+```regex
+RX_CHECK_NULL_PTR\s*\(
+RX_RETURN_ON_ERROR\s*\(
+if\s*\([^)]*==\s*NULL
+assert\s*\(
+```
+
+**Compliant Example:**
+```c
+rx_err_t pid_compute(pid_handle_t* handle, float setpoint,
+                     float measurement, float dt, float* output)
+{
+    /* Pre-condition checks */
+    if (handle == NULL) {
+        return RX_ERR_INVALID_ARG;
+    }
+    if (!handle->initialized) {
+        return RX_ERR_INVALID_STATE;
+    }
+    if (output == NULL) {
+        return RX_ERR_INVALID_ARG;
+    }
+    if (dt <= 0.0f || dt > 1.0f) {
+        return RX_ERR_INVALID_ARG;
+    }
+
+    /* Function logic */
+    float error = setpoint - measurement;
+    *output = handle->kp * error;
+    return RX_OK;
+}
+```
+
+### Rule 6: Declare Data at Smallest Scope
+
+**Rule:** Minimize variable scope to reduce accidental corruption risks.
+
+**Rationale:** Limits chances of accidental reference or corruption from other code.
+
+**Red Flags:**
+- Variables declared at file scope without `static`
+- Variables declared far from first use
+- Loop counters declared outside loop
+
+**Compliant Example:**
+```c
+void process_sensors(void)
+{
+    for (uint8_t i = 0; i < SENSOR_COUNT; i++) {
+        float temp_c = 0.0f;  /* Declared at smallest scope */
+        if (read_sensor(i, &temp_c) == RX_OK) {
+            update_telemetry(i, temp_c);
+        }
+    }
+}
+```
+
+### Rule 7: Check All Return Values
+
+**Rule:** Validate all function returns and input parameters; treat warnings as errors.
+
+**Rationale:** Forces explicit failure-condition handling rather than ignoring error codes.
+
+**Detection Patterns:**
+```regex
+=\s*\w+\s*\([^)]*\)\s*;    # Assignment from function - check for use
+\w+\s*\([^)]*\)\s*;        # Function call without assignment - check if void
+```
+
+**Compliant Example:**
+```c
+rx_err_t ret = bus_init(config);
+if (ret != RX_OK) {
+    RX_LOG_ERROR("Bus init failed: %d", ret);
+    return ret;
+}
+```
+
+**Explicit Ignore:**
+```c
+(void)optional_cleanup();  /* Explicitly ignored */
+```
+
+### Rule 8: Limit Preprocessor Use
+
+**Rule:** Restrict to header inclusion and simple macros; forbid token pasting, recursive macros, and incomplete syntactic units.
+
+**Rationale:** Preprocessor complexity obscures operations, fooling developers and static analysis tools.
+
+**Preference Hierarchy:**
+1. **Enums** - For related integer constants
+2. **const variables** - For single typed values
+3. **Macros** - Only when compile-time evaluation required
+
+**Compliant Example:**
+```c
+/* PREFER: Type-safe enum */
+typedef enum {
+    k_motor_state_idle    = 0,
+    k_motor_state_running = 1,
+    k_motor_state_error   = 2,
+} motor_state_t;
+
+/* PREFER: Typed const */
+static const float s_max_velocity_mps = 2.5f;
+
+/* ACCEPTABLE: Compile-time macro */
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+```
+
+### Rule 9: Restrict Pointer Use
+
+**Rule:** Maximum one dereferencing level (`*ptr` OK, `**ptr` forbidden); no function pointers.
+
+**STAR Deviation:** Function pointers are ALLOWED for Dependency Inversion Principle (DIP).
+
+**Compliant DIP Pattern:**
+```c
+/* INTENTIONAL DEVIATION - DIP interface */
+typedef struct rx_error_interface {
+    rx_err_t (*record_error)(void* ctx, rx_err_t error, const char* msg);
+    bool (*can_retry)(void* ctx);
+    void* ctx;
+} rx_error_interface_t;
+
+/* Why: Enables mock implementations for unit testing */
+```
+
+### Rule 10: Compile with Maximum Warnings
+
+**Rule:** Enable all compiler warnings at highest pedantry; achieve zero-warning builds.
+
+**Required Flags:**
+```cmake
+-Wall -Wextra -Werror
+```
+
+**Check:** Verify CMakeLists.txt contains these flags.
+
+## C Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Functions | snake_case | `motor_init()` |
+| Variables | snake_case | `motor_speed` |
+| Macros | SCREAMING_SNAKE | `MAX_SPEED` |
+| Types | snake_case_t | `motor_config_t` |
+| Static functions | internal_ prefix | `internal_validate()` |
+| Private functions | priv_ prefix | `priv_reset()` |
+| Static variables | s_ prefix | `s_instance_count` |
+| Global variables | g_ prefix | `g_system_state` (avoid) |
+| Enum values | k_ prefix | `k_state_idle` |
+
+## Unit Suffixes
+
+| Suffix | Unit | Example |
+|--------|------|---------|
+| `_m` | meters | `distance_m` |
+| `_mps` | m/s | `velocity_mps` |
+| `_mps2` | m/s^2 | `accel_mps2` |
+| `_rad` | radians | `angle_rad` |
+| `_rad_per_s` | rad/s | `omega_rad_per_s` |
+| `_celsius` | degrees C | `temp_celsius` |
+| `_ms` | milliseconds | `timeout_ms` |
+| `_us` | microseconds | `delay_us` |
+| `_ma` | milliamps | `current_ma` |
+| `_mv` | millivolts | `voltage_mv` |
+| `_percent` | 0-100% | `duty_percent` |
+
+## Inclusive Terminology
+
+| Use | Avoid | Context |
+|-----|-------|---------|
+| Controller | Master | I2C/SPI/1-Wire bus roles |
+| Peripheral | Slave | I2C/SPI/1-Wire bus roles |
+| COPI | MOSI | SPI data line |
+| CIPO | MISO | SPI data line |
+| Primary | Master | Configuration |
+| Main | Master | Configuration |
+
+## SOLID Principles for C
+
+### Single Responsibility
+- One module = one purpose
+- One function = one action
+- Separate configuration from logic
+
+### Open/Closed
+- Use configuration structs for customization
+- Avoid hardcoded values
+- Design for extension
+
+### Liskov Substitution
+- Interface implementations interchangeable
+- Mocks substitute real implementations
+- Consistent error handling
+
+### Interface Segregation
+- Small, focused interfaces
+- Separate read/write operations
+- Don't force unused dependencies
+
+### Dependency Inversion
+- Use function pointer interfaces
+- Inject dependencies via init functions
+- Enable unit testing with mocks
+
+**DIP Pattern:**
+```c
+typedef struct {
+    rx_err_t (*read)(void* ctx, uint8_t* data, uint32_t len);
+    rx_err_t (*write)(void* ctx, const uint8_t* data, uint32_t len);
+    void* ctx;
+} bus_interface_t;
+
+rx_err_t driver_init(driver_t* driver, const bus_interface_t* bus);
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,96 @@ star.v1.RequestHeader.request_id max_size:64
 - Avoid inline ASM; if required, use `volatile` and document why
 - Zero dynamic allocation in RX72N firmware (safety-critical)
 
+## NASA Power of 10 Rules (STAR Implementation)
+
+The STAR project follows NASA/JPL Power of 10 rules for safety-critical embedded code with one intentional deviation for testability.
+
+### Rule 1: Simplify Control Flow ✓ COMPLIANT
+- No `goto`, `setjmp`/`longjmp`, or recursion
+- All control flow uses `if`/`while`/`for` only
+- Example: `rx_pid_init()` uses sequential error checking, no goto cleanup
+
+### Rule 2: Fixed Loop Upper-Bounds ✓ COMPLIANT
+- All loops have statically provable bounds
+- Exception: Main control loops use `while(1)` with watchdog
+- Example: `for (uint8_t i = 0; i < k_max_retries; i++)` - enum provides bound
+
+### Rule 3: No Dynamic Memory After Initialization ✓ COMPLIANT
+- **Zero malloc/free in RX72N firmware** (safety-critical)
+- All buffers statically allocated with enum-defined sizes
+- ThreadX stacks are static arrays
+- Example: `char items[k_max_items][k_max_desc_len]` - compile-time allocation
+
+### Rule 4: Keep Functions Short (~60 lines) ✓ COMPLIANT
+- Functions represent single verifiable units
+- Example: `rx_pid_compute()` is 44 lines - complete PID algorithm in one screen
+
+### Rule 5: Use Assertions/Validation ✓ COMPLIANT
+- Minimum 2 validation checks per function
+- **Pre-conditions**: `RX_CHECK_NULL_PTR`, state validation
+- **Post-conditions**: Output bounds checking, invariant validation
+- Example: `rx_pid_compute()` has 4 checks (NULL×2, initialized, dt > 0)
+
+### Rule 6: Declare Data at Smallest Scope ✓ COMPLIANT
+- Variables declared close to first use
+- Loop counters in for-statement: `for (uint8_t i = 0; ...)`
+- File-scope variables use `static` prefix (`s_tag`)
+
+### Rule 7: Check All Return Values ✓ COMPLIANT
+- All function returns validated or explicitly cast to `(void)`
+- Use `RX_RETURN_ON_ERROR` macro for propagation
+- Example: `rx_err_t ret = bus_init(config); if (ret != k_rx_ok) return ret;`
+
+### Rule 8: Limit Preprocessor Use ✓ COMPLIANT
+- Enums for ALL integer constants (mandatory)
+- Macros ONLY for: duplicated code, conditional compilation, hardware addresses, build flags
+- See "Constants and Macros" section above for complete policy
+
+### Rule 9: Restrict Pointer Use ⚠️ INTENTIONAL DEVIATION
+- **Standard**: Maximum one level of dereferencing, no function pointers
+- **STAR Deviation**: Function pointers ALLOWED for Dependency Inversion Principle (DIP)
+- **Why**: Enables mock implementations for unit testing and hardware abstraction
+- Example: `typedef struct { rx_err_t (*read)(void* ctx, ...); void* ctx; } bus_interface_t;`
+
+### Rule 10: Compile with Maximum Warnings ✓ COMPLIANT
+- CMake flags: `-Wall -Wextra -Werror`
+- Build fails on ANY warning
+- CI/CD enforces zero-warning builds
+
+## SOLID Principles for C (STAR Implementation)
+
+### Single Responsibility (S)
+- **One module = one purpose**: `rx_pid` handles ONLY PID algorithm (no motor control, no hardware)
+- **One function = one action**: `rx_pid_compute()` does PID math, `rx_pid_reset()` clears state
+- **Separation of concerns**: Configuration (`rx_pid_config_t`) separate from runtime state (`rx_pid_handle_t`)
+
+### Open/Closed (O)
+- **Extensible without modification**: `rx_pid` configured via `rx_pid_config_t` struct
+- **Runtime tuning**: `rx_pid_set_gains()` allows updates without recompilation
+- **Avoid hardcoded values**: All limits defined in config (output_min/max, integral_min/max)
+
+### Liskov Substitution (L)
+- **Interface implementations interchangeable**: Bus manager accepts any bus type (I2C/SPI/1-Wire)
+- **Mocks substitute real implementations**: Tests use `mock_rx_bus_onewire` in place of real hardware
+- **Consistent error handling**: All drivers return `rx_err_t` with same semantics
+
+### Interface Segregation (I)
+- **Small, focused interfaces**: `rx_pid` API has 7 functions, each with clear purpose
+- **No "fat" interfaces**: Bus interface split into `read()`, `write()`, `configure()` - use only what you need
+- **Separate read/write**: Motor encoder read separate from motor driver write operations
+
+### Dependency Inversion (D)
+- **High-level modules don't depend on low-level details**: Motor control uses bus interface, not direct GPIO
+- **Function pointer interfaces for abstraction**:
+  ```c
+  typedef struct {
+      rx_err_t (*read)(void* ctx, uint8_t* data, uint32_t len);
+      rx_err_t (*write)(void* ctx, const uint8_t* data, uint32_t len);
+      void* ctx;
+  } bus_interface_t;
+  ```
+- **Testable via mock injection**: `driver_init(driver, &mock_bus)` vs `driver_init(driver, &real_bus)`
+
 ## Motor Control
 
 ### PID Tuning Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Note: External APIs may still use legacy terminology internally. Map these to our terminology in comments and documentation.
 
+## Backward Compatibility Policy
+
+**IMPORTANT:** This project has not released any versions yet. There is **NO backward compatibility requirement**.
+
+- Do NOT add function aliases or deprecation macros for renamed functions
+- Do NOT keep old API signatures "for compatibility"
+- When refactoring, update all call sites directly - no shims
+- Clean code now is better than technical debt for non-existent users
+
+**Example - What NOT to do:**
+```c
+// WRONG - No backward compatibility needed!
+#define old_function_name new_function_name  /* ❌ Delete old code instead */
+```
+
+**Example - What to do:**
+```c
+// CORRECT - Just update the function name and all call sites
+rx_err_t new_function_name(...)  /* ✓ Clean break, no compatibility layer */
+```
+
 ## Project Overview
 
 **STAR (Simultaneous Tracking and Robotics)** - A distributed robotics platform with custom PCB hardware, Renesas RX72N motor control firmware, Raspberry Pi 5 control system, and Protocol Buffers communication.
@@ -131,41 +152,63 @@ star.v1.RequestHeader.request_id max_size:64
 
 ### Constants and Macros
 
-Prefer enums over const variables over macros for defining constant values.
+**Strict preference hierarchy:**
 
-1. **Enums** - Use for related integer constants
+1. **Enums** - ALWAYS use for ALL integer constants
    ```c
-   // PREFER: Type-safe enums with debugger support
+   // CORRECT: Type-safe enums with debugger support
    typedef enum {
      k_motor_state_idle    = 0,
      k_motor_state_running = 1,
      k_motor_state_error   = 2,
-   } motor_state_t;
+     k_timeout_ms          = 1000,    // Integer constant → enum
+     k_max_retries         = 3        // Integer constant → enum
+   } motor_config_t;
 
-   // AVOID: Macros for related constants
-   #define MOTOR_STATE_IDLE    (0)
-   #define MOTOR_STATE_RUNNING (1)
-   #define MOTOR_STATE_ERROR   (2)
+   // WRONG: Never use macros for integer constants
+   #define TIMEOUT_MS (1000)  // ❌ Should be enum!
    ```
 
-2. **const variables** - Use for single typed values
+2. **const variables** - ONLY for floating-point (enum limitation)
    ```c
-   // PREFER: Type-safe const with scope
-   static const float    s_max_velocity_mps = 2.5f;
-   static const uint32_t s_timeout_ms       = 1000;
+   // CORRECT: Floating-point must use const (can't use enum)
+   static const float s_max_velocity_mps = 2.5f;
+   static const float s_pid_kp = 1.0f;
 
-   // AVOID: Macros for simple constants
-   #define MAX_VELOCITY_MPS (2.5f)
-   #define TIMEOUT_MS       (1000)
+   // WRONG: Never use macros for floats
+   #define MAX_VELOCITY_MPS (2.5f)  // ❌ Should be const!
    ```
 
-3. **Macros** - Only when compile-time evaluation or token pasting is required
+3. **Macros** - ONLY for these 4 specific cases:
    ```c
-   // ACCEPTABLE: Macro required for token pasting
-   #define CONCAT(a, b) a##b
+   // ✓ ALLOWED: Reducing duplicated code
+   #define RX_RETURN_ON_ERROR(err, tag, msg) \
+       do { \
+           rx_err_t _err = (err); \
+           if (_err != k_rx_ok) { \
+               rx_log_error((tag), (msg)); \
+               return _err; \
+           } \
+       } while (0)
 
-   // ACCEPTABLE: Macro required for compile-time size
-   #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+   // ✓ ALLOWED: Conditional compilation (optimization)
+   #if LOG_LEVEL >= k_log_error
+   #define rx_log_error(tag, msg) internal_rx_log_error((tag), (msg))
+   #else
+   #define rx_log_error(tag, msg) ((void)0)
+   #endif
+
+   // ✓ ALLOWED: Hardware register addresses
+   #define CMT0_BASE ((rx_cmt_channel_regs_t*)0x00088000)
+   #define CMT0      (*CMT0_BASE)
+
+   // ✓ ALLOWED: Build configuration flags
+   #ifdef __RX__
+   #define RX_CRC32_USE_HARDWARE
+   #endif
+
+   // ❌ FORBIDDEN: Backward compatibility (no releases = no compatibility)
+   #define old_function new_function  // Wrong! Update call sites instead
    ```
 
 **Why this matters:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,9 +211,50 @@ star.v1.RequestHeader.request_id max_size:64
    #define old_function new_function  // Wrong! Update call sites instead
    ```
 
+### No Magic Numbers
+
+**ZERO TOLERANCE for magic numbers.** ALL numeric literals must be named enums, including:
+
+```c
+// ✓ CORRECT: Array indices as enums
+typedef enum {
+    k_idx_high_byte = 0,
+    k_idx_low_byte  = 1
+} be16_byte_idx_t;
+
+buf[k_idx_high_byte] = (val >> k_shift_byte);
+
+// ✓ CORRECT: Bit shifts as enums
+typedef enum {
+    k_shift_byte   = 8,
+    k_shift_enable = 7
+} bit_shifts_t;
+
+// ✓ CORRECT: Protocol offsets as enums
+typedef enum {
+    k_offset_sync    = 0,
+    k_offset_payload = 4
+} frame_offsets_t;
+
+// ✓ CORRECT: Bit masks as enums
+typedef enum {
+    k_mask_byte   = 0xFF,
+    k_mask_enable = 0x80
+} bit_masks_t;
+
+// ❌ WRONG: Magic numbers
+buf[0] = (val >> 8);              // What is 0? What is 8?
+frame[4] = payload;               // What's at index 4?
+REG = (1 << 7) | (3 << 3);       // Which bits? Why?
+```
+
 **Why this matters:**
-- Enums provide type safety and debugger support
-- const variables have type information and scope
+- Self-documenting code (k_idx_high_byte vs 0)
+- Searchable (grep for "high_byte" finds all uses)
+- Maintainable (change offset in one place)
+- Debugger-friendly (see names, not numbers)
+- Compile-time checked (typos caught)
+- Enums provide type safety
 - Macros lack type safety and can cause subtle bugs
 
 ### Critical Rules

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -87,6 +87,61 @@ static const float s_max_velocity_mps = 2.5f;
 #define old_func new_func      // No compatibility needed!
 ```
 
+## No Magic Numbers Policy
+
+**ZERO TOLERANCE for magic numbers.** ALL numeric literals must be named enums, including:
+- Array indices (`buf[0]` → `buf[k_idx_high_byte]`)
+- Bit shift amounts (`val >> 8` → `val >> k_shift_byte`)
+- Protocol offsets (`frame[4]` → `frame[k_offset_payload]`)
+- Register bit positions (`1 << 7` → `1 << k_bit_enable`)
+- Bit masks (`0xFF` → `k_mask_byte`)
+
+**Examples:**
+```c
+// ✓ CORRECT: Named indices
+typedef enum {
+    k_idx_high_byte = 0,
+    k_idx_low_byte  = 1
+} be16_byte_idx_t;
+
+buf[k_idx_high_byte] = (val >> k_shift_byte);
+
+// ✓ CORRECT: Named shifts
+typedef enum {
+    k_shift_byte   = 8,
+    k_shift_enable = 7
+} bit_shifts_t;
+
+// ✓ CORRECT: Named offsets
+typedef enum {
+    k_offset_sync    = 0,
+    k_offset_payload = 4
+} frame_offsets_t;
+
+frame[k_offset_sync] = SYNC_MARKER;
+
+// ✓ CORRECT: Named masks
+typedef enum {
+    k_mask_byte   = 0xFF,
+    k_mask_enable = 0x80
+} bit_masks_t;
+
+val &= k_mask_byte;
+
+// ❌ WRONG: Magic numbers
+buf[0] = (val >> 8);         // What is 0? What is 8?
+frame[4] = payload;          // What's at index 4?
+REG = (1 << 7) | (3 << 3);  // Which bits? Why?
+val &= 0xFF;                 // What does 0xFF represent?
+```
+
+**Benefits:**
+- Self-documenting: `k_idx_high_byte` vs `0`
+- Searchable: grep "high_byte" finds all uses
+- Maintainable: change offset in one place
+- Debugger-friendly: see names, not numbers
+- Type-safe: compiler catches typos
+
 ## Project Overview
 
 **STAR (Simultaneous Tracking and Robotics)** - A distributed robotics platform with custom PCB hardware, embedded firmware, and high-level control software.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -230,6 +230,96 @@ buf generate
 - **Tuning:** MATLAB-based system identification and controller design
 - **Safety:** Watchdog timeout 500ms, emergency stop <20ms
 
+## NASA Power of 10 Rules (STAR Implementation)
+
+The STAR project follows NASA/JPL Power of 10 rules for safety-critical embedded code with one intentional deviation for testability.
+
+### Rule 1: Simplify Control Flow ✓ COMPLIANT
+- No `goto`, `setjmp`/`longjmp`, or recursion
+- All control flow uses `if`/`while`/`for` only
+- Example: `rx_pid_init()` uses sequential error checking, no goto cleanup
+
+### Rule 2: Fixed Loop Upper-Bounds ✓ COMPLIANT
+- All loops have statically provable bounds
+- Exception: Main control loops use `while(1)` with watchdog
+- Example: `for (uint8_t i = 0; i < k_max_retries; i++)` - enum provides bound
+
+### Rule 3: No Dynamic Memory After Initialization ✓ COMPLIANT
+- **Zero malloc/free in RX72N firmware** (safety-critical)
+- All buffers statically allocated with enum-defined sizes
+- ThreadX stacks are static arrays
+- Example: `char items[k_max_items][k_max_desc_len]` - compile-time allocation
+
+### Rule 4: Keep Functions Short (~60 lines) ✓ COMPLIANT
+- Functions represent single verifiable units
+- Example: `rx_pid_compute()` is 44 lines - complete PID algorithm in one screen
+
+### Rule 5: Use Assertions/Validation ✓ COMPLIANT
+- Minimum 2 validation checks per function
+- **Pre-conditions**: `RX_CHECK_NULL_PTR`, state validation
+- **Post-conditions**: Output bounds checking, invariant validation
+- Example: `rx_pid_compute()` has 4 checks (NULL×2, initialized, dt > 0)
+
+### Rule 6: Declare Data at Smallest Scope ✓ COMPLIANT
+- Variables declared close to first use
+- Loop counters in for-statement: `for (uint8_t i = 0; ...)`
+- File-scope variables use `static` prefix (`s_tag`)
+
+### Rule 7: Check All Return Values ✓ COMPLIANT
+- All function returns validated or explicitly cast to `(void)`
+- Use `RX_RETURN_ON_ERROR` macro for propagation
+- Example: `rx_err_t ret = bus_init(config); if (ret != k_rx_ok) return ret;`
+
+### Rule 8: Limit Preprocessor Use ✓ COMPLIANT
+- Enums for ALL integer constants (mandatory)
+- Macros ONLY for: duplicated code, conditional compilation, hardware addresses, build flags
+- See "Constants and Macros Policy" section above for complete policy
+
+### Rule 9: Restrict Pointer Use ⚠️ INTENTIONAL DEVIATION
+- **Standard**: Maximum one level of dereferencing, no function pointers
+- **STAR Deviation**: Function pointers ALLOWED for Dependency Inversion Principle (DIP)
+- **Why**: Enables mock implementations for unit testing and hardware abstraction
+- Example: `typedef struct { rx_err_t (*read)(void* ctx, ...); void* ctx; } bus_interface_t;`
+
+### Rule 10: Compile with Maximum Warnings ✓ COMPLIANT
+- CMake flags: `-Wall -Wextra -Werror`
+- Build fails on ANY warning
+- CI/CD enforces zero-warning builds
+
+## SOLID Principles for C (STAR Implementation)
+
+### Single Responsibility (S)
+- **One module = one purpose**: `rx_pid` handles ONLY PID algorithm (no motor control, no hardware)
+- **One function = one action**: `rx_pid_compute()` does PID math, `rx_pid_reset()` clears state
+- **Separation of concerns**: Configuration (`rx_pid_config_t`) separate from runtime state (`rx_pid_handle_t`)
+
+### Open/Closed (O)
+- **Extensible without modification**: `rx_pid` configured via `rx_pid_config_t` struct
+- **Runtime tuning**: `rx_pid_set_gains()` allows updates without recompilation
+- **Avoid hardcoded values**: All limits defined in config (output_min/max, integral_min/max)
+
+### Liskov Substitution (L)
+- **Interface implementations interchangeable**: Bus manager accepts any bus type (I2C/SPI/1-Wire)
+- **Mocks substitute real implementations**: Tests use `mock_rx_bus_onewire` in place of real hardware
+- **Consistent error handling**: All drivers return `rx_err_t` with same semantics
+
+### Interface Segregation (I)
+- **Small, focused interfaces**: `rx_pid` API has 7 functions, each with clear purpose
+- **No "fat" interfaces**: Bus interface split into `read()`, `write()`, `configure()` - use only what you need
+- **Separate read/write**: Motor encoder read separate from motor driver write operations
+
+### Dependency Inversion (D)
+- **High-level modules don't depend on low-level details**: Motor control uses bus interface, not direct GPIO
+- **Function pointer interfaces for abstraction**:
+  ```c
+  typedef struct {
+      rx_err_t (*read)(void* ctx, uint8_t* data, uint32_t len);
+      rx_err_t (*write)(void* ctx, const uint8_t* data, uint32_t len);
+      void* ctx;
+  } bus_interface_t;
+  ```
+- **Testable via mock injection**: `driver_init(driver, &mock_bus)` vs `driver_init(driver, &real_bus)`
+
 ## Key Files
 
 - `star-rx72n-firmware/CLAUDE.md` - RX72N firmware development guide

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,71 @@ When writing or modifying code, documentation, or comments:
 
 Note: Renesas RX and other external APIs may still use legacy terminology internally. Map these to our terminology in comments and documentation.
 
+## Backward Compatibility Policy
+
+**IMPORTANT:** This project has not released any versions yet. There is **NO backward compatibility requirement**.
+
+- Do NOT add function aliases or deprecation macros for renamed functions
+- Do NOT keep old API signatures "for compatibility"
+- When refactoring, update all call sites directly - no shims or compatibility layers
+- Clean code now is better than technical debt for non-existent users
+
+**Example - What NOT to do:**
+```c
+// WRONG - No backward compatibility needed!
+#define old_function_name new_function_name  /* ❌ Delete old code instead */
+```
+
+**Example - What to do:**
+```c
+// CORRECT - Just update the function name and all call sites
+rx_err_t new_function_name(...)  /* ✓ Clean break, no compatibility layer */
+```
+
+## Constants and Macros Policy
+
+**Strict hierarchy for constants:**
+
+1. **Enums** - ALWAYS use for ALL integer constants (mandatory)
+2. **static const** - ONLY for floating-point values (enum can't hold floats)
+3. **Macros** - ONLY for these 4 specific cases:
+   - Reducing duplicated code (function-like macros: `RX_RETURN_ON_ERROR`)
+   - Conditional compilation (optimization: `#if LOG_LEVEL >= k_log_error`)
+   - Hardware register addresses (`#define CMT0_BASE ((type*)0x00088000)`)
+   - Build configuration flags (`#ifdef __RX__`)
+
+**Never use macros for:**
+- Simple integer constants (use enum instead)
+- Simple floating-point constants (use static const instead)
+- Backward compatibility/function aliases (no releases = no compatibility)
+
+**Examples:**
+```c
+// ✓ CORRECT - Integer constants use enum
+typedef enum {
+    k_timeout_ms  = 1000,
+    k_max_retries = 3
+} limits_t;
+
+// ✓ CORRECT - Floats use const (enum limitation)
+static const float s_max_velocity_mps = 2.5f;
+
+// ✓ CORRECT - Function-like macro reduces duplication
+#define RX_RETURN_ON_ERROR(err, tag, msg) \
+    do { \
+        rx_err_t _err = (err); \
+        if (_err != k_rx_ok) { \
+            rx_log_error((tag), (msg)); \
+            return _err; \
+        } \
+    } while (0)
+
+// ❌ WRONG - Never use macro for simple constants
+#define TIMEOUT_MS 1000        // Should be enum!
+#define MAX_VELOCITY 2.5f      // Should be static const!
+#define old_func new_func      // No compatibility needed!
+```
+
 ## Project Overview
 
 **STAR (Simultaneous Tracking and Robotics)** - A distributed robotics platform with custom PCB hardware, embedded firmware, and high-level control software.


### PR DESCRIPTION
## Summary

- Implements Claude Code skill for automated code review
- Validates compliance with NASA Power of 10 rules
- Checks SOLID principles (especially DIP)
- Enforces project C style guide conventions

## Files Added

| File | Purpose |
|------|---------|
| `.claude/skills/code-review/SKILL.md` | Main skill definition with checklists |
| `.claude/skills/code-review/STANDARDS.md` | Detailed reference documentation |

## Usage

Invoke the skill by requesting a code review:
```
Review the code in star-rx72n-firmware/lib/rx_motor/
```

The agent will:
1. Glob for `*.c` and `*.h` files
2. Analyze each file against the checklists
3. Generate a structured markdown report

## NASA Power of 10 Rules Covered

1. No goto/setjmp/longjmp/recursion
2. Fixed loop upper-bounds
3. No dynamic memory after init
4. Functions under ~60 lines
5. Minimum 2 assertions per function
6. Declare data at smallest scope
7. Check all return values
8. Limit preprocessor use
9. Restrict pointers (with DIP exception)
10. Compile with maximum warnings

## SOLID Principles Covered

- Single Responsibility
- Open/Closed
- Liskov Substitution
- Interface Segregation
- Dependency Inversion (via function pointer interfaces)

## Test Plan

- [ ] Invoke skill on `star-rx72n-firmware/lib/rx_hal/`
- [ ] Verify report format matches specification
- [ ] Compare against existing `star-rx72n-firmware/reviews/` output

Closes #71