### PR TITLE
fix: refactor motors to use GPTW instead of MTU

### DIFF
--- a/star-rx72n-firmware/CMakeLists.txt
+++ b/star-rx72n-firmware/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(rx_hal STATIC
     lib/rx_hal/src/riic.c
     lib/rx_hal/src/rspi.c
     lib/rx_hal/src/rx_mtu3a.c
+    lib/rx_hal/src/rx_gptw.c
     lib/rx_hal/src/rx_cmt.c
     lib/rx_hal/src/rx_mpc.c
 )
@@ -314,10 +315,10 @@ message(STATUS "Build Type:       ${CMAKE_BUILD_TYPE}")
 message(STATUS "C Compiler:       ${CMAKE_C_COMPILER}")
 message(STATUS "==============================================")
 message(STATUS "Libraries:")
-message(STATUS "  rx_hal         - Hardware abstraction (MTU, CMT, GPIO, UART)")
+message(STATUS "  rx_hal         - Hardware abstraction (GPTW, MTU, CMT, GPIO, UART)")
 message(STATUS "  rx_core        - Core infrastructure (error, logging, DIP)")
 message(STATUS "  rx_bus         - Bus manager (GPIO, ADC, I2C, SMBUS)")
-message(STATUS "  rx_motor       - Motor control (MTU3a PWM)")
+message(STATUS "  rx_motor       - Motor control (GPTW PWM)")
 message(STATUS "  rx_encoder     - Encoder (MTU phase counting)")
 message(STATUS "  rx_pid         - PID controller")
 message(STATUS "  rx_fec         - FEC codec (K=7 convolutional + Viterbi)")

--- a/star-rx72n-firmware/lib/rx_drv8243/inc/rx_drv8243.h
+++ b/star-rx72n-firmware/lib/rx_drv8243/inc/rx_drv8243.h
@@ -19,8 +19,8 @@
  * - PWM frequency: up to 25 kHz
  *
  * Hardware Connections:
- * - RX72N MTU PWM_A -> DRV8243 PH (Phase/Direction)
- * - RX72N MTU PWM_B -> DRV8243 EN (Enable/Speed)
+ * - RX72N GPTW PWM_A -> DRV8243 PH (Phase/Direction)
+ * - RX72N GPTW PWM_B -> DRV8243 EN (Enable/Speed)
  * - DRV8243 IPROPI -> RX72N ADC (Current sense)
  * - DRV8243 nFAULT -> RX72N GPIO (Fault detect)
  *
@@ -32,9 +32,9 @@
  *     .bus_manager = &bus_manager,
  *     .gpio_bus_name = "gpio_bus",
  *     .adc_bus_name = "adc_bus",
- *     .mtu_channel = k_mtu_channel_3,
- *     .output_ph = k_mtu_output_a,
- *     .output_en = k_mtu_output_b,
+ *     .gptw_channel = k_gptw_channel_3,
+ *     .output_ph = k_gptw_output_a,
+ *     .output_en = k_gptw_output_b,
  *     .pin_ipropi = k_adc_channel_0,
  *     .port_nfault = 3, .pin_nfault = 2,  // PORT3.2
  *     .pwm_freq_hz = 20000,
@@ -103,9 +103,9 @@ typedef struct {
   const char*       adc_bus_name;  /**< ADC bus name for current sense (required) */
 
   /* Motor control configuration */
-  rx_mtu_channel_t mtu_channel; /**< MTU channel for PWM */
-  rx_mtu_output_t  output_ph;   /**< PWM output for phase/direction (MTIOC) */
-  rx_mtu_output_t  output_en;   /**< PWM output for enable/speed (MTIOC) */
+  rx_gptw_channel_t gptw_channel; /**< GPTW channel for PWM */
+  rx_gptw_output_t  output_ph;    /**< PWM output for phase/direction (GTIOC) */
+  rx_gptw_output_t  output_en;    /**< PWM output for enable/speed (GTIOC) */
 
   /* Monitoring pins */
   uint8_t pin_ipropi;  /**< Current sense ADC channel (0-7) */
@@ -129,7 +129,7 @@ typedef struct {
   const char*       gpio_bus_name; /**< GPIO bus name (not owned) */
   const char*       adc_bus_name;  /**< ADC bus name (not owned) */
 
-  rx_motor_handle_t motor; /**< Underlying MTU motor control handle */
+  rx_motor_handle_t motor; /**< Underlying GPTW motor control handle */
 
   /* Pin assignments */
   uint8_t pin_ipropi;  /**< Current sense ADC channel (0-7) */

--- a/star-rx72n-firmware/lib/rx_drv8243/src/rx_drv8243.c
+++ b/star-rx72n-firmware/lib/rx_drv8243/src/rx_drv8243.c
@@ -94,9 +94,9 @@ rx_err_t rx_drv8243_init(rx_drv8243_handle_t* handle, const rx_drv8243_config_t*
   handle->current_limit_ma = config->current_limit_ma;
   handle->ki_propi         = config->ki_propi > 0 ? config->ki_propi : k_drv8243_default_ki_propi;
 
-  /* Initialize motor control (MTU for H-bridge) */
+  /* Initialize motor control (GPTW for H-bridge) */
   rx_motor_config_t motor_config = {
-    .channel      = config->mtu_channel,
+    .channel      = config->gptw_channel,
     .output_a     = config->output_ph,
     .output_b     = config->output_en,
     .pwm_freq_hz  = config->pwm_freq_hz,

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_gptw_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_gptw_regs.h
@@ -128,24 +128,41 @@ typedef struct {
  * need verification against the official RX72N Hardware Manual.
  */
 
-/** @brief Channel spacing between GPTW registers */
-#define GPTW_CHANNEL_OFFSET (0x100)
+/** @brief GPTW hardware addresses (tentative - verify against HW manual) */
+typedef enum {
+  k_gptw_channel_offset = 0x100,   /**< Channel spacing between GPTW registers */
+  k_gptw_common_addr    = 0x000D3000, /**< GPTW common registers base */
+  k_gptw0_base_addr     = 0x000D4000, /**< GPTW channel 0 base address */
+  k_gptw1_base_addr     = 0x000D4100, /**< GPTW channel 1 base address */
+  k_gptw2_base_addr     = 0x000D4200, /**< GPTW channel 2 base address */
+  k_gptw3_base_addr     = 0x000D4300, /**< GPTW channel 3 base address */
+} gptw_addresses_t;
 
-/** @brief GPTW common registers base (tentative) */
-#define GPTW_COMMON_BASE ((rx_gptw_common_regs_t*)0x000D3000)
+/** @brief GPTW register inline accessor functions */
+static inline volatile rx_gptw_common_regs_t* gptw_common(void)
+{
+  return (volatile rx_gptw_common_regs_t*)k_gptw_common_addr;
+}
 
-/** @brief GPTW channel base addresses (tentative - verify against HW manual) */
-#define GPTW0_BASE ((rx_gptw_channel_regs_t*)0x000D4000)
-#define GPTW1_BASE ((rx_gptw_channel_regs_t*)0x000D4100)
-#define GPTW2_BASE ((rx_gptw_channel_regs_t*)0x000D4200)
-#define GPTW3_BASE ((rx_gptw_channel_regs_t*)0x000D4300)
+static inline volatile rx_gptw_channel_regs_t* gptw0(void)
+{
+  return (volatile rx_gptw_channel_regs_t*)k_gptw0_base_addr;
+}
 
-/** @brief GPTW register access macros */
-#define GPTW_COMMON (*GPTW_COMMON_BASE)
-#define GPTW0       (*GPTW0_BASE)
-#define GPTW1       (*GPTW1_BASE)
-#define GPTW2       (*GPTW2_BASE)
-#define GPTW3       (*GPTW3_BASE)
+static inline volatile rx_gptw_channel_regs_t* gptw1(void)
+{
+  return (volatile rx_gptw_channel_regs_t*)k_gptw1_base_addr;
+}
+
+static inline volatile rx_gptw_channel_regs_t* gptw2(void)
+{
+  return (volatile rx_gptw_channel_regs_t*)k_gptw2_base_addr;
+}
+
+static inline volatile rx_gptw_channel_regs_t* gptw3(void)
+{
+  return (volatile rx_gptw_channel_regs_t*)k_gptw3_base_addr;
+}
 
 /* =============================================================================
  * Write Protection Register (GTWP) Bits

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_gptw_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_gptw_regs.h
@@ -3,7 +3,7 @@
 /**
  * @file rx72n_gptw_regs.h
  * @brief RX72N GPTW (General PWM Timer) Register Definitions
- *
+ * @details
  * Register definitions for the General PWM Timer (GPTW) used for motor PWM
  * generation. The GPTW provides 32-bit resolution and is optimized for
  * motor control applications.
@@ -129,7 +129,7 @@ typedef struct {
  */
 
 /** @brief Channel spacing between GPTW registers */
-#define GPTW_CHANNEL_OFFSET 0x100
+#define GPTW_CHANNEL_OFFSET (0x100)
 
 /** @brief GPTW common registers base (tentative) */
 #define GPTW_COMMON_BASE ((rx_gptw_common_regs_t*)0x000D3000)

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_gptw_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_gptw_regs.h
@@ -1,0 +1,307 @@
+/* lib/rx_hal/inc/rx72n_gptw_regs.h */
+
+/**
+ * @file rx72n_gptw_regs.h
+ * @brief RX72N GPTW (General PWM Timer) Register Definitions
+ *
+ * Register definitions for the General PWM Timer (GPTW) used for motor PWM
+ * generation. The GPTW provides 32-bit resolution and is optimized for
+ * motor control applications.
+ *
+ * @warning Base addresses are derived from the hirakuni45/RX open-source
+ * framework. These addresses MUST be verified against the official RX72N
+ * Hardware Manual (R01UH0883EJ) before production use.
+ *
+ * @see https://github.com/hirakuni45/RX/blob/master/RX600/gptw.hpp
+ * @see RX72N Hardware Manual Section 20: General PWM Timer (GPT)
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef STAR_RX72N_GPTW_REGS_H
+#define STAR_RX72N_GPTW_REGS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * General PWM Timer (GPTW) - 32-bit PWM for Motor Control
+ * =============================================================================
+ *
+ * GPTW Features:
+ * - 32-bit counter resolution (vs MTU's 16-bit)
+ * - 4 independent channels (GPTW0-GPTW3)
+ * - Each channel has 2 outputs (GTIOCA, GTIOCB)
+ * - Optimized for motor PWM generation
+ * - Dead-time control for H-bridge safety
+ *
+ * Pin Mapping (Port E):
+ * - GPTW0: PE5/GTIOC0A, PE2/GTIOC0B
+ * - GPTW1: PE4/GTIOC1A, PE1/GTIOC1B
+ * - GPTW2: PE3/GTIOC2A, PE0/GTIOC2B
+ * - GPTW3: PE7/GTIOC3A, PE6/GTIOC3B
+ */
+
+/**
+ * @brief GPTW Channel Register Map
+ * @details
+ * General PWM Timer channel registers for 32-bit PWM generation.
+ *
+ * @warning Base addresses derived from hirakuni45/RX framework.
+ * Verify against RX72N Hardware Manual before production use.
+ *
+ * Channel base addresses (tentative - needs verification):
+ * - GPTW0: 0x000D4000
+ * - GPTW1: 0x000D4100
+ * - GPTW2: 0x000D4200
+ * - GPTW3: 0x000D4300
+ */
+typedef struct {
+  volatile uint32_t gtwp;     /**< 0x00: Write Protection Register */
+  volatile uint32_t gtstr;    /**< 0x04: Software Start Register */
+  volatile uint32_t gtstp;    /**< 0x08: Software Stop Register */
+  volatile uint32_t gtclr;    /**< 0x0C: Software Clear Register */
+  volatile uint32_t gtssr;    /**< 0x10: Start Source Select Register */
+  volatile uint32_t gtpsr;    /**< 0x14: Stop Source Select Register */
+  volatile uint32_t gtcsr;    /**< 0x18: Clear Source Select Register */
+  volatile uint32_t gtupsr;   /**< 0x1C: Count-Up Source Select Register */
+  volatile uint32_t gtdnsr;   /**< 0x20: Count-Down Source Select Register */
+  volatile uint32_t gticasr;  /**< 0x24: Input Capture Source Select A */
+  volatile uint32_t gticbsr;  /**< 0x28: Input Capture Source Select B */
+  volatile uint32_t gtcr;     /**< 0x2C: Control Register */
+  volatile uint32_t gtuddtyc; /**< 0x30: Up/Down Count Duty Setting */
+  volatile uint32_t gtior;    /**< 0x34: I/O Control Register */
+  volatile uint32_t gtintad;  /**< 0x38: Interrupt Output Setting */
+  volatile uint32_t gtst;     /**< 0x3C: Status Register */
+  volatile uint32_t gtber;    /**< 0x40: Buffer Enable Register */
+  volatile uint32_t gtitc;    /**< 0x44: Interrupt/ADC Trigger Control */
+  volatile uint32_t gtcnt;    /**< 0x48: Counter */
+  volatile uint32_t gtccra;   /**< 0x4C: Compare Capture Register A */
+  volatile uint32_t gtccrb;   /**< 0x50: Compare Capture Register B */
+  volatile uint32_t gtccrc;   /**< 0x54: Compare Capture Register C */
+  volatile uint32_t gtccre;   /**< 0x58: Compare Capture Register E */
+  volatile uint32_t gtccrd;   /**< 0x5C: Compare Capture Register D */
+  volatile uint32_t gtccrf;   /**< 0x60: Compare Capture Register F */
+  volatile uint32_t gtpr;     /**< 0x64: Cycle Setting Register (Period) */
+  volatile uint32_t gtpbr;    /**< 0x68: Cycle Setting Buffer Register */
+  volatile uint32_t gtpdbr;   /**< 0x6C: Cycle Setting Double Buffer */
+  volatile uint32_t gtadtra;  /**< 0x70: A/D Trigger Register A */
+  volatile uint32_t gtadtbra; /**< 0x74: A/D Trigger Buffer Register A */
+  volatile uint32_t gtadtdbra; /**< 0x78: A/D Trigger Double Buffer A */
+  volatile uint32_t gtadtrb;   /**< 0x7C: A/D Trigger Register B */
+  volatile uint32_t gtadtbrb;  /**< 0x80: A/D Trigger Buffer Register B */
+  volatile uint32_t gtadtdbrb; /**< 0x84: A/D Trigger Double Buffer B */
+  volatile uint32_t gtdtcr;    /**< 0x88: Dead Time Control Register */
+  volatile uint32_t gtdvu;     /**< 0x8C: Dead Time Value Upper */
+  volatile uint32_t gtdvd;     /**< 0x90: Dead Time Value Down */
+  volatile uint32_t gtdbu;     /**< 0x94: Dead Time Buffer Upper */
+  volatile uint32_t gtdbd;     /**< 0x98: Dead Time Buffer Down */
+  volatile uint32_t gtsos;     /**< 0x9C: Output Protection */
+  volatile uint32_t gtsotr;    /**< 0xA0: Output Protection Trigger */
+} rx_gptw_channel_regs_t;
+
+/**
+ * @brief GPTW Common Register Map
+ * @details
+ * Shared registers for all GPTW channels (start/stop control).
+ * Base address: 0x000D3000 (tentative - needs verification)
+ */
+typedef struct {
+  volatile uint32_t gtstra;  /**< 0x00: General Timer Start Register A */
+  volatile uint32_t gtstpa;  /**< 0x04: General Timer Stop Register A */
+  volatile uint32_t gtclra;  /**< 0x08: General Timer Clear Register A */
+  uint32_t          reserved0[5]; /**< Reserved */
+  volatile uint32_t gtstra2; /**< 0x20: General Timer Start Register A2 */
+  volatile uint32_t gtstpa2; /**< 0x24: General Timer Stop Register A2 */
+  volatile uint32_t gtclra2; /**< 0x28: General Timer Clear Register A2 */
+} rx_gptw_common_regs_t;
+
+/* =============================================================================
+ * Base Address Definitions
+ * =============================================================================
+ *
+ * WARNING: These addresses are derived from hirakuni45/RX framework and
+ * need verification against the official RX72N Hardware Manual.
+ */
+
+/** @brief Channel spacing between GPTW registers */
+#define GPTW_CHANNEL_OFFSET 0x100
+
+/** @brief GPTW common registers base (tentative) */
+#define GPTW_COMMON_BASE ((rx_gptw_common_regs_t*)0x000D3000)
+
+/** @brief GPTW channel base addresses (tentative - verify against HW manual) */
+#define GPTW0_BASE ((rx_gptw_channel_regs_t*)0x000D4000)
+#define GPTW1_BASE ((rx_gptw_channel_regs_t*)0x000D4100)
+#define GPTW2_BASE ((rx_gptw_channel_regs_t*)0x000D4200)
+#define GPTW3_BASE ((rx_gptw_channel_regs_t*)0x000D4300)
+
+/** @brief GPTW register access macros */
+#define GPTW_COMMON (*GPTW_COMMON_BASE)
+#define GPTW0       (*GPTW0_BASE)
+#define GPTW1       (*GPTW1_BASE)
+#define GPTW2       (*GPTW2_BASE)
+#define GPTW3       (*GPTW3_BASE)
+
+/* =============================================================================
+ * Write Protection Register (GTWP) Bits
+ * =============================================================================
+ */
+
+typedef enum {
+  k_gptw_gtwp_wp0    = (1 << 0), /**< Register write protect bit 0 */
+  k_gptw_gtwp_wp1    = (1 << 1), /**< Register write protect bit 1 */
+  k_gptw_gtwp_wp2    = (1 << 2), /**< Register write protect bit 2 */
+  k_gptw_gtwp_wp3    = (1 << 3), /**< Register write protect bit 3 */
+  k_gptw_gtwp_unlock = 0xA500,   /**< Write protection unlock key */
+  k_gptw_gtwp_lock   = 0xA501,   /**< Write protection lock key */
+} gptw_gtwp_bits_t;
+
+/* =============================================================================
+ * Control Register (GTCR) Bits
+ * =============================================================================
+ */
+
+typedef enum {
+  /* Counter Start bit */
+  k_gptw_gtcr_cst = (1 << 0), /**< Counter Start (0=stop, 1=count) */
+
+  /* Timer Prescaler Select (bits 24-26) */
+  k_gptw_gtcr_tpcs_shift = 24,
+  k_gptw_gtcr_tpcs_mask  = (0x07 << 24),
+  k_gptw_gtcr_tpcs_1     = (0x00 << 24), /**< PCLKA/1 */
+  k_gptw_gtcr_tpcs_4     = (0x01 << 24), /**< PCLKA/4 */
+  k_gptw_gtcr_tpcs_16    = (0x02 << 24), /**< PCLKA/16 */
+  k_gptw_gtcr_tpcs_64    = (0x03 << 24), /**< PCLKA/64 */
+  k_gptw_gtcr_tpcs_256   = (0x04 << 24), /**< PCLKA/256 */
+  k_gptw_gtcr_tpcs_1024  = (0x05 << 24), /**< PCLKA/1024 */
+
+  /* Mode Select (bits 16-18) */
+  k_gptw_gtcr_md_shift     = 16,
+  k_gptw_gtcr_md_mask      = (0x07 << 16),
+  k_gptw_gtcr_md_saw_1shot = (0x00 << 16), /**< Sawtooth wave one-shot */
+  k_gptw_gtcr_md_saw_cont  = (0x01 << 16), /**< Sawtooth wave continuous */
+  k_gptw_gtcr_md_tri_1shot = (0x04 << 16), /**< Triangle wave one-shot */
+  k_gptw_gtcr_md_tri_cont  = (0x05 << 16), /**< Triangle wave continuous */
+} gptw_gtcr_bits_t;
+
+/* =============================================================================
+ * I/O Control Register (GTIOR) Bits
+ * =============================================================================
+ */
+
+typedef enum {
+  /* GTIOCA Output Control (bits 0-4) */
+  k_gptw_gtior_oa_shift      = 0,
+  k_gptw_gtior_oa_mask       = 0x1F,
+  k_gptw_gtior_oa_disabled   = 0x00, /**< Output disabled */
+  k_gptw_gtior_oa_low_cmpup  = 0x01, /**< Low on compare match (up) */
+  k_gptw_gtior_oa_high_cmpup = 0x02, /**< High on compare match (up) */
+  k_gptw_gtior_oa_toggle     = 0x03, /**< Toggle on compare match */
+  k_gptw_gtior_oa_init_low   = 0x09, /**< Initial low, PWM output */
+  k_gptw_gtior_oa_init_high  = 0x0A, /**< Initial high, PWM output */
+
+  /* GTIOCA Output Enable (bit 6) */
+  k_gptw_gtior_oae = (1 << 6), /**< GTIOCA Output Enable */
+
+  /* GTIOCB Output Control (bits 16-20) */
+  k_gptw_gtior_ob_shift      = 16,
+  k_gptw_gtior_ob_mask       = (0x1F << 16),
+  k_gptw_gtior_ob_disabled   = (0x00 << 16), /**< Output disabled */
+  k_gptw_gtior_ob_low_cmpup  = (0x01 << 16), /**< Low on compare match (up) */
+  k_gptw_gtior_ob_high_cmpup = (0x02 << 16), /**< High on compare match (up) */
+  k_gptw_gtior_ob_toggle     = (0x03 << 16), /**< Toggle on compare match */
+  k_gptw_gtior_ob_init_low   = (0x09 << 16), /**< Initial low, PWM output */
+  k_gptw_gtior_ob_init_high  = (0x0A << 16), /**< Initial high, PWM output */
+
+  /* GTIOCB Output Enable (bit 22) */
+  k_gptw_gtior_obe = (1 << 22), /**< GTIOCB Output Enable */
+} gptw_gtior_bits_t;
+
+/* =============================================================================
+ * Buffer Enable Register (GTBER) Bits
+ * =============================================================================
+ */
+
+typedef enum {
+  k_gptw_gtber_ccra_buf = (1 << 0),  /**< GTCCRA buffer enable */
+  k_gptw_gtber_ccrb_buf = (1 << 1),  /**< GTCCRB buffer enable */
+  k_gptw_gtber_pr_buf   = (1 << 16), /**< GTPR buffer enable */
+} gptw_gtber_bits_t;
+
+/* =============================================================================
+ * Dead Time Control Register (GTDTCR) Bits
+ * =============================================================================
+ */
+
+typedef enum {
+  k_gptw_gtdtcr_tde  = (1 << 0), /**< Dead time enable */
+  k_gptw_gtdtcr_tdfe = (1 << 4), /**< Dead time buffer enable */
+} gptw_gtdtcr_bits_t;
+
+/* =============================================================================
+ * Status Register (GTST) Bits
+ * =============================================================================
+ */
+
+typedef enum {
+  k_gptw_gtst_tcfa  = (1 << 0),  /**< Compare match flag A */
+  k_gptw_gtst_tcfb  = (1 << 1),  /**< Compare match flag B */
+  k_gptw_gtst_tcfc  = (1 << 2),  /**< Compare match flag C */
+  k_gptw_gtst_tcfd  = (1 << 3),  /**< Compare match flag D */
+  k_gptw_gtst_tcfe  = (1 << 4),  /**< Compare match flag E */
+  k_gptw_gtst_tcff  = (1 << 5),  /**< Compare match flag F */
+  k_gptw_gtst_tcfpo = (1 << 6),  /**< Overflow flag (at period) */
+  k_gptw_gtst_tcfpu = (1 << 7),  /**< Underflow flag (at 0) */
+  k_gptw_gtst_tucf  = (1 << 15), /**< Count direction flag (1=up) */
+} gptw_gtst_bits_t;
+
+/* =============================================================================
+ * Start/Stop Register Bits (GTSTRA)
+ * =============================================================================
+ */
+
+typedef enum {
+  k_gptw_gtstr_cst0 = (1 << 0), /**< Channel 0 count start */
+  k_gptw_gtstr_cst1 = (1 << 1), /**< Channel 1 count start */
+  k_gptw_gtstr_cst2 = (1 << 2), /**< Channel 2 count start */
+  k_gptw_gtstr_cst3 = (1 << 3), /**< Channel 3 count start */
+} gptw_gtstr_bits_t;
+
+/* =============================================================================
+ * Module Stop Control (MSTPCRC)
+ * =============================================================================
+ */
+
+typedef enum {
+  /**
+   * @brief GPTW module stop bit in MSTPCRC
+   * @warning Verify this bit position against RX72N Hardware Manual.
+   * Different RX series may use different bit positions.
+   */
+  k_mstpc_gptw = 6, /**< GPTW module stop bit in MSTPCRC */
+} gptw_module_stop_bits_t;
+
+/* =============================================================================
+ * MPC PFS Select Values for GPTW Pins
+ * =============================================================================
+ */
+
+typedef enum {
+  /**
+   * @brief Peripheral select value for GPTW outputs on Port E
+   * @warning Verify this value against RX72N Hardware Manual.
+   * PSEL values are chip-specific.
+   */
+  k_pfs_psel_gptw = 0x14, /**< PSEL value for GPTW alternate function */
+} gptw_mpc_psel_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STAR_RX72N_GPTW_REGS_H */

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_regs.h
@@ -98,11 +98,18 @@ extern "C" {
 #include "rx72n_usb_regs.h"
 
 /* =============================================================================
- * Multi-Function Timer Unit (MTU3a)
+ * Multi-Function Timer Unit (MTU3a) - Encoder Quadrature Counting
  * =============================================================================
  */
 
 #include "rx72n_mtu_regs.h"
+
+/* =============================================================================
+ * General PWM Timer (GPTW) - Motor PWM Generation
+ * =============================================================================
+ */
+
+#include "rx72n_gptw_regs.h"
 
 /* =============================================================================
  * Multi-Function Pin Controller (MPC)

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx_gptw.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx_gptw.h
@@ -1,0 +1,215 @@
+/* lib/rx_hal/inc/rx_gptw.h */
+
+/**
+ * @file rx_gptw.h
+ * @brief GPTW PWM Driver for RX72N Motor Control
+ * @details
+ * General PWM Timer (GPTW) driver for brushed DC motor control.
+ *
+ * The GPTW provides:
+ * - 4 timer channels (GPTW0-GPTW3)
+ * - 32-bit resolution (vs MTU's 16-bit)
+ * - Optimized for PWM motor control
+ * - Complementary outputs for H-bridge control
+ * - Configurable deadtime for shoot-through protection
+ * - Up to 120MHz operation (PCLKA)
+ *
+ * For 4-motor control (as per hardware_pinout.h):
+ * - Motor 0: GPTW0 channel (PE5/GTIOC0A, PE2/GTIOC0B)
+ * - Motor 1: GPTW1 channel (PE4/GTIOC1A, PE1/GTIOC1B)
+ * - Motor 2: GPTW2 channel (PE3/GTIOC2A, PE0/GTIOC2B)
+ * - Motor 3: GPTW3 channel (PE7/GTIOC3A, PE6/GTIOC3B)
+ *
+ * PWM Configuration:
+ * - Frequency: 20 kHz (typical for motor control)
+ * - Resolution: ~6000 counts at 20kHz (PCLKA=120MHz)
+ * - Duty cycle: 0-100% (0-period counts)
+ * - Deadtime: ~1 us (configurable)
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef STAR_RX72N_GPTW_H
+#define STAR_RX72N_GPTW_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "rx_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Type Definitions
+ * =============================================================================
+ */
+
+/**
+ * @brief GPTW channel identifiers
+ */
+typedef enum {
+  k_gptw_channel_0 = 0, /**< GPTW0 - Motor 0 */
+  k_gptw_channel_1 = 1, /**< GPTW1 - Motor 1 */
+  k_gptw_channel_2 = 2, /**< GPTW2 - Motor 2 */
+  k_gptw_channel_3 = 3, /**< GPTW3 - Motor 3 */
+} rx_gptw_channel_t;
+
+/**
+ * @brief GPTW output channel (for complementary PWM)
+ */
+typedef enum {
+  k_gptw_output_a = 0, /**< GTIOCA output */
+  k_gptw_output_b = 1, /**< GTIOCB output */
+} rx_gptw_output_t;
+
+/**
+ * @brief GPTW PWM configuration
+ */
+typedef struct {
+  uint32_t frequency_hz;         /**< PWM frequency in Hz (e.g., 20000 for 20kHz) */
+  uint16_t deadtime_ns;          /**< Deadtime in nanoseconds (e.g., 1000 for 1us) */
+  bool     enable_complementary; /**< Enable complementary outputs */
+  bool     invert_polarity;      /**< Invert PWM polarity */
+} rx_gptw_config_t;
+
+/* =============================================================================
+ * Public API
+ * =============================================================================
+ */
+
+/**
+ * @brief Initialize GPTW channel for PWM output
+ *
+ * Configures GPTW channel for PWM mode (sawtooth or triangle wave).
+ * Automatically configures MPC for Port E pin alternate functions.
+ * Enables timer and starts PWM generation at 0% duty cycle.
+ *
+ * @param[in] channel GPTW channel (0-3)
+ * @param[in] config PWM configuration
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel or config is invalid
+ * @return k_rx_err_invalid_state if GPTW module not enabled
+ */
+rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* config);
+
+/**
+ * @brief Set PWM duty cycle
+ *
+ * Updates duty cycle for specified output channel.
+ * Change takes effect on next PWM period for glitch-free operation.
+ *
+ * @param[in] channel GPTW channel (0-3)
+ * @param[in] output Output channel (A/B)
+ * @param[in] duty_percent Duty cycle in percent (0.0 - 100.0)
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel, output, or duty is invalid
+ * @return k_rx_err_invalid_state if channel not initialized
+ */
+rx_err_t rx_gptw_set_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float duty_percent);
+
+/**
+ * @brief Set PWM duty cycle (raw count value)
+ *
+ * Updates duty cycle using raw counter value for efficiency.
+ * Useful in tight control loops where floating-point calculation overhead
+ * should be avoided.
+ *
+ * @param[in] channel GPTW channel (0-3)
+ * @param[in] output Output channel (A/B)
+ * @param[in] duty_count Duty cycle count (0 - period_count)
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel, output, or count is invalid
+ * @return k_rx_err_invalid_state if channel not initialized
+ */
+rx_err_t rx_gptw_set_duty_raw(rx_gptw_channel_t channel, rx_gptw_output_t output, uint32_t duty_count);
+
+/**
+ * @brief Get current duty cycle
+ *
+ * @param[in] channel GPTW channel (0-3)
+ * @param[in] output Output channel (A/B)
+ * @param[out] duty_percent Pointer to store duty cycle in percent
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if duty_percent is NULL
+ * @return k_rx_err_invalid_arg if channel or output is invalid
+ * @return k_rx_err_invalid_state if channel not initialized
+ */
+rx_err_t rx_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float* duty_percent);
+
+/**
+ * @brief Get PWM period count
+ *
+ * Returns the period register value (useful for raw duty cycle calculations).
+ *
+ * @param[in] channel GPTW channel (0-3)
+ * @param[out] period_count Pointer to store period count
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_null_pointer if period_count is NULL
+ * @return k_rx_err_invalid_arg if channel is invalid
+ * @return k_rx_err_invalid_state if channel not initialized
+ */
+rx_err_t rx_gptw_get_period(rx_gptw_channel_t channel, uint32_t* period_count);
+
+/**
+ * @brief Enable or disable PWM output
+ *
+ * @param[in] channel GPTW channel (0-3)
+ * @param[in] output Output channel (A/B)
+ * @param[in] enable True to enable output, false to disable
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel or output is invalid
+ * @return k_rx_err_invalid_state if channel not initialized
+ */
+rx_err_t rx_gptw_enable_output(rx_gptw_channel_t channel, rx_gptw_output_t output, bool enable);
+
+/**
+ * @brief Start GPTW timer
+ *
+ * Starts the timer counter for PWM generation.
+ * Timer is automatically started during init, but can be stopped/restarted.
+ *
+ * @param[in] channel GPTW channel (0-3)
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel is invalid
+ */
+rx_err_t rx_gptw_start(rx_gptw_channel_t channel);
+
+/**
+ * @brief Stop GPTW timer
+ *
+ * Stops the timer counter. PWM outputs will hold their last state.
+ *
+ * @param[in] channel GPTW channel (0-3)
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel is invalid
+ */
+rx_err_t rx_gptw_stop(rx_gptw_channel_t channel);
+
+/**
+ * @brief Deinitialize GPTW channel
+ *
+ * Stops timer, disables outputs, and releases resources.
+ *
+ * @param[in] channel GPTW channel (0-3)
+ *
+ * @return k_rx_ok on success
+ * @return k_rx_err_invalid_arg if channel is invalid
+ */
+rx_err_t rx_gptw_deinit(rx_gptw_channel_t channel);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STAR_RX72N_GPTW_H */

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
@@ -170,40 +170,43 @@ static rx_err_t internal_configure_mpc(rx_gptw_channel_t channel)
    */
 
   /* Unlock MPC write protection */
-  MPC.pwpr = k_mpc_pwpr_b0wi_clear; /* Clear B0WI */
-  MPC.pwpr = k_mpc_pwpr_pfswe_set;  /* Set PFSWE to enable PFS write */
+  mpc()->pwpr = k_mpc_pwpr_b0wi_clear; /* Clear B0WI */
+  mpc()->pwpr = k_mpc_pwpr_pfswe_set;  /* Set PFSWE to enable PFS write */
 
   /* Configure PFS for the appropriate pins
    * PSEL value for GPTW is 0x14 (verify against HW manual)
-   */
+   * Note: Port E PFS registers not in rx_mpc_regs_t structure,
+   * so we use base + offset calculation */
+  volatile uint8_t* pe_pfs = (volatile uint8_t*)((uintptr_t)mpc() + 0x40 + 0xE * 8);
+
   switch (channel) {
     case k_gptw_channel_0:
       /* PE5/GTIOC0A and PE2/GTIOC0B */
-      MPC_PE5PFS = k_pfs_psel_gptw;
-      MPC_PE2PFS = k_pfs_psel_gptw;
+      pe_pfs[5] = k_pfs_psel_gptw;
+      pe_pfs[2] = k_pfs_psel_gptw;
       break;
     case k_gptw_channel_1:
       /* PE4/GTIOC1A and PE1/GTIOC1B */
-      MPC_PE4PFS = k_pfs_psel_gptw;
-      MPC_PE1PFS = k_pfs_psel_gptw;
+      pe_pfs[4] = k_pfs_psel_gptw;
+      pe_pfs[1] = k_pfs_psel_gptw;
       break;
     case k_gptw_channel_2:
       /* PE3/GTIOC2A and PE0/GTIOC2B */
-      MPC_PE3PFS = k_pfs_psel_gptw;
-      MPC_PE0PFS = k_pfs_psel_gptw;
+      pe_pfs[3] = k_pfs_psel_gptw;
+      pe_pfs[0] = k_pfs_psel_gptw;
       break;
     case k_gptw_channel_3:
       /* PE7/GTIOC3A and PE6/GTIOC3B */
-      MPC_PE7PFS = k_pfs_psel_gptw;
-      MPC_PE6PFS = k_pfs_psel_gptw;
+      pe_pfs[7] = k_pfs_psel_gptw;
+      pe_pfs[6] = k_pfs_psel_gptw;
       break;
     default:
-      MPC.pwpr = k_mpc_pwpr_lock; /* Lock before returning error */
+      mpc()->pwpr = k_mpc_pwpr_lock; /* Lock before returning error */
       return k_rx_err_invalid_arg;
   }
 
   /* Lock MPC write protection */
-  MPC.pwpr = k_mpc_pwpr_lock;
+  mpc()->pwpr = k_mpc_pwpr_lock;
 
   return k_rx_ok;
 }
@@ -232,20 +235,20 @@ static void internal_configure_port_pins(rx_gptw_channel_t channel)
    */
   switch (channel) {
     case k_gptw_channel_0:
-      PORTE.pmr |= (1 << k_porte_gptw0_a) | (1 << k_porte_gptw0_b);
-      PORTE.pdr |= (1 << k_porte_gptw0_a) | (1 << k_porte_gptw0_b);
+      porte()->pmr |= (1 << k_porte_gptw0_a) | (1 << k_porte_gptw0_b);
+      porte()->pdr |= (1 << k_porte_gptw0_a) | (1 << k_porte_gptw0_b);
       break;
     case k_gptw_channel_1:
-      PORTE.pmr |= (1 << k_porte_gptw1_a) | (1 << k_porte_gptw1_b);
-      PORTE.pdr |= (1 << k_porte_gptw1_a) | (1 << k_porte_gptw1_b);
+      porte()->pmr |= (1 << k_porte_gptw1_a) | (1 << k_porte_gptw1_b);
+      porte()->pdr |= (1 << k_porte_gptw1_a) | (1 << k_porte_gptw1_b);
       break;
     case k_gptw_channel_2:
-      PORTE.pmr |= (1 << k_porte_gptw2_a) | (1 << k_porte_gptw2_b);
-      PORTE.pdr |= (1 << k_porte_gptw2_a) | (1 << k_porte_gptw2_b);
+      porte()->pmr |= (1 << k_porte_gptw2_a) | (1 << k_porte_gptw2_b);
+      porte()->pdr |= (1 << k_porte_gptw2_a) | (1 << k_porte_gptw2_b);
       break;
     case k_gptw_channel_3:
-      PORTE.pmr |= (1 << k_porte_gptw3_a) | (1 << k_porte_gptw3_b);
-      PORTE.pdr |= (1 << k_porte_gptw3_a) | (1 << k_porte_gptw3_b);
+      porte()->pmr |= (1 << k_porte_gptw3_a) | (1 << k_porte_gptw3_b);
+      porte()->pdr |= (1 << k_porte_gptw3_a) | (1 << k_porte_gptw3_b);
       break;
     default:
       break;
@@ -281,9 +284,9 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
   rx_log_info(s_tag, "Initializing GPTW");
 
   /* Enable GPTW module (clear module stop bit in MSTPCRC) */
-  SYSTEM.prcr = k_gptw_prcr_unlock;
-  SYSTEM.mstpcrc &= ~(1UL << k_mstpc_gptw);
-  SYSTEM.prcr = k_gptw_prcr_lock;
+  system_regs()->prcr = k_gptw_prcr_unlock;
+  system_regs()->mstpcrc &= ~(1UL << k_mstpc_gptw);
+  system_regs()->prcr = k_gptw_prcr_lock;
 
   /* Stop timer before configuration */
   rx_gptw_stop(channel);

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
@@ -51,8 +51,8 @@ typedef enum {
 } gptw_prcr_values_t;
 
 /** @brief Period calculation constants */
-#define GPTW_PERIOD_MAX       (0xFFFFFFFFUL) /**< Maximum valid period (32-bit) */
-#define GPTW_NS_PER_SECOND    (1000000000ULL) /**< Nanoseconds per second for deadtime calc */
+static const uint32_t s_gptw_period_max    = 0xFFFFFFFFUL;  /**< Maximum valid period (32-bit) */
+static const uint64_t s_gptw_ns_per_second = 1000000000ULL; /**< Nanoseconds per second */
 
 typedef enum {
   k_gptw_period_min  = 10, /**< Minimum valid period */
@@ -134,7 +134,7 @@ static rx_err_t internal_calculate_period(uint32_t frequency_hz, uint32_t* perio
   uint32_t period_calc = pclka / frequency_hz;
 
   /* Check if period fits in 32-bit register */
-  if (period_calc > GPTW_PERIOD_MAX) {
+  if (period_calc > s_gptw_period_max) {
     rx_log_error(s_tag, "Frequency too low");
     return k_rx_err_invalid_arg;
   }
@@ -323,7 +323,7 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
   /* Configure dead time if requested */
   if (config->deadtime_ns > 0) {
     /* Calculate dead time count: deadtime_ns * (PCLKA / 1e9) */
-    uint32_t deadtime_count = (uint32_t)((uint64_t)config->deadtime_ns * k_pclka_hz / GPTW_NS_PER_SECOND);
+    uint32_t deadtime_count = (uint32_t)((uint64_t)config->deadtime_ns * k_pclka_hz / s_gptw_ns_per_second);
     gptw->gtdvu = deadtime_count;
     gptw->gtdvd = deadtime_count;
     gptw->gtdtcr = k_gptw_gtdtcr_tde; /* Enable dead time */

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
@@ -207,6 +207,18 @@ static rx_err_t internal_configure_mpc(rx_gptw_channel_t channel)
   return k_rx_ok;
 }
 
+/** @brief Port E pin indices for GPTW motor outputs */
+typedef enum {
+  k_porte_gptw0_a = 5, /**< PE5/GTIOC0A - Motor 0 phase */
+  k_porte_gptw0_b = 2, /**< PE2/GTIOC0B - Motor 0 enable */
+  k_porte_gptw1_a = 4, /**< PE4/GTIOC1A - Motor 1 phase */
+  k_porte_gptw1_b = 1, /**< PE1/GTIOC1B - Motor 1 enable */
+  k_porte_gptw2_a = 3, /**< PE3/GTIOC2A - Motor 2 phase */
+  k_porte_gptw2_b = 0, /**< PE0/GTIOC2B - Motor 2 enable */
+  k_porte_gptw3_a = 7, /**< PE7/GTIOC3A - Motor 3 phase */
+  k_porte_gptw3_b = 6, /**< PE6/GTIOC3B - Motor 3 enable */
+} porte_gptw_pin_t;
+
 /**
  * @brief Configure Port E pins as peripheral outputs
  *
@@ -219,24 +231,20 @@ static void internal_configure_port_pins(rx_gptw_channel_t channel)
    */
   switch (channel) {
     case k_gptw_channel_0:
-      /* PE5 and PE2 */
-      PORTE.pmr |= (1 << 5) | (1 << 2);
-      PORTE.pdr |= (1 << 5) | (1 << 2);
+      PORTE.pmr |= (1 << k_porte_gptw0_a) | (1 << k_porte_gptw0_b);
+      PORTE.pdr |= (1 << k_porte_gptw0_a) | (1 << k_porte_gptw0_b);
       break;
     case k_gptw_channel_1:
-      /* PE4 and PE1 */
-      PORTE.pmr |= (1 << 4) | (1 << 1);
-      PORTE.pdr |= (1 << 4) | (1 << 1);
+      PORTE.pmr |= (1 << k_porte_gptw1_a) | (1 << k_porte_gptw1_b);
+      PORTE.pdr |= (1 << k_porte_gptw1_a) | (1 << k_porte_gptw1_b);
       break;
     case k_gptw_channel_2:
-      /* PE3 and PE0 */
-      PORTE.pmr |= (1 << 3) | (1 << 0);
-      PORTE.pdr |= (1 << 3) | (1 << 0);
+      PORTE.pmr |= (1 << k_porte_gptw2_a) | (1 << k_porte_gptw2_b);
+      PORTE.pdr |= (1 << k_porte_gptw2_a) | (1 << k_porte_gptw2_b);
       break;
     case k_gptw_channel_3:
-      /* PE7 and PE6 */
-      PORTE.pmr |= (1 << 7) | (1 << 6);
-      PORTE.pdr |= (1 << 7) | (1 << 6);
+      PORTE.pmr |= (1 << k_porte_gptw3_a) | (1 << k_porte_gptw3_b);
+      PORTE.pdr |= (1 << k_porte_gptw3_a) | (1 << k_porte_gptw3_b);
       break;
     default:
       break;

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
@@ -3,7 +3,7 @@
 /**
  * @file rx_gptw.c
  * @brief GPTW PWM Driver Implementation for Motor Control
- *
+ * @details
  * General PWM Timer driver for brushed DC motors on RX72N.
  *
  * PWM Mode (Sawtooth Wave - Edge-Aligned):
@@ -51,7 +51,8 @@ typedef enum {
 } gptw_prcr_values_t;
 
 /** @brief Period calculation constants */
-#define GPTW_PERIOD_MAX 0xFFFFFFFFUL /**< Maximum valid period (32-bit) */
+#define GPTW_PERIOD_MAX       (0xFFFFFFFFUL) /**< Maximum valid period (32-bit) */
+#define GPTW_NS_PER_SECOND    (1000000000ULL) /**< Nanoseconds per second for deadtime calc */
 
 typedef enum {
   k_gptw_period_min  = 10, /**< Minimum valid period */
@@ -319,7 +320,7 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
   /* Configure dead time if requested */
   if (config->deadtime_ns > 0) {
     /* Calculate dead time count: deadtime_ns * (PCLKA / 1e9) */
-    uint32_t deadtime_count = (uint32_t)((uint64_t)config->deadtime_ns * k_pclka_hz / 1000000000ULL);
+    uint32_t deadtime_count = (uint32_t)((uint64_t)config->deadtime_ns * k_pclka_hz / GPTW_NS_PER_SECOND);
     gptw->gtdvu = deadtime_count;
     gptw->gtdvd = deadtime_count;
     gptw->gtdtcr = k_gptw_gtdtcr_tde; /* Enable dead time */

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
@@ -1,0 +1,537 @@
+/* lib/rx_hal/src/rx_gptw.c */
+
+/**
+ * @file rx_gptw.c
+ * @brief GPTW PWM Driver Implementation for Motor Control
+ *
+ * General PWM Timer driver for brushed DC motors on RX72N.
+ *
+ * PWM Mode (Sawtooth Wave - Edge-Aligned):
+ * - Counter counts up from 0 to GTPR (period)
+ * - GTCCRA/GTCCRB control duty cycle
+ * - Efficient for H-bridge motor control
+ *
+ * For 20kHz PWM with PCLKA=120MHz:
+ * - Period = PCLKA / frequency = 120MHz / 20kHz = 6000
+ * - Resolution = 6000 counts (approximately 12.5-bit)
+ * - Duty cycle range: 0-6000
+ *
+ * @warning Base addresses derived from hirakuni45/RX framework.
+ * Verify against RX72N Hardware Manual before production use.
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "rx_gptw.h"
+
+#include <stddef.h>
+
+#include "rx72n_regs.h"
+#include "rx_check.h"
+#include "rx_log.h"
+
+static const char* s_tag = "GPTW";
+
+/* =============================================================================
+ * Constants
+ * =============================================================================
+ */
+
+/** @brief GPTW general constants */
+typedef enum {
+  k_gptw_max_channels = 4, /**< GPTW0-GPTW3 */
+  k_gptw_outputs_per_channel = 2, /**< GTIOCA and GTIOCB */
+} gptw_constants_t;
+
+/** @brief System protection register values */
+typedef enum {
+  k_gptw_prcr_unlock = 0xA50B, /**< Enable writes to MSTPCR */
+  k_gptw_prcr_lock   = 0xA500, /**< Disable writes to MSTPCR */
+} gptw_prcr_values_t;
+
+/** @brief Period calculation constants */
+#define GPTW_PERIOD_MAX 0xFFFFFFFFUL /**< Maximum valid period (32-bit) */
+
+typedef enum {
+  k_gptw_period_min  = 10, /**< Minimum valid period */
+  k_gptw_period_zero = 0,  /**< Zero period value */
+} gptw_period_constants_t;
+
+/** @brief Duty cycle calculation constants */
+typedef enum {
+  k_gptw_duty_min     = 0,   /**< Minimum duty cycle (0%) */
+  k_gptw_duty_max     = 100, /**< Maximum duty cycle (100%) */
+  k_gptw_duty_divisor = 100, /**< Divisor for percentage conversion */
+} gptw_duty_constants_t;
+
+/** @brief MPC configuration constants */
+typedef enum {
+  k_mpc_pwpr_b0wi_clear = 0x00, /**< Clear B0WI to enable PFSWE write */
+  k_mpc_pwpr_pfswe_set  = 0x40, /**< Set PFSWE to enable PFS write */
+  k_mpc_pwpr_lock       = 0x80, /**< Set B0WI to lock PFS */
+} mpc_pwpr_constants_t;
+
+/* =============================================================================
+ * Static Variables
+ * =============================================================================
+ */
+
+/** @brief Track initialized channels */
+static bool     s_gptw_initialized[k_gptw_max_channels] = {false};
+/** @brief Period values for each channel */
+static uint32_t s_gptw_period[k_gptw_max_channels]      = {0};
+
+/* =============================================================================
+ * Internal Helper Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Get GPTW channel base address
+ *
+ * @param[in] channel GPTW channel
+ *
+ * @return Pointer to GPTW register base, or NULL if invalid
+ */
+static volatile rx_gptw_channel_regs_t* internal_get_gptw_base(rx_gptw_channel_t channel)
+{
+  switch (channel) {
+    case k_gptw_channel_0:
+      return GPTW0_BASE;
+    case k_gptw_channel_1:
+      return GPTW1_BASE;
+    case k_gptw_channel_2:
+      return GPTW2_BASE;
+    case k_gptw_channel_3:
+      return GPTW3_BASE;
+    default:
+      return NULL;
+  }
+}
+
+/**
+ * @brief Calculate period register value from frequency
+ *
+ * @param[in] frequency_hz Desired PWM frequency in Hz
+ * @param[out] period Pointer to store period value
+ *
+ * @return k_rx_ok on success, k_rx_err_invalid_arg if frequency too high/low
+ */
+static rx_err_t internal_calculate_period(uint32_t frequency_hz, uint32_t* period)
+{
+  /* For PWM mode (sawtooth wave):
+   * Period = PCLKA / frequency
+   * PCLKA = 120 MHz
+   */
+  const uint32_t pclka = k_pclka_hz;
+
+  if (frequency_hz == k_gptw_period_zero) {
+    return k_rx_err_invalid_arg;
+  }
+
+  uint32_t period_calc = pclka / frequency_hz;
+
+  /* Check if period fits in 32-bit register */
+  if (period_calc > GPTW_PERIOD_MAX) {
+    rx_log_error(s_tag, "Frequency too low");
+    return k_rx_err_invalid_arg;
+  }
+
+  if (period_calc < k_gptw_period_min) {
+    rx_log_error(s_tag, "Frequency too high");
+    return k_rx_err_invalid_arg;
+  }
+
+  *period = period_calc;
+  return k_rx_ok;
+}
+
+/**
+ * @brief Configure MPC for GPTW output pins
+ *
+ * Sets up Port E alternate functions for GPTW outputs.
+ *
+ * @param[in] channel GPTW channel to configure
+ *
+ * @return k_rx_ok on success
+ */
+static rx_err_t internal_configure_mpc(rx_gptw_channel_t channel)
+{
+  /* MPC Pin Function Select values for GPTW on Port E
+   * Each channel uses 2 pins (GTIOCA and GTIOCB)
+   *
+   * Pin mapping (from hardware_pinout.h):
+   * - GPTW0: PE5/GTIOC0A, PE2/GTIOC0B
+   * - GPTW1: PE4/GTIOC1A, PE1/GTIOC1B
+   * - GPTW2: PE3/GTIOC2A, PE0/GTIOC2B
+   * - GPTW3: PE7/GTIOC3A, PE6/GTIOC3B
+   */
+
+  /* Unlock MPC write protection */
+  MPC.pwpr = k_mpc_pwpr_b0wi_clear; /* Clear B0WI */
+  MPC.pwpr = k_mpc_pwpr_pfswe_set;  /* Set PFSWE to enable PFS write */
+
+  /* Configure PFS for the appropriate pins
+   * PSEL value for GPTW is 0x14 (verify against HW manual)
+   */
+  switch (channel) {
+    case k_gptw_channel_0:
+      /* PE5/GTIOC0A and PE2/GTIOC0B */
+      MPC_PE5PFS = k_pfs_psel_gptw;
+      MPC_PE2PFS = k_pfs_psel_gptw;
+      break;
+    case k_gptw_channel_1:
+      /* PE4/GTIOC1A and PE1/GTIOC1B */
+      MPC_PE4PFS = k_pfs_psel_gptw;
+      MPC_PE1PFS = k_pfs_psel_gptw;
+      break;
+    case k_gptw_channel_2:
+      /* PE3/GTIOC2A and PE0/GTIOC2B */
+      MPC_PE3PFS = k_pfs_psel_gptw;
+      MPC_PE0PFS = k_pfs_psel_gptw;
+      break;
+    case k_gptw_channel_3:
+      /* PE7/GTIOC3A and PE6/GTIOC3B */
+      MPC_PE7PFS = k_pfs_psel_gptw;
+      MPC_PE6PFS = k_pfs_psel_gptw;
+      break;
+    default:
+      MPC.pwpr = k_mpc_pwpr_lock; /* Lock before returning error */
+      return k_rx_err_invalid_arg;
+  }
+
+  /* Lock MPC write protection */
+  MPC.pwpr = k_mpc_pwpr_lock;
+
+  return k_rx_ok;
+}
+
+/**
+ * @brief Configure Port E pins as peripheral outputs
+ *
+ * @param[in] channel GPTW channel
+ */
+static void internal_configure_port_pins(rx_gptw_channel_t channel)
+{
+  /* Set pins as output and enable peripheral function
+   * PMR = 1 (peripheral mode), PDR = 1 (output)
+   */
+  switch (channel) {
+    case k_gptw_channel_0:
+      /* PE5 and PE2 */
+      PORTE.pmr |= (1 << 5) | (1 << 2);
+      PORTE.pdr |= (1 << 5) | (1 << 2);
+      break;
+    case k_gptw_channel_1:
+      /* PE4 and PE1 */
+      PORTE.pmr |= (1 << 4) | (1 << 1);
+      PORTE.pdr |= (1 << 4) | (1 << 1);
+      break;
+    case k_gptw_channel_2:
+      /* PE3 and PE0 */
+      PORTE.pmr |= (1 << 3) | (1 << 0);
+      PORTE.pdr |= (1 << 3) | (1 << 0);
+      break;
+    case k_gptw_channel_3:
+      /* PE7 and PE6 */
+      PORTE.pmr |= (1 << 7) | (1 << 6);
+      PORTE.pdr |= (1 << 7) | (1 << 6);
+      break;
+    default:
+      break;
+  }
+}
+
+/* =============================================================================
+ * Public API Implementation
+ * =============================================================================
+ */
+
+rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* config)
+{
+  RX_CHECK_NULL_PTR(config, s_tag, "config pointer is NULL");
+
+  if ((int32_t)channel >= k_gptw_max_channels) {
+    rx_log_error(s_tag, "Invalid GPTW channel");
+    return k_rx_err_invalid_arg;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Calculate period from frequency */
+  uint32_t period;
+  rx_err_t err = internal_calculate_period(config->frequency_hz, &period);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  rx_log_info(s_tag, "Initializing GPTW");
+
+  /* Enable GPTW module (clear module stop bit in MSTPCRC) */
+  SYSTEM.prcr = k_gptw_prcr_unlock;
+  SYSTEM.mstpcrc &= ~(1UL << k_mstpc_gptw);
+  SYSTEM.prcr = k_gptw_prcr_lock;
+
+  /* Stop timer before configuration */
+  rx_gptw_stop(channel);
+
+  /* Unlock write protection for this channel */
+  gptw->gtwp = k_gptw_gtwp_unlock;
+
+  /* Configure control register
+   * - PCLKA/1 (120 MHz)
+   * - Sawtooth wave continuous mode
+   */
+  gptw->gtcr = k_gptw_gtcr_tpcs_1 | k_gptw_gtcr_md_saw_cont;
+
+  /* Configure I/O control register
+   * - Initial low, toggle on compare match for both outputs
+   * - Enable both outputs
+   */
+  gptw->gtior = k_gptw_gtior_oa_init_low | k_gptw_gtior_oae |
+                k_gptw_gtior_ob_init_low | k_gptw_gtior_obe;
+
+  /* Set period (GTPR = PWM cycle) */
+  gptw->gtpr = period;
+
+  /* Set initial duty cycle to 0% for both outputs */
+  gptw->gtccra = k_gptw_period_zero;
+  gptw->gtccrb = k_gptw_period_zero;
+
+  /* Clear counter */
+  gptw->gtcnt = k_gptw_period_zero;
+
+  /* Enable buffer operation for glitch-free updates */
+  gptw->gtber = k_gptw_gtber_ccra_buf | k_gptw_gtber_ccrb_buf;
+
+  /* Configure dead time if requested */
+  if (config->deadtime_ns > 0) {
+    /* Calculate dead time count: deadtime_ns * (PCLKA / 1e9) */
+    uint32_t deadtime_count = (uint32_t)((uint64_t)config->deadtime_ns * k_pclka_hz / 1000000000ULL);
+    gptw->gtdvu = deadtime_count;
+    gptw->gtdvd = deadtime_count;
+    gptw->gtdtcr = k_gptw_gtdtcr_tde; /* Enable dead time */
+  }
+
+  /* Lock write protection */
+  gptw->gtwp = k_gptw_gtwp_lock;
+
+  /* Configure MPC for Port E alternate functions */
+  err = internal_configure_mpc(channel);
+  if (err != k_rx_ok) {
+    rx_log_error(s_tag, "Failed to configure MPC");
+    return err;
+  }
+
+  /* Configure port pins */
+  internal_configure_port_pins(channel);
+
+  /* Save period for duty cycle calculations */
+  s_gptw_period[channel]      = period;
+  s_gptw_initialized[channel] = true;
+
+  /* Start timer */
+  rx_gptw_start(channel);
+
+  rx_log_info(s_tag, "GPTW initialized successfully");
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_set_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float duty_percent)
+{
+  if ((int32_t)channel >= k_gptw_max_channels || !s_gptw_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  if (duty_percent < (float)k_gptw_duty_min || duty_percent > (float)k_gptw_duty_max) {
+    rx_log_error(s_tag, "Invalid duty cycle");
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Convert percentage to count value */
+  uint32_t period     = s_gptw_period[channel];
+  uint32_t duty_count = (uint32_t)((duty_percent * period) / (float)k_gptw_duty_divisor);
+
+  return rx_gptw_set_duty_raw(channel, output, duty_count);
+}
+
+rx_err_t rx_gptw_set_duty_raw(rx_gptw_channel_t channel, rx_gptw_output_t output, uint32_t duty_count)
+{
+  if ((int32_t)channel >= k_gptw_max_channels || !s_gptw_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Clamp to period */
+  uint32_t period = s_gptw_period[channel];
+  if (duty_count > period) {
+    duty_count = period;
+  }
+
+  /* Update duty cycle (buffered, takes effect on next period) */
+  switch (output) {
+    case k_gptw_output_a:
+      gptw->gtccra = duty_count;
+      break;
+    case k_gptw_output_b:
+      gptw->gtccrb = duty_count;
+      break;
+    default:
+      return k_rx_err_invalid_arg;
+  }
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float* duty_percent)
+{
+  RX_CHECK_NULL_PTR(duty_percent, s_tag, "duty_percent pointer is NULL");
+
+  if ((int32_t)channel >= k_gptw_max_channels || !s_gptw_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  uint32_t period     = s_gptw_period[channel];
+  uint32_t duty_count = 0;
+
+  switch (output) {
+    case k_gptw_output_a:
+      duty_count = gptw->gtccra;
+      break;
+    case k_gptw_output_b:
+      duty_count = gptw->gtccrb;
+      break;
+    default:
+      return k_rx_err_invalid_arg;
+  }
+
+  *duty_percent = (float)(duty_count * (float)k_gptw_duty_max) / period;
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_get_period(rx_gptw_channel_t channel, uint32_t* period_count)
+{
+  RX_CHECK_NULL_PTR(period_count, s_tag, "period_count pointer is NULL");
+
+  if ((int32_t)channel >= k_gptw_max_channels || !s_gptw_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  *period_count = s_gptw_period[channel];
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_enable_output(rx_gptw_channel_t channel, rx_gptw_output_t output, bool enable)
+{
+  if ((int32_t)channel >= k_gptw_max_channels || !s_gptw_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Unlock for modification */
+  gptw->gtwp = k_gptw_gtwp_unlock;
+
+  /* Modify GTIOR to enable/disable output */
+  switch (output) {
+    case k_gptw_output_a:
+      if (enable) {
+        gptw->gtior |= k_gptw_gtior_oae;
+      } else {
+        gptw->gtior &= ~k_gptw_gtior_oae;
+      }
+      break;
+    case k_gptw_output_b:
+      if (enable) {
+        gptw->gtior |= k_gptw_gtior_obe;
+      } else {
+        gptw->gtior &= ~k_gptw_gtior_obe;
+      }
+      break;
+    default:
+      gptw->gtwp = k_gptw_gtwp_lock;
+      return k_rx_err_invalid_arg;
+  }
+
+  gptw->gtwp = k_gptw_gtwp_lock;
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_start(rx_gptw_channel_t channel)
+{
+  if ((int32_t)channel >= k_gptw_max_channels) {
+    return k_rx_err_invalid_arg;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Unlock and set CST bit in GTCR */
+  gptw->gtwp = k_gptw_gtwp_unlock;
+  gptw->gtcr |= k_gptw_gtcr_cst;
+  gptw->gtwp = k_gptw_gtwp_lock;
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_stop(rx_gptw_channel_t channel)
+{
+  if ((int32_t)channel >= k_gptw_max_channels) {
+    return k_rx_err_invalid_arg;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Unlock and clear CST bit in GTCR */
+  gptw->gtwp = k_gptw_gtwp_unlock;
+  gptw->gtcr &= ~k_gptw_gtcr_cst;
+  gptw->gtwp = k_gptw_gtwp_lock;
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_deinit(rx_gptw_channel_t channel)
+{
+  if ((int32_t)channel >= k_gptw_max_channels) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Stop timer */
+  rx_gptw_stop(channel);
+
+  /* Disable outputs */
+  rx_gptw_enable_output(channel, k_gptw_output_a, false);
+  rx_gptw_enable_output(channel, k_gptw_output_b, false);
+
+  /* Mark as uninitialized */
+  s_gptw_initialized[channel] = false;
+  s_gptw_period[channel]      = k_gptw_period_zero;
+
+  rx_log_info(s_tag, "GPTW deinitialized");
+
+  return k_rx_ok;
+}

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_gptw.c
@@ -99,13 +99,13 @@ static volatile rx_gptw_channel_regs_t* internal_get_gptw_base(rx_gptw_channel_t
 {
   switch (channel) {
     case k_gptw_channel_0:
-      return GPTW0_BASE;
+      return gptw0();
     case k_gptw_channel_1:
-      return GPTW1_BASE;
+      return gptw1();
     case k_gptw_channel_2:
-      return GPTW2_BASE;
+      return gptw2();
     case k_gptw_channel_3:
-      return GPTW3_BASE;
+      return gptw3();
     default:
       return NULL;
   }
@@ -255,42 +255,31 @@ static void internal_configure_port_pins(rx_gptw_channel_t channel)
   }
 }
 
-/* =============================================================================
- * Public API Implementation
- * =============================================================================
+/**
+ * @brief Enable GPTW module clock
+ *
+ * Unlocks system protection and clears the GPTW module stop bit.
  */
-
-rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* config)
+static void internal_enable_gptw_module_clock(void)
 {
-  RX_CHECK_NULL_PTR(config, s_tag, "config pointer is NULL");
-
-  if ((int32_t)channel >= k_gptw_max_channels) {
-    rx_log_error(s_tag, "Invalid GPTW channel");
-    return k_rx_err_invalid_arg;
-  }
-
-  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
-  if (gptw == NULL) {
-    return k_rx_err_invalid_arg;
-  }
-
-  /* Calculate period from frequency */
-  uint32_t period;
-  rx_err_t err = internal_calculate_period(config->frequency_hz, &period);
-  if (err != k_rx_ok) {
-    return err;
-  }
-
-  rx_log_info(s_tag, "Initializing GPTW");
-
-  /* Enable GPTW module (clear module stop bit in MSTPCRC) */
   system_regs()->prcr = k_gptw_prcr_unlock;
   system_regs()->mstpcrc &= ~(1UL << k_mstpc_gptw);
   system_regs()->prcr = k_gptw_prcr_lock;
+}
 
-  /* Stop timer before configuration */
-  rx_gptw_stop(channel);
-
+/**
+ * @brief Configure GPTW hardware registers
+ *
+ * Sets up GPTW control, I/O, period, duty cycle, buffer, and dead time registers.
+ *
+ * @param[in] gptw   Pointer to GPTW channel registers
+ * @param[in] config Configuration parameters
+ * @param[in] period Calculated period value
+ */
+static void internal_configure_gptw_hardware(volatile rx_gptw_channel_regs_t* gptw,
+                                              const rx_gptw_config_t* config,
+                                              uint32_t period)
+{
   /* Unlock write protection for this channel */
   gptw->gtwp = k_gptw_gtwp_unlock;
 
@@ -331,6 +320,46 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
 
   /* Lock write protection */
   gptw->gtwp = k_gptw_gtwp_lock;
+}
+
+/* =============================================================================
+ * Public API Implementation
+ * =============================================================================
+ */
+
+rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* config)
+{
+  rx_err_t err;
+
+  RX_CHECK_NULL_PTR(config, s_tag, "config pointer is NULL");
+
+  if ((int32_t)channel >= k_gptw_max_channels) {
+    rx_log_error(s_tag, "Invalid GPTW channel");
+    return k_rx_err_invalid_arg;
+  }
+
+  volatile rx_gptw_channel_regs_t* gptw = internal_get_gptw_base(channel);
+  if (gptw == NULL) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Calculate period from frequency */
+  uint32_t period;
+  err = internal_calculate_period(config->frequency_hz, &period);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  rx_log_info(s_tag, "Initializing GPTW");
+
+  /* Enable GPTW module clock */
+  internal_enable_gptw_module_clock();
+
+  /* Stop timer before configuration */
+  rx_gptw_stop(channel);
+
+  /* Configure GPTW hardware registers */
+  internal_configure_gptw_hardware(gptw, config, period);
 
   /* Configure MPC for Port E alternate functions */
   err = internal_configure_mpc(channel);

--- a/star-rx72n-firmware/lib/rx_motor/inc/rx_motor.h
+++ b/star-rx72n-firmware/lib/rx_motor/inc/rx_motor.h
@@ -2,10 +2,10 @@
 
 /**
  * @file rx_motor.h
- * @brief Brushed DC motor control API using RX72N MTU3a PWM
+ * @brief Brushed DC motor control API using RX72N GPTW PWM
  * @details
  * Provides an interface for controlling brushed DC motors via H-bridge drivers using the
- * RX72N Multi-Function Timer Unit (MTU3a) peripheral. Supports bidirectional control with
+ * RX72N General PWM Timer (GPTW) peripheral. Supports bidirectional control with
  * configurable PWM frequency and dead-time insertion for preventing shoot-through.
  *
  * Port of star_motor from ESP32 to RX72N platform.
@@ -16,15 +16,16 @@
  * - Configurable PWM frequency (typically 20kHz)
  * - Brake and coast modes
  * - Hardware-based PWM (zero CPU overhead during operation)
+ * - 32-bit resolution (GPTW vs MTU's 16-bit)
  *
  * Example Usage:
  * @code
  * // Initialize motor controller
  * rx_motor_handle_t motor;
  * rx_motor_config_t config = {
- *     .channel = k_mtu_channel_3,    // MTU3 channel
- *     .output_a = k_mtu_output_a,    // MTIOC3A
- *     .output_b = k_mtu_output_b,    // MTIOC3B
+ *     .channel = k_gptw_channel_0,   // GPTW0 channel
+ *     .output_a = k_gptw_output_a,   // GTIOC0A
+ *     .output_b = k_gptw_output_b,   // GTIOC0B
  *     .pwm_freq_hz = 20000,          // 20kHz PWM
  *     .dead_time_ns = 1000,          // 1us dead-time
  *     .invert_pwm = false,
@@ -40,7 +41,7 @@
  * rx_motor_deinit(&motor);
  * @endcode
  *
- * @date 2026-01-01
+ * @date 2026-01-04
  * @copyright Copyright (c) 2026 STAR Project
  */
 
@@ -55,7 +56,7 @@ extern "C" {
 #include <stdint.h>
 
 #include "rx_err.h"
-#include "rx_mtu3a.h"
+#include "rx_gptw.h"
 
 /* =============================================================================
  * Type Definitions
@@ -66,25 +67,25 @@ extern "C" {
  * @brief Motor controller configuration structure
  */
 typedef struct {
-  rx_mtu_channel_t channel;      /**< MTU channel (0-4, 6-7) */
-  rx_mtu_output_t  output_a;     /**< PWM output A (H-bridge IN1) */
-  rx_mtu_output_t  output_b;     /**< PWM output B (H-bridge IN2) */
-  uint32_t         pwm_freq_hz;  /**< PWM frequency in Hz (e.g., 20kHz) */
-  uint32_t         dead_time_ns; /**< Dead-time in nanoseconds (e.g., 1000ns = 1us) */
-  bool             invert_pwm;   /**< Invert PWM polarity */
+  rx_gptw_channel_t channel;      /**< GPTW channel (0-3) */
+  rx_gptw_output_t  output_a;     /**< PWM output A (H-bridge IN1) */
+  rx_gptw_output_t  output_b;     /**< PWM output B (H-bridge IN2) */
+  uint32_t          pwm_freq_hz;  /**< PWM frequency in Hz (e.g., 20kHz) */
+  uint32_t          dead_time_ns; /**< Dead-time in nanoseconds (e.g., 1000ns = 1us) */
+  bool              invert_pwm;   /**< Invert PWM polarity */
 } rx_motor_config_t;
 
 /**
  * @brief Motor controller handle structure
  */
 typedef struct {
-  rx_mtu_channel_t channel;      /**< MTU channel */
-  rx_mtu_output_t  output_a;     /**< PWM output A */
-  rx_mtu_output_t  output_b;     /**< PWM output B */
-  uint32_t         pwm_freq_hz;  /**< PWM frequency */
-  float            current_duty; /**< Current duty cycle (-100 to +100) */
-  bool             invert_pwm;   /**< PWM inversion flag */
-  bool             initialized;  /**< Initialization flag */
+  rx_gptw_channel_t channel;      /**< GPTW channel */
+  rx_gptw_output_t  output_a;     /**< PWM output A */
+  rx_gptw_output_t  output_b;     /**< PWM output B */
+  uint32_t          pwm_freq_hz;  /**< PWM frequency */
+  float             current_duty; /**< Current duty cycle (-100 to +100) */
+  bool              invert_pwm;   /**< PWM inversion flag */
+  bool              initialized;  /**< Initialization flag */
 } rx_motor_handle_t;
 
 /* =============================================================================
@@ -93,9 +94,9 @@ typedef struct {
  */
 
 /**
- * @brief Initialize motor controller with MTU PWM
+ * @brief Initialize motor controller with GPTW PWM
  *
- * Configures the RX72N MTU3a peripheral for H-bridge motor control.
+ * Configures the RX72N GPTW peripheral for H-bridge motor control.
  * Initializes PWM outputs with specified frequency and dead-time.
  *
  * @param[out] handle Pointer to motor handle structure. Must not be NULL.
@@ -104,14 +105,14 @@ typedef struct {
  * @return k_rx_ok on success
  * @return k_rx_err_null_pointer if handle or config is NULL
  * @return k_rx_err_invalid_arg if configuration is invalid
- * @return k_rx_err_invalid_state if MTU initialization fails
+ * @return k_rx_err_invalid_state if GPTW initialization fails
  */
 rx_err_t rx_motor_init(rx_motor_handle_t* handle, const rx_motor_config_t* config);
 
 /**
  * @brief Deinitialize motor controller and release resources
  *
- * Stops motor, disables PWM outputs, and releases MTU peripheral.
+ * Stops motor, disables PWM outputs, and releases GPTW peripheral.
  *
  * @param[in] handle Pointer to initialized motor handle. Must not be NULL.
  *

--- a/star-rx72n-firmware/lib/rx_motor/src/rx_motor.c
+++ b/star-rx72n-firmware/lib/rx_motor/src/rx_motor.c
@@ -37,6 +37,15 @@
 
 static const char* s_tag = "MOTOR";
 
+/** @brief Motor control constants for DRV8243 PH/EN mode */
+typedef enum {
+  k_motor_duty_min  = -100, /**< Minimum duty cycle (full reverse) */
+  k_motor_duty_max  = 100,  /**< Maximum duty cycle (full forward) */
+  k_motor_duty_zero = 0,    /**< Zero duty cycle (stopped) */
+  k_motor_ph_high   = 100,  /**< PH signal for forward direction */
+  k_motor_ph_low    = 0,    /**< PH signal for reverse direction */
+} motor_constants_t;
+
 /* =============================================================================
  * Internal Helper Functions
  * =============================================================================
@@ -51,11 +60,11 @@ static const char* s_tag = "MOTOR";
  */
 static float internal_clamp_duty(float duty)
 {
-  if (duty > 100.0f) {
-    return 100.0f;
+  if (duty > (float)k_motor_duty_max) {
+    return (float)k_motor_duty_max;
   }
-  if (duty < -100.0f) {
-    return -100.0f;
+  if (duty < (float)k_motor_duty_min) {
+    return (float)k_motor_duty_min;
   }
   return duty;
 }
@@ -153,13 +162,13 @@ rx_err_t rx_motor_set_duty(rx_motor_handle_t* handle, float duty)
    * EN (output_b) = speed (PWM duty cycle)
    */
   float speed_pwm = fabsf(duty);
-  if (duty >= 0.0f) {
+  if (duty >= (float)k_motor_duty_zero) {
     /* Forward: PH = HIGH, EN = PWM */
-    rx_gptw_set_duty(handle->channel, handle->output_a, 100.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_a, (float)k_motor_ph_high);
     rx_gptw_set_duty(handle->channel, handle->output_b, speed_pwm);
   } else {
     /* Reverse: PH = LOW, EN = PWM */
-    rx_gptw_set_duty(handle->channel, handle->output_a, 0.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_a, (float)k_motor_ph_low);
     rx_gptw_set_duty(handle->channel, handle->output_b, speed_pwm);
   }
 

--- a/star-rx72n-firmware/lib/rx_motor/src/rx_motor.c
+++ b/star-rx72n-firmware/lib/rx_motor/src/rx_motor.c
@@ -4,7 +4,7 @@
  * @file rx_motor.c
  * @brief Brushed DC motor control implementation for RX72N
  * @details
- * H-bridge motor control using MTU3a PWM peripheral.
+ * H-bridge motor control using GPTW PWM peripheral.
  *
  * Motor Control Modes:
  * 1. Forward: output_a = PWM, output_b = LOW
@@ -20,7 +20,7 @@
  * - Prevents shoot-through in H-bridge
  * - Typical: 500ns - 2us depending on FET switching speed
  *
- * @date 2026-01-01
+ * @date 2026-01-04
  * @copyright Copyright (c) 2026 STAR Project
  */
 
@@ -73,23 +73,23 @@ rx_err_t rx_motor_init(rx_motor_handle_t* handle, const rx_motor_config_t* confi
 
   rx_log_info(s_tag, "Initializing motor");
 
-  /* Initialize MTU PWM */
-  rx_mtu_config_t mtu_config = {
+  /* Initialize GPTW PWM */
+  rx_gptw_config_t gptw_config = {
     .frequency_hz         = config->pwm_freq_hz,
     .deadtime_ns          = config->dead_time_ns,
     .enable_complementary = false, /* We control direction manually */
     .invert_polarity      = config->invert_pwm,
   };
 
-  rx_err_t err = rx_mtu_init_pwm(config->channel, &mtu_config);
+  rx_err_t err = rx_gptw_init_pwm(config->channel, &gptw_config);
   if (err != k_rx_ok) {
-    rx_log_error(s_tag, "Failed to initialize MTU PWM");
+    rx_log_error(s_tag, "Failed to initialize GPTW PWM");
     return err;
   }
 
   /* Initialize both outputs to 0% duty (stopped) */
-  rx_mtu_set_duty(config->channel, config->output_a, 0.0f);
-  rx_mtu_set_duty(config->channel, config->output_b, 0.0f);
+  rx_gptw_set_duty(config->channel, config->output_a, 0.0f);
+  rx_gptw_set_duty(config->channel, config->output_b, 0.0f);
 
   /* Save configuration */
   handle->channel      = config->channel;
@@ -117,8 +117,8 @@ rx_err_t rx_motor_deinit(rx_motor_handle_t* handle)
   /* Stop motor before deinit */
   rx_motor_stop(handle, false);
 
-  /* Deinitialize MTU (note: this affects the entire channel) */
-  rx_mtu_deinit(handle->channel);
+  /* Deinitialize GPTW (note: this affects the entire channel) */
+  rx_gptw_deinit(handle->channel);
 
   handle->initialized = false;
 
@@ -147,12 +147,12 @@ rx_err_t rx_motor_set_duty(rx_motor_handle_t* handle, float duty)
   /* Set PWM outputs based on direction */
   if (duty >= 0.0f) {
     /* Forward: output_a = PWM, output_b = 0 */
-    rx_mtu_set_duty(handle->channel, handle->output_a, duty);
-    rx_mtu_set_duty(handle->channel, handle->output_b, 0.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_a, duty);
+    rx_gptw_set_duty(handle->channel, handle->output_b, 0.0f);
   } else {
     /* Reverse: output_a = 0, output_b = PWM */
-    rx_mtu_set_duty(handle->channel, handle->output_a, 0.0f);
-    rx_mtu_set_duty(handle->channel, handle->output_b, fabsf(duty));
+    rx_gptw_set_duty(handle->channel, handle->output_a, 0.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_b, fabsf(duty));
   }
 
   handle->current_duty = duty;
@@ -171,12 +171,12 @@ rx_err_t rx_motor_stop(rx_motor_handle_t* handle, bool brake)
 
   if (brake) {
     /* Brake mode: both outputs HIGH (short circuit brake) */
-    rx_mtu_set_duty(handle->channel, handle->output_a, 100.0f);
-    rx_mtu_set_duty(handle->channel, handle->output_b, 100.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_a, 100.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_b, 100.0f);
   } else {
     /* Coast mode: both outputs LOW (high impedance) */
-    rx_mtu_set_duty(handle->channel, handle->output_a, 0.0f);
-    rx_mtu_set_duty(handle->channel, handle->output_b, 0.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_a, 0.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_b, 0.0f);
   }
 
   handle->current_duty = 0.0f;

--- a/star-rx72n-firmware/lib/rx_motor/src/rx_motor.c
+++ b/star-rx72n-firmware/lib/rx_motor/src/rx_motor.c
@@ -6,11 +6,15 @@
  * @details
  * H-bridge motor control using GPTW PWM peripheral.
  *
- * Motor Control Modes:
- * 1. Forward: output_a = PWM, output_b = LOW
- * 2. Reverse: output_a = LOW, output_b = PWM
- * 3. Brake: output_a = HIGH, output_b = HIGH (short circuit)
- * 4. Coast: output_a = LOW, output_b = LOW (high impedance)
+ * Motor Control Modes (PH/EN for DRV8243):
+ * - PH (output_a) = direction (HIGH=forward, LOW=reverse)
+ * - EN (output_b) = speed (PWM duty cycle)
+ *
+ * States:
+ * 1. Forward: PH = HIGH (100%), EN = PWM (speed)
+ * 2. Reverse: PH = LOW (0%), EN = PWM (speed)
+ * 3. Coast: EN = LOW (0%) - motor in high impedance
+ * 4. Brake: NOT SUPPORTED in PH/EN mode (falls back to coast)
  *
  * PWM Frequency:
  * - Typical: 20 kHz (above human hearing, motor-friendly)
@@ -144,15 +148,19 @@ rx_err_t rx_motor_set_duty(rx_motor_handle_t* handle, float duty)
     duty = -duty;
   }
 
-  /* Set PWM outputs based on direction */
+  /* Set PWM outputs based on direction (PH/EN mode)
+   * PH (output_a) = direction (HIGH=forward, LOW=reverse)
+   * EN (output_b) = speed (PWM duty cycle)
+   */
+  float speed_pwm = fabsf(duty);
   if (duty >= 0.0f) {
-    /* Forward: output_a = PWM, output_b = 0 */
-    rx_gptw_set_duty(handle->channel, handle->output_a, duty);
-    rx_gptw_set_duty(handle->channel, handle->output_b, 0.0f);
+    /* Forward: PH = HIGH, EN = PWM */
+    rx_gptw_set_duty(handle->channel, handle->output_a, 100.0f);
+    rx_gptw_set_duty(handle->channel, handle->output_b, speed_pwm);
   } else {
-    /* Reverse: output_a = 0, output_b = PWM */
+    /* Reverse: PH = LOW, EN = PWM */
     rx_gptw_set_duty(handle->channel, handle->output_a, 0.0f);
-    rx_gptw_set_duty(handle->channel, handle->output_b, fabsf(duty));
+    rx_gptw_set_duty(handle->channel, handle->output_b, speed_pwm);
   }
 
   handle->current_duty = duty;
@@ -170,14 +178,12 @@ rx_err_t rx_motor_stop(rx_motor_handle_t* handle, bool brake)
   }
 
   if (brake) {
-    /* Brake mode: both outputs HIGH (short circuit brake) */
-    rx_gptw_set_duty(handle->channel, handle->output_a, 100.0f);
-    rx_gptw_set_duty(handle->channel, handle->output_b, 100.0f);
-  } else {
-    /* Coast mode: both outputs LOW (high impedance) */
-    rx_gptw_set_duty(handle->channel, handle->output_a, 0.0f);
-    rx_gptw_set_duty(handle->channel, handle->output_b, 0.0f);
+    /* Brake mode not supported in PH/EN mode - coast instead */
+    rx_log_warn(s_tag, "Brake not supported in PH/EN mode, coasting");
   }
+  /* Coast mode: set EN (output_b) to LOW for high impedance */
+  rx_gptw_set_duty(handle->channel, handle->output_a, 0.0f);
+  rx_gptw_set_duty(handle->channel, handle->output_b, 0.0f);
 
   handle->current_duty = 0.0f;
 

--- a/star-rx72n-firmware/tests/CMakeLists.txt
+++ b/star-rx72n-firmware/tests/CMakeLists.txt
@@ -86,6 +86,16 @@ set(MOCK_HCSR04_SRC
     ${CMAKE_SOURCE_DIR}/mocks/mock_hcsr04_hw.c
 )
 
+# Mock GPTW source for motor testing
+set(MOCK_GPTW_SRC
+    ${CMAKE_SOURCE_DIR}/mocks/mock_rx_gptw.c
+)
+
+# rx_motor source
+set(RX_MOTOR_SRC
+    ${CMAKE_SOURCE_DIR}/../lib/rx_motor/src/rx_motor.c
+)
+
 # Include directories for library headers
 include_directories(
     ${CMAKE_SOURCE_DIR}/../lib/rx_frame/inc
@@ -97,6 +107,8 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb_comm/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/src
+    ${CMAKE_SOURCE_DIR}/../lib/rx_motor/inc
+    ${CMAKE_SOURCE_DIR}/../lib/rx_hal/inc
     ${CMAKE_SOURCE_DIR}/mocks
     ${unity_SOURCE_DIR}/src
 )
@@ -170,6 +182,16 @@ add_executable(test_rx_hcsr04
 )
 target_link_libraries(test_rx_hcsr04 unity)
 
+# Test: Motor Driver (GPTW-based)
+add_executable(test_rx_motor
+    test_rx_motor.c
+    ${RX_MOTOR_SRC}
+    ${MOCK_GPTW_SRC}
+    ${MOCK_LOG_SRC}
+)
+target_compile_definitions(test_rx_motor PRIVATE UNIT_TEST)
+target_link_libraries(test_rx_motor m)
+
 # =============================================================================
 # CTest Integration
 # =============================================================================
@@ -184,6 +206,7 @@ add_test(NAME test_rx_usb COMMAND test_rx_usb)
 add_test(NAME test_rx_usb_comm COMMAND test_rx_usb_comm)
 add_test(NAME test_rx_time COMMAND test_rx_time)
 add_test(NAME test_rx_hcsr04 COMMAND test_rx_hcsr04)
+add_test(NAME test_rx_motor COMMAND test_rx_motor)
 
 # =============================================================================
 # Convenience Targets
@@ -191,7 +214,7 @@ add_test(NAME test_rx_hcsr04 COMMAND test_rx_hcsr04)
 
 add_custom_target(run_all_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS test_rx_crc32 test_rx_frame test_rx_fec test_rx_harq test_rx_usb test_rx_usb_comm test_rx_time test_rx_hcsr04
+    DEPENDS test_rx_crc32 test_rx_frame test_rx_fec test_rx_harq test_rx_usb test_rx_usb_comm test_rx_time test_rx_hcsr04 test_rx_motor
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running all unit tests..."
 )

--- a/star-rx72n-firmware/tests/mocks/mock_rx_gptw.c
+++ b/star-rx72n-firmware/tests/mocks/mock_rx_gptw.c
@@ -1,0 +1,256 @@
+/**
+ * @file mock_rx_gptw.c
+ * @brief Mock GPTW Driver Implementation for Unit Testing
+ *
+ * Provides mock implementation of GPTW driver for host-side testing.
+ * Records all operations for verification without actual hardware.
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "mock_rx_gptw.h"
+
+#include <string.h>
+
+/* =============================================================================
+ * Constants
+ * =============================================================================
+ */
+
+#define MOCK_GPTW_MAX_CHANNELS   4
+#define MOCK_GPTW_OUTPUTS_PER_CH 2
+
+/* Simulated PCLKA for period calculation */
+#define MOCK_PCLKA_HZ 120000000UL
+
+/* =============================================================================
+ * Static Variables
+ * =============================================================================
+ */
+
+static bool     s_initialized[MOCK_GPTW_MAX_CHANNELS]                              = {false};
+static bool     s_running[MOCK_GPTW_MAX_CHANNELS]                                  = {false};
+static uint32_t s_period[MOCK_GPTW_MAX_CHANNELS]                                   = {0};
+static uint32_t s_frequency[MOCK_GPTW_MAX_CHANNELS]                                = {0};
+static float    s_duty[MOCK_GPTW_MAX_CHANNELS][MOCK_GPTW_OUTPUTS_PER_CH]           = {{0}};
+static bool     s_output_enabled[MOCK_GPTW_MAX_CHANNELS][MOCK_GPTW_OUTPUTS_PER_CH] = {{false}};
+
+/* =============================================================================
+ * Mock Test Helpers
+ * =============================================================================
+ */
+
+void mock_gptw_reset(void)
+{
+  memset(s_initialized, 0, sizeof(s_initialized));
+  memset(s_running, 0, sizeof(s_running));
+  memset(s_period, 0, sizeof(s_period));
+  memset(s_frequency, 0, sizeof(s_frequency));
+  memset(s_duty, 0, sizeof(s_duty));
+  memset(s_output_enabled, 0, sizeof(s_output_enabled));
+}
+
+bool mock_gptw_is_initialized(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return false;
+  }
+  return s_initialized[channel];
+}
+
+float mock_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || (int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+    return 0.0f;
+  }
+  return s_duty[channel][output];
+}
+
+uint32_t mock_gptw_get_period_value(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return 0;
+  }
+  return s_period[channel];
+}
+
+uint32_t mock_gptw_get_frequency(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return 0;
+  }
+  return s_frequency[channel];
+}
+
+bool mock_gptw_is_output_enabled(rx_gptw_channel_t channel, rx_gptw_output_t output)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || (int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+    return false;
+  }
+  return s_output_enabled[channel][output];
+}
+
+bool mock_gptw_is_running(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return false;
+  }
+  return s_running[channel];
+}
+
+/* =============================================================================
+ * GPTW Driver Mock Implementation
+ * =============================================================================
+ */
+
+rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* config)
+{
+  if (config == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return k_rx_err_invalid_arg;
+  }
+
+  if (config->frequency_hz == 0) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Calculate period */
+  s_period[channel]    = MOCK_PCLKA_HZ / config->frequency_hz;
+  s_frequency[channel] = config->frequency_hz;
+
+  /* Initialize outputs to 0% duty, enabled */
+  s_duty[channel][0]           = 0.0f;
+  s_duty[channel][1]           = 0.0f;
+  s_output_enabled[channel][0] = true;
+  s_output_enabled[channel][1] = true;
+
+  s_initialized[channel] = true;
+  s_running[channel]     = true;
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_set_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float duty_percent)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+    return k_rx_err_invalid_arg;
+  }
+
+  if (duty_percent < 0.0f || duty_percent > 100.0f) {
+    return k_rx_err_invalid_arg;
+  }
+
+  s_duty[channel][output] = duty_percent;
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_set_duty_raw(rx_gptw_channel_t channel, rx_gptw_output_t output, uint32_t duty_count)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Convert to percentage */
+  uint32_t period = s_period[channel];
+  if (period > 0) {
+    s_duty[channel][output] = (float)duty_count * 100.0f / (float)period;
+  }
+
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float* duty_percent)
+{
+  if (duty_percent == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+    return k_rx_err_invalid_arg;
+  }
+
+  *duty_percent = s_duty[channel][output];
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_get_period(rx_gptw_channel_t channel, uint32_t* period_count)
+{
+  if (period_count == NULL) {
+    return k_rx_err_null_pointer;
+  }
+
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  *period_count = s_period[channel];
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_enable_output(rx_gptw_channel_t channel, rx_gptw_output_t output, bool enable)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+    return k_rx_err_invalid_state;
+  }
+
+  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+    return k_rx_err_invalid_arg;
+  }
+
+  s_output_enabled[channel][output] = enable;
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_start(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return k_rx_err_invalid_arg;
+  }
+
+  s_running[channel] = true;
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_stop(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return k_rx_err_invalid_arg;
+  }
+
+  s_running[channel] = false;
+  return k_rx_ok;
+}
+
+rx_err_t rx_gptw_deinit(rx_gptw_channel_t channel)
+{
+  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+    return k_rx_err_invalid_arg;
+  }
+
+  s_initialized[channel]       = false;
+  s_running[channel]           = false;
+  s_period[channel]            = 0;
+  s_frequency[channel]         = 0;
+  s_duty[channel][0]           = 0.0f;
+  s_duty[channel][1]           = 0.0f;
+  s_output_enabled[channel][0] = false;
+  s_output_enabled[channel][1] = false;
+
+  return k_rx_ok;
+}

--- a/star-rx72n-firmware/tests/mocks/mock_rx_gptw.c
+++ b/star-rx72n-firmware/tests/mocks/mock_rx_gptw.c
@@ -1,7 +1,9 @@
+/* tests/mocks/mock_rx_gptw.c */
+
 /**
  * @file mock_rx_gptw.c
  * @brief Mock GPTW Driver Implementation for Unit Testing
- *
+ * @details
  * Provides mock implementation of GPTW driver for host-side testing.
  * Records all operations for verification without actual hardware.
  *
@@ -18,23 +20,33 @@
  * =============================================================================
  */
 
-#define MOCK_GPTW_MAX_CHANNELS   4
-#define MOCK_GPTW_OUTPUTS_PER_CH 2
+/** @brief Mock GPTW channel and output constants */
+typedef enum {
+  k_mock_gptw_max_channels   = 4,   /**< Number of GPTW channels (0-3) */
+  k_mock_gptw_outputs_per_ch = 2,   /**< Outputs per channel (A and B) */
+  k_mock_gptw_output_a       = 0,   /**< Output A array index */
+  k_mock_gptw_output_b       = 1,   /**< Output B array index */
+} mock_gptw_constants_t;
 
-/* Simulated PCLKA for period calculation */
-#define MOCK_PCLKA_HZ 120000000UL
+/** @brief Duty cycle percentage constants */
+typedef enum {
+  k_mock_duty_percent_max = 100, /**< Maximum duty cycle percentage */
+} mock_duty_constants_t;
+
+/** @brief Simulated PCLKA for period calculation */
+static const uint32_t s_mock_pclka_hz = 120000000UL;
 
 /* =============================================================================
  * Static Variables
  * =============================================================================
  */
 
-static bool     s_initialized[MOCK_GPTW_MAX_CHANNELS]                              = {false};
-static bool     s_running[MOCK_GPTW_MAX_CHANNELS]                                  = {false};
-static uint32_t s_period[MOCK_GPTW_MAX_CHANNELS]                                   = {0};
-static uint32_t s_frequency[MOCK_GPTW_MAX_CHANNELS]                                = {0};
-static float    s_duty[MOCK_GPTW_MAX_CHANNELS][MOCK_GPTW_OUTPUTS_PER_CH]           = {{0}};
-static bool     s_output_enabled[MOCK_GPTW_MAX_CHANNELS][MOCK_GPTW_OUTPUTS_PER_CH] = {{false}};
+static bool     s_initialized[k_mock_gptw_max_channels]                                  = {false};
+static bool     s_running[k_mock_gptw_max_channels]                                      = {false};
+static uint32_t s_period[k_mock_gptw_max_channels]                                       = {0};
+static uint32_t s_frequency[k_mock_gptw_max_channels]                                    = {0};
+static float    s_duty[k_mock_gptw_max_channels][k_mock_gptw_outputs_per_ch]             = {{0}};
+static bool     s_output_enabled[k_mock_gptw_max_channels][k_mock_gptw_outputs_per_ch]   = {{false}};
 
 /* =============================================================================
  * Mock Test Helpers
@@ -53,7 +65,7 @@ void mock_gptw_reset(void)
 
 bool mock_gptw_is_initialized(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return false;
   }
   return s_initialized[channel];
@@ -61,7 +73,7 @@ bool mock_gptw_is_initialized(rx_gptw_channel_t channel)
 
 float mock_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || (int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || (int32_t)output >= k_mock_gptw_outputs_per_ch) {
     return 0.0f;
   }
   return s_duty[channel][output];
@@ -69,7 +81,7 @@ float mock_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output)
 
 uint32_t mock_gptw_get_period_value(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return 0;
   }
   return s_period[channel];
@@ -77,7 +89,7 @@ uint32_t mock_gptw_get_period_value(rx_gptw_channel_t channel)
 
 uint32_t mock_gptw_get_frequency(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return 0;
   }
   return s_frequency[channel];
@@ -85,7 +97,7 @@ uint32_t mock_gptw_get_frequency(rx_gptw_channel_t channel)
 
 bool mock_gptw_is_output_enabled(rx_gptw_channel_t channel, rx_gptw_output_t output)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || (int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || (int32_t)output >= k_mock_gptw_outputs_per_ch) {
     return false;
   }
   return s_output_enabled[channel][output];
@@ -93,7 +105,7 @@ bool mock_gptw_is_output_enabled(rx_gptw_channel_t channel, rx_gptw_output_t out
 
 bool mock_gptw_is_running(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return false;
   }
   return s_running[channel];
@@ -110,7 +122,7 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
     return k_rx_err_null_pointer;
   }
 
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return k_rx_err_invalid_arg;
   }
 
@@ -119,14 +131,14 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
   }
 
   /* Calculate period */
-  s_period[channel]    = MOCK_PCLKA_HZ / config->frequency_hz;
+  s_period[channel]    = s_mock_pclka_hz / config->frequency_hz;
   s_frequency[channel] = config->frequency_hz;
 
   /* Initialize outputs to 0% duty, enabled */
-  s_duty[channel][0]           = 0.0f;
-  s_duty[channel][1]           = 0.0f;
-  s_output_enabled[channel][0] = true;
-  s_output_enabled[channel][1] = true;
+  s_duty[channel][k_mock_gptw_output_a]           = 0.0f;
+  s_duty[channel][k_mock_gptw_output_b]           = 0.0f;
+  s_output_enabled[channel][k_mock_gptw_output_a] = true;
+  s_output_enabled[channel][k_mock_gptw_output_b] = true;
 
   s_initialized[channel] = true;
   s_running[channel]     = true;
@@ -136,15 +148,15 @@ rx_err_t rx_gptw_init_pwm(rx_gptw_channel_t channel, const rx_gptw_config_t* con
 
 rx_err_t rx_gptw_set_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, float duty_percent)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || !s_initialized[channel]) {
     return k_rx_err_invalid_state;
   }
 
-  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+  if ((int32_t)output >= k_mock_gptw_outputs_per_ch) {
     return k_rx_err_invalid_arg;
   }
 
-  if (duty_percent < 0.0f || duty_percent > 100.0f) {
+  if (duty_percent < 0.0f || duty_percent > (float)k_mock_duty_percent_max) {
     return k_rx_err_invalid_arg;
   }
 
@@ -154,18 +166,18 @@ rx_err_t rx_gptw_set_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, fl
 
 rx_err_t rx_gptw_set_duty_raw(rx_gptw_channel_t channel, rx_gptw_output_t output, uint32_t duty_count)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || !s_initialized[channel]) {
     return k_rx_err_invalid_state;
   }
 
-  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+  if ((int32_t)output >= k_mock_gptw_outputs_per_ch) {
     return k_rx_err_invalid_arg;
   }
 
   /* Convert to percentage */
   uint32_t period = s_period[channel];
   if (period > 0) {
-    s_duty[channel][output] = (float)duty_count * 100.0f / (float)period;
+    s_duty[channel][output] = (float)duty_count * (float)k_mock_duty_percent_max / (float)period;
   }
 
   return k_rx_ok;
@@ -177,11 +189,11 @@ rx_err_t rx_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output, fl
     return k_rx_err_null_pointer;
   }
 
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || !s_initialized[channel]) {
     return k_rx_err_invalid_state;
   }
 
-  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+  if ((int32_t)output >= k_mock_gptw_outputs_per_ch) {
     return k_rx_err_invalid_arg;
   }
 
@@ -195,7 +207,7 @@ rx_err_t rx_gptw_get_period(rx_gptw_channel_t channel, uint32_t* period_count)
     return k_rx_err_null_pointer;
   }
 
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || !s_initialized[channel]) {
     return k_rx_err_invalid_state;
   }
 
@@ -205,11 +217,11 @@ rx_err_t rx_gptw_get_period(rx_gptw_channel_t channel, uint32_t* period_count)
 
 rx_err_t rx_gptw_enable_output(rx_gptw_channel_t channel, rx_gptw_output_t output, bool enable)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS || !s_initialized[channel]) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels || !s_initialized[channel]) {
     return k_rx_err_invalid_state;
   }
 
-  if ((int)output >= MOCK_GPTW_OUTPUTS_PER_CH) {
+  if ((int32_t)output >= k_mock_gptw_outputs_per_ch) {
     return k_rx_err_invalid_arg;
   }
 
@@ -219,7 +231,7 @@ rx_err_t rx_gptw_enable_output(rx_gptw_channel_t channel, rx_gptw_output_t outpu
 
 rx_err_t rx_gptw_start(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return k_rx_err_invalid_arg;
   }
 
@@ -229,7 +241,7 @@ rx_err_t rx_gptw_start(rx_gptw_channel_t channel)
 
 rx_err_t rx_gptw_stop(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return k_rx_err_invalid_arg;
   }
 
@@ -239,18 +251,18 @@ rx_err_t rx_gptw_stop(rx_gptw_channel_t channel)
 
 rx_err_t rx_gptw_deinit(rx_gptw_channel_t channel)
 {
-  if ((int)channel >= MOCK_GPTW_MAX_CHANNELS) {
+  if ((int32_t)channel >= k_mock_gptw_max_channels) {
     return k_rx_err_invalid_arg;
   }
 
-  s_initialized[channel]       = false;
-  s_running[channel]           = false;
-  s_period[channel]            = 0;
-  s_frequency[channel]         = 0;
-  s_duty[channel][0]           = 0.0f;
-  s_duty[channel][1]           = 0.0f;
-  s_output_enabled[channel][0] = false;
-  s_output_enabled[channel][1] = false;
+  s_initialized[channel]                            = false;
+  s_running[channel]                                = false;
+  s_period[channel]                                 = 0;
+  s_frequency[channel]                              = 0;
+  s_duty[channel][k_mock_gptw_output_a]             = 0.0f;
+  s_duty[channel][k_mock_gptw_output_b]             = 0.0f;
+  s_output_enabled[channel][k_mock_gptw_output_a]   = false;
+  s_output_enabled[channel][k_mock_gptw_output_b]   = false;
 
   return k_rx_ok;
 }

--- a/star-rx72n-firmware/tests/mocks/mock_rx_gptw.h
+++ b/star-rx72n-firmware/tests/mocks/mock_rx_gptw.h
@@ -1,0 +1,96 @@
+/**
+ * @file mock_rx_gptw.h
+ * @brief Mock GPTW Driver for Unit Testing
+ *
+ * Provides mock implementation of GPTW driver for host-side testing.
+ * Tracks initialization state and duty cycle values without hardware.
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef MOCK_RX_GPTW_H
+#define MOCK_RX_GPTW_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "rx_gptw.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Mock Test Helpers
+ * =============================================================================
+ */
+
+/**
+ * @brief Reset all mock state
+ *
+ * Call before each test to ensure clean state.
+ */
+void mock_gptw_reset(void);
+
+/**
+ * @brief Check if channel is initialized
+ *
+ * @param[in] channel GPTW channel
+ *
+ * @return true if initialized, false otherwise
+ */
+bool mock_gptw_is_initialized(rx_gptw_channel_t channel);
+
+/**
+ * @brief Get recorded duty cycle for output
+ *
+ * @param[in] channel GPTW channel
+ * @param[in] output Output channel (A/B)
+ *
+ * @return Duty cycle percentage (0.0 - 100.0)
+ */
+float mock_gptw_get_duty(rx_gptw_channel_t channel, rx_gptw_output_t output);
+
+/**
+ * @brief Get recorded period for channel
+ *
+ * @param[in] channel GPTW channel
+ *
+ * @return Period count value
+ */
+uint32_t mock_gptw_get_period_value(rx_gptw_channel_t channel);
+
+/**
+ * @brief Get recorded frequency for channel
+ *
+ * @param[in] channel GPTW channel
+ *
+ * @return Frequency in Hz
+ */
+uint32_t mock_gptw_get_frequency(rx_gptw_channel_t channel);
+
+/**
+ * @brief Check if output is enabled
+ *
+ * @param[in] channel GPTW channel
+ * @param[in] output Output channel (A/B)
+ *
+ * @return true if enabled, false otherwise
+ */
+bool mock_gptw_is_output_enabled(rx_gptw_channel_t channel, rx_gptw_output_t output);
+
+/**
+ * @brief Check if timer is running
+ *
+ * @param[in] channel GPTW channel
+ *
+ * @return true if running, false otherwise
+ */
+bool mock_gptw_is_running(rx_gptw_channel_t channel);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCK_RX_GPTW_H */

--- a/star-rx72n-firmware/tests/mocks/mock_rx_gptw.h
+++ b/star-rx72n-firmware/tests/mocks/mock_rx_gptw.h
@@ -1,7 +1,9 @@
+/* tests/mocks/mock_rx_gptw.h */
+
 /**
  * @file mock_rx_gptw.h
  * @brief Mock GPTW Driver for Unit Testing
- *
+ * @details
  * Provides mock implementation of GPTW driver for host-side testing.
  * Tracks initialization state and duty cycle values without hardware.
  *

--- a/star-rx72n-firmware/tests/test_rx_motor.c
+++ b/star-rx72n-firmware/tests/test_rx_motor.c
@@ -118,11 +118,11 @@ static int test_motor_set_duty_forward(void)
   rx_err_t err = rx_motor_set_duty(&motor, 50.0f);
   TEST_ASSERT_OK(err);
 
-  /* Forward: output_a = 50%, output_b = 0% */
-  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_0, k_gptw_output_a), 50.0f,
-                       "Output A should be 50%");
-  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_0, k_gptw_output_b), 0.0f,
-                       "Output B should be 0%");
+  /* Forward (PH/EN mode): PH (output_a) = 100%, EN (output_b) = 50% */
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_0, k_gptw_output_a), 100.0f,
+                       "Output A (PH) should be 100%");
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_0, k_gptw_output_b), 50.0f,
+                       "Output B (EN) should be 50%");
 
   printf("PASS: %s\n", __func__);
   return 0;
@@ -147,11 +147,11 @@ static int test_motor_set_duty_reverse(void)
   rx_err_t err = rx_motor_set_duty(&motor, -75.0f);
   TEST_ASSERT_OK(err);
 
-  /* Reverse: output_a = 0%, output_b = 75% */
+  /* Reverse (PH/EN mode): PH (output_a) = 0%, EN (output_b) = 75% */
   TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_1, k_gptw_output_a), 0.0f,
-                       "Output A should be 0%");
+                       "Output A (PH) should be 0%");
   TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_1, k_gptw_output_b), 75.0f,
-                       "Output B should be 75%");
+                       "Output B (EN) should be 75%");
 
   printf("PASS: %s\n", __func__);
   return 0;
@@ -177,11 +177,11 @@ static int test_motor_stop_brake(void)
   rx_err_t err = rx_motor_stop(&motor, true); /* brake = true */
   TEST_ASSERT_OK(err);
 
-  /* Brake: both outputs HIGH (100%) */
-  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_2, k_gptw_output_a), 100.0f,
-                       "Output A should be 100% for brake");
-  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_2, k_gptw_output_b), 100.0f,
-                       "Output B should be 100% for brake");
+  /* Brake not supported in PH/EN mode - falls back to coast (both 0%) */
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_2, k_gptw_output_a), 0.0f,
+                       "Output A should be 0% (coast fallback)");
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_2, k_gptw_output_b), 0.0f,
+                       "Output B should be 0% (coast fallback)");
 
   printf("PASS: %s\n", __func__);
   return 0;
@@ -207,11 +207,11 @@ static int test_motor_stop_coast(void)
   rx_err_t err = rx_motor_stop(&motor, false); /* brake = false (coast) */
   TEST_ASSERT_OK(err);
 
-  /* Coast: both outputs LOW (0%) */
+  /* Coast (PH/EN mode): EN = LOW for high impedance */
   TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_3, k_gptw_output_a), 0.0f,
-                       "Output A should be 0% for coast");
+                       "Output A (PH) should be 0% for coast");
   TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_3, k_gptw_output_b), 0.0f,
-                       "Output B should be 0% for coast");
+                       "Output B (EN) should be 0% for coast");
 
   printf("PASS: %s\n", __func__);
   return 0;

--- a/star-rx72n-firmware/tests/test_rx_motor.c
+++ b/star-rx72n-firmware/tests/test_rx_motor.c
@@ -1,0 +1,296 @@
+/**
+ * @file test_rx_motor.c
+ * @brief Unit Tests for RX Motor Driver (GPTW-based)
+ *
+ * Tests motor initialization, duty cycle control, brake/coast modes
+ * using the GPTW mock implementation.
+ *
+ * @date 2026-01-04
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include <assert.h>
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "rx_motor.h"
+#include "mocks/mock_rx_gptw.h"
+
+/* =============================================================================
+ * Test Helpers
+ * =============================================================================
+ */
+
+#define TEST_ASSERT(cond, msg)                                                                     \
+  do {                                                                                             \
+    if (!(cond)) {                                                                                 \
+      printf("FAIL: %s (line %d): %s\n", __func__, __LINE__, msg);                                 \
+      return 1;                                                                                    \
+    }                                                                                              \
+  } while (0)
+
+#define TEST_ASSERT_EQ(a, b, msg) TEST_ASSERT((a) == (b), msg)
+#define TEST_ASSERT_OK(err)       TEST_ASSERT((err) == k_rx_ok, "Expected k_rx_ok")
+
+#define FLOAT_EPSILON 0.01f
+#define TEST_ASSERT_FLOAT_EQ(a, b, msg) TEST_ASSERT(fabsf((a) - (b)) < FLOAT_EPSILON, msg)
+
+static void test_setup(void)
+{
+  mock_gptw_reset();
+}
+
+/* =============================================================================
+ * Test Cases
+ * =============================================================================
+ */
+
+static int test_motor_init_success(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_0,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 1000,
+    .invert_pwm   = false,
+  };
+
+  rx_err_t err = rx_motor_init(&motor, &config);
+  TEST_ASSERT_OK(err);
+  TEST_ASSERT(motor.initialized, "Motor should be initialized");
+  TEST_ASSERT(mock_gptw_is_initialized(k_gptw_channel_0), "GPTW should be initialized");
+  TEST_ASSERT_EQ(mock_gptw_get_frequency(k_gptw_channel_0), 20000, "Frequency should be 20kHz");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_init_null_handle(void)
+{
+  test_setup();
+
+  rx_motor_config_t config = {
+    .channel     = k_gptw_channel_0,
+    .pwm_freq_hz = 20000,
+  };
+
+  rx_err_t err = rx_motor_init(NULL, &config);
+  TEST_ASSERT_EQ(err, k_rx_err_null_pointer, "Should return null pointer error");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_init_null_config(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+
+  rx_err_t err = rx_motor_init(&motor, NULL);
+  TEST_ASSERT_EQ(err, k_rx_err_null_pointer, "Should return null pointer error");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_set_duty_forward(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_0,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 0,
+    .invert_pwm   = false,
+  };
+
+  rx_motor_init(&motor, &config);
+
+  rx_err_t err = rx_motor_set_duty(&motor, 50.0f);
+  TEST_ASSERT_OK(err);
+
+  /* Forward: output_a = 50%, output_b = 0% */
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_0, k_gptw_output_a), 50.0f,
+                       "Output A should be 50%");
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_0, k_gptw_output_b), 0.0f,
+                       "Output B should be 0%");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_set_duty_reverse(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_1,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 0,
+    .invert_pwm   = false,
+  };
+
+  rx_motor_init(&motor, &config);
+
+  rx_err_t err = rx_motor_set_duty(&motor, -75.0f);
+  TEST_ASSERT_OK(err);
+
+  /* Reverse: output_a = 0%, output_b = 75% */
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_1, k_gptw_output_a), 0.0f,
+                       "Output A should be 0%");
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_1, k_gptw_output_b), 75.0f,
+                       "Output B should be 75%");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_stop_brake(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_2,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 0,
+    .invert_pwm   = false,
+  };
+
+  rx_motor_init(&motor, &config);
+  rx_motor_set_duty(&motor, 50.0f);
+
+  rx_err_t err = rx_motor_stop(&motor, true); /* brake = true */
+  TEST_ASSERT_OK(err);
+
+  /* Brake: both outputs HIGH (100%) */
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_2, k_gptw_output_a), 100.0f,
+                       "Output A should be 100% for brake");
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_2, k_gptw_output_b), 100.0f,
+                       "Output B should be 100% for brake");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_stop_coast(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_3,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 0,
+    .invert_pwm   = false,
+  };
+
+  rx_motor_init(&motor, &config);
+  rx_motor_set_duty(&motor, 50.0f);
+
+  rx_err_t err = rx_motor_stop(&motor, false); /* brake = false (coast) */
+  TEST_ASSERT_OK(err);
+
+  /* Coast: both outputs LOW (0%) */
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_3, k_gptw_output_a), 0.0f,
+                       "Output A should be 0% for coast");
+  TEST_ASSERT_FLOAT_EQ(mock_gptw_get_duty(k_gptw_channel_3, k_gptw_output_b), 0.0f,
+                       "Output B should be 0% for coast");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_get_duty(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_0,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 0,
+    .invert_pwm   = false,
+  };
+
+  rx_motor_init(&motor, &config);
+  rx_motor_set_duty(&motor, 65.0f);
+
+  float duty;
+  rx_err_t err = rx_motor_get_duty(&motor, &duty);
+  TEST_ASSERT_OK(err);
+  TEST_ASSERT_FLOAT_EQ(duty, 65.0f, "Duty should be 65%");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+static int test_motor_deinit(void)
+{
+  test_setup();
+
+  rx_motor_handle_t motor = {0};
+  rx_motor_config_t config = {
+    .channel      = k_gptw_channel_0,
+    .output_a     = k_gptw_output_a,
+    .output_b     = k_gptw_output_b,
+    .pwm_freq_hz  = 20000,
+    .dead_time_ns = 0,
+    .invert_pwm   = false,
+  };
+
+  rx_motor_init(&motor, &config);
+  TEST_ASSERT(motor.initialized, "Motor should be initialized");
+
+  rx_err_t err = rx_motor_deinit(&motor);
+  TEST_ASSERT_OK(err);
+  TEST_ASSERT(!motor.initialized, "Motor should not be initialized after deinit");
+  TEST_ASSERT(!mock_gptw_is_initialized(k_gptw_channel_0), "GPTW should be deinitialized");
+
+  printf("PASS: %s\n", __func__);
+  return 0;
+}
+
+/* =============================================================================
+ * Test Runner
+ * =============================================================================
+ */
+
+int main(void)
+{
+  int failures = 0;
+
+  printf("\n=== RX Motor Tests (GPTW-based) ===\n\n");
+
+  failures += test_motor_init_success();
+  failures += test_motor_init_null_handle();
+  failures += test_motor_init_null_config();
+  failures += test_motor_set_duty_forward();
+  failures += test_motor_set_duty_reverse();
+  failures += test_motor_stop_brake();
+  failures += test_motor_stop_coast();
+  failures += test_motor_get_duty();
+  failures += test_motor_deinit();
+
+  printf("\n=== Results: %d failures ===\n\n", failures);
+
+  return failures;
+}

--- a/star-rx72n-firmware/tests/test_rx_motor.c
+++ b/star-rx72n-firmware/tests/test_rx_motor.c
@@ -1,7 +1,9 @@
+/* tests/test_rx_motor.c */
+
 /**
  * @file test_rx_motor.c
  * @brief Unit Tests for RX Motor Driver (GPTW-based)
- *
+ * @details
  * Tests motor initialization, duty cycle control, brake/coast modes
  * using the GPTW mock implementation.
  *


### PR DESCRIPTION
## Summary

Fixes #42 - Motors were incorrectly using MTU timers which should be reserved for encoder quadrature decoding.

- Refactored motor control to use GPTW (General PWM Timer) for 32-bit PWM resolution
- Added complete GPTW driver with register definitions and API
- Updated DRV8243 H-bridge driver to use GPTW types
- Added MPC configuration for Port E GPTW pins (auto-configured in init)
- Added mock implementation and unit tests for motor driver

## Changes

| File | Description |
|------|-------------|
| `rx72n_gptw_regs.h` | NEW - GPTW register definitions |
| `rx_gptw.h` | NEW - GPTW driver API |
| `rx_gptw.c` | NEW - GPTW driver implementation |
| `mock_rx_gptw.c/h` | NEW - Mock for unit testing |
| `test_rx_motor.c` | NEW - Motor driver unit tests |
| `rx_motor.h/c` | Updated to use GPTW types |
| `rx_drv8243.h/c` | Updated to use GPTW types |
| `rx72n_mpc_regs.h` | Added Port E PFS registers |
| `CMakeLists.txt` | Added rx_gptw.c to build |

## Motor Pin Mapping (Port E)

| Motor | GPTW Ch | Output A | Output B |
|-------|---------|----------|----------|
| 0 | GPTW0 | PE5/GTIOC0A | PE2/GTIOC0B |
| 1 | GPTW1 | PE4/GTIOC1A | PE1/GTIOC1B |
| 2 | GPTW2 | PE3/GTIOC2A | PE0/GTIOC2B |
| 3 | GPTW3 | PE7/GTIOC3A | PE6/GTIOC3B |

## Test plan

- [x] Project compiles successfully
- [x] Motors use GPTW channels 0-3
- [x] Encoders still use MTU (unchanged)
- [x] DRV8243 driver updated
- [ ] Hardware verification on RX72N board