### PR TITLE
refactor: Replace hardware register macros with inline accessor functions

### DIFF
--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -72,8 +72,9 @@ Review rx_pid.c for NASA Power of 10 compliance
 ### Rule 8: Limit Preprocessor Use
 - [ ] **ALWAYS use `enum` for integer constants** (never `#define`)
 - [ ] Use `static const` ONLY for floating-point values (enum can't hold floats)
-- [ ] Macros ONLY allowed for: (1) reducing duplicated code, (2) conditional compilation, (3) hardware addresses, (4) build flags
-- [ ] **FORBIDDEN**: Macros for simple constants or backward compatibility (no releases = no compatibility needed)
+- [ ] Macros ONLY allowed for: (1) reducing duplicated code, (2) conditional compilation, (3) build flags
+- [ ] **FORBIDDEN**: Macros for simple constants, hardware addresses, or backward compatibility
+- [ ] **Hardware register access**: Use inline accessor functions with enum addresses (never macros)
 - [ ] **NO MAGIC NUMBERS**: All numeric literals must be named enums (including array indices, bit shifts, offsets)
 - [ ] No token pasting (`##`) except in allowed macro cases
 - [ ] No recursive macros
@@ -81,9 +82,11 @@ Review rx_pid.c for NASA Power of 10 compliance
 - Good: `typedef enum { k_idx_high_byte = 0, k_idx_low_byte = 1 } be16_idx_t;`
 - Good: `typedef enum { k_shift_enable = 7, k_shift_mode = 3 } reg_shifts_t;`
 - Good: `#define RX_RETURN_ON_ERROR(err, tag, msg) /* multi-line validation */`
+- Good: `static inline CMT_Type* cmt0(void) { return (CMT_Type*)k_cmt0_base; }` (hardware accessor)
 - Bad: `buf[0] = (val >> 8);` (magic 0 and 8 - use enums!)
 - Bad: `#define TIMEOUT_MS 1000` (should be enum!)
 - Bad: `#define MAX_VELOCITY 2.5f` (should be static const float!)
+- Bad: `#define CMT0 ((CMT_Type*)0x00088000)` (should be inline accessor!)
 - Bad: `#define old_func new_func` (no backward compatibility - just update call sites!)
 
 ### Rule 9: Restrict Pointer Use

--- a/.claude/skills/code-review/STANDARDS.md
+++ b/.claude/skills/code-review/STANDARDS.md
@@ -208,12 +208,12 @@ if (ret != RX_OK) {
 **Allowed Macro Uses (Exhaustive List):**
 1. **Reducing duplicated code** - Function-like macros (e.g., `RX_RETURN_ON_ERROR`)
 2. **Conditional compilation** - Compile-time optimization (e.g., logging macros)
-3. **Hardware addresses** - Register pointers (can't use enum for addresses)
-4. **Build configuration flags** - Feature selection (e.g., `RX_CRC32_USE_HARDWARE`)
+3. **Build configuration flags** - Feature selection (e.g., `RX_CRC32_USE_HARDWARE`)
 
 **Forbidden Macro Uses:**
 - Simple integer constants (use enum)
 - Simple floating-point constants (use static const)
+- Hardware register addresses (use inline accessor functions instead)
 - Function aliases for backward compatibility (project has no releases, no backward compatibility needed)
 
 **No Magic Numbers Policy:**
@@ -296,16 +296,30 @@ static void parse_frame(const uint8_t* frame) {
 #define rx_log_error(tag, msg) ((void)0)  /* Optimized away at compile time */
 #endif
 
-/* ACCEPTABLE: Hardware register addresses */
-#define CMT0_BASE ((rx_cmt_channel_regs_t*)0x00088000)
-#define CMT0      (*CMT0_BASE)
-
 /* ACCEPTABLE: Build configuration flags */
 #ifdef __RX__
 #define RX_CRC32_USE_HARDWARE
 #else
 #define RX_CRC32_USE_SOFTWARE
 #endif
+
+/* PREFERRED: Hardware register access via inline accessors */
+typedef enum {
+    k_cmt0_base_addr  = 0x00088000,  /* CMT0 peripheral base address */
+    k_port0_base_addr = 0x000C0000,  /* PORT0 GPIO base address */
+} hw_addresses_t;
+
+static inline CMT_Type* cmt0(void) {
+    return (CMT_Type*)k_cmt0_base_addr;
+}
+
+static inline PORT_Type* port0(void) {
+    return (PORT_Type*)k_port0_base_addr;
+}
+
+/* Usage: Identical syntax to macro-based approach */
+cmt0()->CMCR = 0x0042;
+port0()->PDR |= (1 << 3);
 ```
 
 **Non-Compliant Example (AVOID):**
@@ -315,6 +329,10 @@ static void parse_frame(const uint8_t* frame) {
 #define TIMEOUT_MS 1000        // WRONG! Use enum
 #define BUFFER_SIZE 256        // WRONG! Use enum
 #define MAX_VELOCITY 2.5f      // WRONG! Use static const float
+
+/* BAD: Using macros for hardware addresses - NEVER DO THIS */
+#define CMT0_BASE ((CMT_Type*)0x00088000)  // WRONG! Use inline accessor
+#define CMT0 (*CMT0_BASE)                   // WRONG! Use inline accessor
 
 /* BAD: Magic numbers everywhere */
 static void write_be16_bad(uint8_t* buf, uint16_t val) {
@@ -339,16 +357,25 @@ static void config_register_bad(void) {
  * - Not searchable (can't grep for "sync offset")
  * - No semantic meaning in debugger
  *
- * WHY MACROS ARE BAD:
+ * WHY MACROS ARE BAD (for constants and hardware addresses):
  * - No type safety (preprocessor text substitution)
- * - Not visible in debugger
- * - Can't take address of value
+ * - Not visible in debugger (can't inspect value)
+ * - Can't take address of macro
  * - No scoping/namespacing
  * - Prone to macro expansion bugs
+ * - For hardware: inline accessors provide same zero-overhead with type safety
+ *
+ * WHY INLINE ACCESSORS ARE BETTER (for hardware registers):
+ * - Type-safe (function returns typed pointer)
+ * - Debugger-friendly (can step into, inspect)
+ * - Compiler optimizes to same code as macro (zero overhead)
+ * - Can add validation in debug builds
+ * - Address is enum constant (named, searchable)
  *
  * RULE: If it's an integer (even 0, 1, 8!), use enum. Always.
  *       If it's floating-point, use static const.
- *       Never use #define for constants.
+ *       If it's a hardware address, use inline accessor with enum address.
+ *       Never use #define for constants or hardware addresses.
  *       Never use literal numbers.
  */
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ star.v1.RequestHeader.request_id max_size:64
    #define MAX_VELOCITY_MPS (2.5f)  // ❌ Should be const!
    ```
 
-3. **Macros** - ONLY for these 4 specific cases:
+3. **Macros** - ONLY for these 3 specific cases:
    ```c
    // ✓ ALLOWED: Reducing duplicated code
    #define RX_RETURN_ON_ERROR(err, tag, msg) \
@@ -198,17 +198,38 @@ star.v1.RequestHeader.request_id max_size:64
    #define rx_log_error(tag, msg) ((void)0)
    #endif
 
-   // ✓ ALLOWED: Hardware register addresses
-   #define CMT0_BASE ((rx_cmt_channel_regs_t*)0x00088000)
-   #define CMT0      (*CMT0_BASE)
-
    // ✓ ALLOWED: Build configuration flags
    #ifdef __RX__
    #define RX_CRC32_USE_HARDWARE
    #endif
 
+   // ❌ FORBIDDEN: Hardware register addresses (use inline accessors)
+   #define CMT0_BASE ((rx_cmt_channel_regs_t*)0x00088000)  // Wrong!
+   #define CMT0      (*CMT0_BASE)                          // Wrong!
+
    // ❌ FORBIDDEN: Backward compatibility (no releases = no compatibility)
    #define old_function new_function  // Wrong! Update call sites instead
+   ```
+
+4. **Hardware Register Access** - Use inline accessor functions:
+   ```c
+   // ✓ CORRECT: Inline accessor with enum address
+   typedef enum {
+       k_cmt0_base_addr  = 0x00088000,
+       k_port0_base_addr = 0x000C0000,
+   } hw_addresses_t;
+
+   static inline CMT_Type* cmt0(void) {
+       return (CMT_Type*)k_cmt0_base_addr;
+   }
+
+   static inline PORT_Type* port0(void) {
+       return (PORT_Type*)k_port0_base_addr;
+   }
+
+   // Usage: Same syntax as macro approach
+   cmt0()->CMCR = 0x0042;
+   port0()->PDR |= (1 << k_bit_led);
    ```
 
 ### No Magic Numbers
@@ -306,7 +327,8 @@ The STAR project follows NASA/JPL Power of 10 rules for safety-critical embedded
 
 ### Rule 8: Limit Preprocessor Use ✓ COMPLIANT
 - Enums for ALL integer constants (mandatory)
-- Macros ONLY for: duplicated code, conditional compilation, hardware addresses, build flags
+- Macros ONLY for: duplicated code, conditional compilation, build flags
+- Hardware register access: Use inline accessor functions (never macros)
 - See "Constants and Macros" section above for complete policy
 
 ### Rule 9: Restrict Pointer Use ⚠️ INTENTIONAL DEVIATION

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -49,16 +49,33 @@ rx_err_t new_function_name(...)  /* ✓ Clean break, no compatibility layer */
 
 1. **Enums** - ALWAYS use for ALL integer constants (mandatory)
 2. **static const** - ONLY for floating-point values (enum can't hold floats)
-3. **Macros** - ONLY for these 4 specific cases:
+3. **Macros** - ONLY for these 3 specific cases:
    - Reducing duplicated code (function-like macros: `RX_RETURN_ON_ERROR`)
    - Conditional compilation (optimization: `#if LOG_LEVEL >= k_log_error`)
-   - Hardware register addresses (`#define CMT0_BASE ((type*)0x00088000)`)
    - Build configuration flags (`#ifdef __RX__`)
 
 **Never use macros for:**
 - Simple integer constants (use enum instead)
 - Simple floating-point constants (use static const instead)
+- Hardware register addresses (use inline accessor functions instead)
 - Backward compatibility/function aliases (no releases = no compatibility)
+
+**Hardware register access:**
+Use inline accessor functions with enum addresses (never macros):
+```c
+// ✓ CORRECT - Inline accessor with enum address
+typedef enum {
+    k_cmt0_base_addr  = 0x00088000,
+    k_port0_base_addr = 0x000C0000,
+} hw_addresses_t;
+
+static inline CMT_Type* cmt0(void) {
+    return (CMT_Type*)k_cmt0_base_addr;
+}
+
+// Usage: Same syntax as macro approach
+cmt0()->CMCR = 0x0042;
+```
 
 **Examples:**
 ```c
@@ -84,6 +101,7 @@ static const float s_max_velocity_mps = 2.5f;
 // ❌ WRONG - Never use macro for simple constants
 #define TIMEOUT_MS 1000        // Should be enum!
 #define MAX_VELOCITY 2.5f      // Should be static const!
+#define CMT0_BASE ((CMT_Type*)0x00088000)  // Should be inline accessor!
 #define old_func new_func      // No compatibility needed!
 ```
 
@@ -327,7 +345,8 @@ The STAR project follows NASA/JPL Power of 10 rules for safety-critical embedded
 
 ### Rule 8: Limit Preprocessor Use ✓ COMPLIANT
 - Enums for ALL integer constants (mandatory)
-- Macros ONLY for: duplicated code, conditional compilation, hardware addresses, build flags
+- Macros ONLY for: duplicated code, conditional compilation, build flags
+- Hardware register access: Use inline accessor functions (never macros)
 - See "Constants and Macros Policy" section above for complete policy
 
 ### Rule 9: Restrict Pointer Use ⚠️ INTENTIONAL DEVIATION

--- a/star-rx72n-firmware/lib/rx_bus/src/rx_bus_onewire.c
+++ b/star-rx72n-firmware/lib/rx_bus/src/rx_bus_onewire.c
@@ -96,20 +96,20 @@ static void internal_delay_timer_init(void)
   }
 
   /* Enable CMT module clock */
-  SYSTEM.prcr = k_onewire_prcr_unlock;
-  SYSTEM.mstpcrb &= ~(1UL << k_onewire_mstpb_cmt_bit);
-  SYSTEM.prcr = k_onewire_prcr_lock;
+  system_regs()->prcr = k_onewire_prcr_unlock;
+  system_regs()->mstpcrb &= ~(1UL << k_onewire_mstpb_cmt_bit);
+  system_regs()->prcr = k_onewire_prcr_lock;
 
   /* Stop CMT3 before reconfiguration */
-  CMT_CTRL.cmstr1 &= ~(1U << k_onewire_cmt3_start_bit);
+  cmt_ctrl()->cmstr1 &= ~(1U << k_onewire_cmt3_start_bit);
 
   /* Configure free-running counter (no interrupts) */
-  CMT3.cmcr  = (uint16_t)(k_onewire_cmt_divider_setting << k_onewire_cmt_clk_shift);
-  CMT3.cmcor = k_onewire_timer_counter_max;
-  CMT3.cmcnt = 0;
+  cmt3()->cmcr  = (uint16_t)(k_onewire_cmt_divider_setting << k_onewire_cmt_clk_shift);
+  cmt3()->cmcor = k_onewire_timer_counter_max;
+  cmt3()->cmcnt = 0;
 
   /* Start timer */
-  CMT_CTRL.cmstr1 |= (1U << k_onewire_cmt3_start_bit);
+  cmt_ctrl()->cmstr1 |= (1U << k_onewire_cmt3_start_bit);
 
   s_delay_timer_initialized = true;
 }
@@ -135,8 +135,8 @@ static void internal_delay_us(uint32_t microseconds)
   while (ticks > 0ULL) {
     uint32_t wait_ticks =
       (ticks > k_onewire_timer_counter_max) ? k_onewire_timer_counter_max : (uint32_t)ticks;
-    uint16_t start = CMT3.cmcnt;
-    while ((uint16_t)(CMT3.cmcnt - start) < wait_ticks) {
+    uint16_t start = cmt3()->cmcnt;
+    while ((uint16_t)(cmt3()->cmcnt - start) < wait_ticks) {
       __asm__ volatile("nop");
     }
     ticks -= wait_ticks;

--- a/star-rx72n-firmware/lib/rx_core/src/rx_register_guard.c
+++ b/star-rx72n-firmware/lib/rx_core/src/rx_register_guard.c
@@ -90,24 +90,24 @@ static register_guard_state_t s_state = {0};
  */
 static void internal_capture_pdr(void)
 {
-  s_state.pdr.port0_pdr = PORT0.PDR;
-  s_state.pdr.port1_pdr = PORT1.PDR;
-  s_state.pdr.port2_pdr = PORT2.PDR;
-  s_state.pdr.port3_pdr = PORT3.PDR;
-  s_state.pdr.port4_pdr = PORT4.PDR;
-  s_state.pdr.port5_pdr = PORT5.PDR;
-  s_state.pdr.port6_pdr = PORT6.PDR;
-  s_state.pdr.port7_pdr = PORT7.PDR;
-  s_state.pdr.port8_pdr = PORT8.PDR;
-  s_state.pdr.port9_pdr = PORT9.PDR;
-  s_state.pdr.porta_pdr = PORTA.PDR;
-  s_state.pdr.portb_pdr = PORTB.PDR;
-  s_state.pdr.portc_pdr = PORTC.PDR;
-  s_state.pdr.portd_pdr = PORTD.PDR;
-  s_state.pdr.porte_pdr = PORTE.PDR;
-  s_state.pdr.portf_pdr = PORTF.PDR;
-  s_state.pdr.portg_pdr = PORTG.PDR;
-  s_state.pdr.portj_pdr = PORTJ.PDR;
+  s_state.pdr.port0_pdr = port0()->pdr;
+  s_state.pdr.port1_pdr = port1()->pdr;
+  s_state.pdr.port2_pdr = port2()->pdr;
+  s_state.pdr.port3_pdr = port3()->pdr;
+  s_state.pdr.port4_pdr = port4()->pdr;
+  s_state.pdr.port5_pdr = port5()->pdr;
+  s_state.pdr.port6_pdr = port6()->pdr;
+  s_state.pdr.port7_pdr = port7()->pdr;
+  s_state.pdr.port8_pdr = port8()->pdr;
+  s_state.pdr.port9_pdr = port9()->pdr;
+  s_state.pdr.porta_pdr = porta()->pdr;
+  s_state.pdr.portb_pdr = portb()->pdr;
+  s_state.pdr.portc_pdr = portc()->pdr;
+  s_state.pdr.portd_pdr = portd()->pdr;
+  s_state.pdr.porte_pdr = porte()->pdr;
+  s_state.pdr.portf_pdr = portf()->pdr;
+  s_state.pdr.portg_pdr = portg()->pdr;
+  s_state.pdr.portj_pdr = portj()->pdr;
 }
 
 /**
@@ -115,10 +115,10 @@ static void internal_capture_pdr(void)
  */
 static void internal_capture_mstpcr(void)
 {
-  s_state.mstpcr.mstpcra = SYSTEM.MSTPCRA;
-  s_state.mstpcr.mstpcrb = SYSTEM.MSTPCRB;
-  s_state.mstpcr.mstpcrc = SYSTEM.MSTPCRC;
-  s_state.mstpcr.mstpcrd = SYSTEM.MSTPCRD;
+  s_state.mstpcr.mstpcra = system_regs()->mstpcra;
+  s_state.mstpcr.mstpcrb = system_regs()->mstpcrb;
+  s_state.mstpcr.mstpcrc = system_regs()->mstpcrc;
+  s_state.mstpcr.mstpcrd = system_regs()->mstpcrd;
 }
 
 /**
@@ -127,76 +127,76 @@ static void internal_capture_mstpcr(void)
 static void internal_refresh_pdr(void)
 {
   /* Check and restore each PORT PDR */
-  if (PORT0.PDR != s_state.pdr.port0_pdr) {
-    PORT0.PDR = s_state.pdr.port0_pdr;
+  if (port0()->pdr != s_state.pdr.port0_pdr) {
+    port0()->pdr = s_state.pdr.port0_pdr;
     s_state.corrections++;
   }
-  if (PORT1.PDR != s_state.pdr.port1_pdr) {
-    PORT1.PDR = s_state.pdr.port1_pdr;
+  if (port1()->pdr != s_state.pdr.port1_pdr) {
+    port1()->pdr = s_state.pdr.port1_pdr;
     s_state.corrections++;
   }
-  if (PORT2.PDR != s_state.pdr.port2_pdr) {
-    PORT2.PDR = s_state.pdr.port2_pdr;
+  if (port2()->pdr != s_state.pdr.port2_pdr) {
+    port2()->pdr = s_state.pdr.port2_pdr;
     s_state.corrections++;
   }
-  if (PORT3.PDR != s_state.pdr.port3_pdr) {
-    PORT3.PDR = s_state.pdr.port3_pdr;
+  if (port3()->pdr != s_state.pdr.port3_pdr) {
+    port3()->pdr = s_state.pdr.port3_pdr;
     s_state.corrections++;
   }
-  if (PORT4.PDR != s_state.pdr.port4_pdr) {
-    PORT4.PDR = s_state.pdr.port4_pdr;
+  if (port4()->pdr != s_state.pdr.port4_pdr) {
+    port4()->pdr = s_state.pdr.port4_pdr;
     s_state.corrections++;
   }
-  if (PORT5.PDR != s_state.pdr.port5_pdr) {
-    PORT5.PDR = s_state.pdr.port5_pdr;
+  if (port5()->pdr != s_state.pdr.port5_pdr) {
+    port5()->pdr = s_state.pdr.port5_pdr;
     s_state.corrections++;
   }
-  if (PORT6.PDR != s_state.pdr.port6_pdr) {
-    PORT6.PDR = s_state.pdr.port6_pdr;
+  if (port6()->pdr != s_state.pdr.port6_pdr) {
+    port6()->pdr = s_state.pdr.port6_pdr;
     s_state.corrections++;
   }
-  if (PORT7.PDR != s_state.pdr.port7_pdr) {
-    PORT7.PDR = s_state.pdr.port7_pdr;
+  if (port7()->pdr != s_state.pdr.port7_pdr) {
+    port7()->pdr = s_state.pdr.port7_pdr;
     s_state.corrections++;
   }
-  if (PORT8.PDR != s_state.pdr.port8_pdr) {
-    PORT8.PDR = s_state.pdr.port8_pdr;
+  if (port8()->pdr != s_state.pdr.port8_pdr) {
+    port8()->pdr = s_state.pdr.port8_pdr;
     s_state.corrections++;
   }
-  if (PORT9.PDR != s_state.pdr.port9_pdr) {
-    PORT9.PDR = s_state.pdr.port9_pdr;
+  if (port9()->pdr != s_state.pdr.port9_pdr) {
+    port9()->pdr = s_state.pdr.port9_pdr;
     s_state.corrections++;
   }
-  if (PORTA.PDR != s_state.pdr.porta_pdr) {
-    PORTA.PDR = s_state.pdr.porta_pdr;
+  if (porta()->pdr != s_state.pdr.porta_pdr) {
+    porta()->pdr = s_state.pdr.porta_pdr;
     s_state.corrections++;
   }
-  if (PORTB.PDR != s_state.pdr.portb_pdr) {
-    PORTB.PDR = s_state.pdr.portb_pdr;
+  if (portb()->pdr != s_state.pdr.portb_pdr) {
+    portb()->pdr = s_state.pdr.portb_pdr;
     s_state.corrections++;
   }
-  if (PORTC.PDR != s_state.pdr.portc_pdr) {
-    PORTC.PDR = s_state.pdr.portc_pdr;
+  if (portc()->pdr != s_state.pdr.portc_pdr) {
+    portc()->pdr = s_state.pdr.portc_pdr;
     s_state.corrections++;
   }
-  if (PORTD.PDR != s_state.pdr.portd_pdr) {
-    PORTD.PDR = s_state.pdr.portd_pdr;
+  if (portd()->pdr != s_state.pdr.portd_pdr) {
+    portd()->pdr = s_state.pdr.portd_pdr;
     s_state.corrections++;
   }
-  if (PORTE.PDR != s_state.pdr.porte_pdr) {
-    PORTE.PDR = s_state.pdr.porte_pdr;
+  if (porte()->pdr != s_state.pdr.porte_pdr) {
+    porte()->pdr = s_state.pdr.porte_pdr;
     s_state.corrections++;
   }
-  if (PORTF.PDR != s_state.pdr.portf_pdr) {
-    PORTF.PDR = s_state.pdr.portf_pdr;
+  if (portf()->pdr != s_state.pdr.portf_pdr) {
+    portf()->pdr = s_state.pdr.portf_pdr;
     s_state.corrections++;
   }
-  if (PORTG.PDR != s_state.pdr.portg_pdr) {
-    PORTG.PDR = s_state.pdr.portg_pdr;
+  if (portg()->pdr != s_state.pdr.portg_pdr) {
+    portg()->pdr = s_state.pdr.portg_pdr;
     s_state.corrections++;
   }
-  if (PORTJ.PDR != s_state.pdr.portj_pdr) {
-    PORTJ.PDR = s_state.pdr.portj_pdr;
+  if (portj()->pdr != s_state.pdr.portj_pdr) {
+    portj()->pdr = s_state.pdr.portj_pdr;
     s_state.corrections++;
   }
 }
@@ -214,16 +214,16 @@ static void internal_refresh_mstpcr(void)
   bool needs_update = false;
 
   /* Check if any MSTPCR needs update */
-  if (SYSTEM.MSTPCRA != s_state.mstpcr.mstpcra) {
+  if (system_regs()->mstpcra != s_state.mstpcr.mstpcra) {
     needs_update = true;
   }
-  if (SYSTEM.MSTPCRB != s_state.mstpcr.mstpcrb) {
+  if (system_regs()->mstpcrb != s_state.mstpcr.mstpcrb) {
     needs_update = true;
   }
-  if (SYSTEM.MSTPCRC != s_state.mstpcr.mstpcrc) {
+  if (system_regs()->mstpcrc != s_state.mstpcr.mstpcrc) {
     needs_update = true;
   }
-  if (SYSTEM.MSTPCRD != s_state.mstpcr.mstpcrd) {
+  if (system_regs()->mstpcrd != s_state.mstpcr.mstpcrd) {
     needs_update = true;
   }
 
@@ -241,26 +241,28 @@ static void internal_refresh_mstpcr(void)
   __asm__ volatile("mvfc psw, %0" : "=r"(psw));
   __asm__ volatile("clrpsw i"); /* Disable interrupts during unlock */
 
-  SYSTEM.PRCR = (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_prc1; /* Unlock MSTPCR writes */
+  system_regs()->prcr =
+    (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_prc1; /* Unlock MSTPCR writes */
 
-  if (SYSTEM.MSTPCRA != s_state.mstpcr.mstpcra) {
-    SYSTEM.MSTPCRA = s_state.mstpcr.mstpcra;
+  if (system_regs()->mstpcra != s_state.mstpcr.mstpcra) {
+    system_regs()->mstpcra = s_state.mstpcr.mstpcra;
     s_state.corrections++;
   }
-  if (SYSTEM.MSTPCRB != s_state.mstpcr.mstpcrb) {
-    SYSTEM.MSTPCRB = s_state.mstpcr.mstpcrb;
+  if (system_regs()->mstpcrb != s_state.mstpcr.mstpcrb) {
+    system_regs()->mstpcrb = s_state.mstpcr.mstpcrb;
     s_state.corrections++;
   }
-  if (SYSTEM.MSTPCRC != s_state.mstpcr.mstpcrc) {
-    SYSTEM.MSTPCRC = s_state.mstpcr.mstpcrc;
+  if (system_regs()->mstpcrc != s_state.mstpcr.mstpcrc) {
+    system_regs()->mstpcrc = s_state.mstpcr.mstpcrc;
     s_state.corrections++;
   }
-  if (SYSTEM.MSTPCRD != s_state.mstpcr.mstpcrd) {
-    SYSTEM.MSTPCRD = s_state.mstpcr.mstpcrd;
+  if (system_regs()->mstpcrd != s_state.mstpcr.mstpcrd) {
+    system_regs()->mstpcrd = s_state.mstpcr.mstpcrd;
     s_state.corrections++;
   }
 
-  SYSTEM.PRCR = (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_all; /* Lock MSTPCR writes */
+  system_regs()->prcr =
+    (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_all; /* Lock MSTPCR writes */
 
   __asm__ volatile("mvtc %0, psw" : : "r"(psw)); /* Restore interrupt state */
 }

--- a/star-rx72n-firmware/lib/rx_crc/src/rx_crc32_hw.c
+++ b/star-rx72n-firmware/lib/rx_crc/src/rx_crc32_hw.c
@@ -81,7 +81,7 @@ rx_err_t rx_crc_init(void)
      * The RX72N CRC calculator in this configuration produces output
      * bit-exact with Go's crc32.ChecksumIEEE() when properly initialized.
      */
-  CRC.crccr = k_crc_crccr_lms | k_crc_crccr_gps_crc32;
+  crc_regs()->crccr = k_crc_crccr_lms | k_crc_crccr_gps_crc32;
 
   s_crc_initialized = true;
   return k_rx_ok;
@@ -125,7 +125,7 @@ uint32_t rx_crc32_ieee_impl(const uint8_t* data, uint32_t len)
      * For IEEE 802.3, the initial value is 0xFFFFFFFF. The RX72N hardware
      * handles this automatically when DORCLR is set.
      */
-  CRC.crccr |= k_crc_crccr_dorclr;
+  crc_regs()->crccr |= k_crc_crccr_dorclr;
 
   /*
      * Feed data bytes to the CRC calculator.
@@ -136,7 +136,7 @@ uint32_t rx_crc32_ieee_impl(const uint8_t* data, uint32_t len)
      * Note: For large aligned buffers, 32-bit word writes could be faster,
      * but byte-wise ensures correctness for all cases.
      */
-  volatile uint8_t* crcdir_byte = (volatile uint8_t*)&CRC.crcdir;
+  volatile uint8_t* crcdir_byte = (volatile uint8_t*)&crc_regs()->crcdir;
   for (uint32_t i = 0; i < len; i++) {
     *crcdir_byte = data[i];
   }
@@ -147,7 +147,7 @@ uint32_t rx_crc32_ieee_impl(const uint8_t* data, uint32_t len)
      * IEEE 802.3 requires XOR with 0xFFFFFFFF after calculation.
      * The hardware outputs the raw CRC value, so we apply the final XOR.
      */
-  return CRC.crcdor ^ k_crc_ieee_final_xor;
+  return crc_regs()->crcdor ^ k_crc_ieee_final_xor;
 }
 
 uint32_t rx_crc32_update_impl(uint32_t crc, const uint8_t* data, uint32_t len)

--- a/star-rx72n-firmware/lib/rx_crc/src/rx_crc32_hw.c
+++ b/star-rx72n-firmware/lib/rx_crc/src/rx_crc32_hw.c
@@ -68,10 +68,11 @@ rx_err_t rx_crc_init(void)
   }
 
   /* Enable CRC module by clearing module stop bit */
-  SYSTEM.prcr =
+  system_regs()->prcr =
     (k_prcr_key << k_prcr_key_shift) | k_prcr_unlock_crc; /* Unlock protection for MSTPCR */
-  SYSTEM.mstpcrb &= ~(1UL << k_mstpb_crc);                /* Clear bit 23 to enable CRC */
-  SYSTEM.prcr = (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_all; /* Lock protection */
+  system_regs()->mstpcrb &= ~(1UL << k_mstpb_crc);        /* Clear bit 23 to enable CRC */
+  system_regs()->prcr =
+    (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_all; /* Lock protection */
 
   /*
      * Configure CRC peripheral for IEEE 802.3:
@@ -98,9 +99,9 @@ rx_err_t rx_crc_deinit(void)
      * 3. Power savings from disabling are minimal (CRC is low-power)
      *
      * If power optimization is critical, enable the module stop here:
-     * SYSTEM.PRCR = 0xA50B;
-     * SYSTEM.MSTPCRB |= (1UL << k_mstpb_crc);
-     * SYSTEM.PRCR = 0xA500;
+     * system_regs()->prcr = 0xA50B;
+     * system_regs()->mstpcrb |= (1UL << k_mstpb_crc);
+     * system_regs()->prcr = 0xA500;
      * s_crc_initialized = false;
      */
 

--- a/star-rx72n-firmware/lib/rx_drv8243/src/rx_drv8243.c
+++ b/star-rx72n-firmware/lib/rx_drv8243/src/rx_drv8243.c
@@ -388,27 +388,27 @@ static volatile rx_port_regs_t* internal_get_port_base(uint8_t port)
 {
   switch (port) {
     case 0:
-      return &PORT0;
+      return port0();
     case 1:
-      return &PORT1;
+      return port1();
     case 2:
-      return &PORT2;
+      return port2();
     case 3:
-      return &PORT3;
+      return port3();
     case 4:
-      return &PORT4;
+      return port4();
     case 5:
-      return &PORT5;
+      return port5();
     case 6:
-      return &PORT6;
+      return port6();
     case 7:
-      return &PORT7;
+      return port7();
     case 8:
-      return &PORT8;
+      return port8();
     case 9:
-      return &PORT9;
+      return port9();
     case 10:
-      return &PORTJ;
+      return portj();
     default:
       return NULL;
   }

--- a/star-rx72n-firmware/lib/rx_encoder/src/rx_mtu_encoder.c
+++ b/star-rx72n-firmware/lib/rx_encoder/src/rx_mtu_encoder.c
@@ -144,15 +144,17 @@ rx_err_t rx_encoder_init(const rx_encoder_config_t* config)
   rx_log_info(s_tag, "Info");
 
   /* Enable MTU module (clear module stop bit) */
-  SYSTEM.prcr = (k_prcr_key << k_prcr_key_shift) | k_prcr_unlock_mtu; /* Enable writes to MSTPCR */
+  system_regs()->prcr =
+    (k_prcr_key << k_prcr_key_shift) | k_prcr_unlock_mtu; /* Enable writes to MSTPCR */
 
   if (channel <= k_mtu_channel_4) {
-    SYSTEM.mstpcra &= ~(1 << k_mtu_mstpcra_mtu0_4_bit); /* MTU0-MTU4 */
+    system_regs()->mstpcra &= ~(1 << k_mtu_mstpcra_mtu0_4_bit); /* MTU0-MTU4 */
   } else {
-    SYSTEM.mstpcra &= ~(1 << k_mtu_mstpcra_mtu6_7_bit); /* MTU6-MTU7 */
+    system_regs()->mstpcra &= ~(1 << k_mtu_mstpcra_mtu6_7_bit); /* MTU6-MTU7 */
   }
 
-  SYSTEM.prcr = (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_all; /* Lock MSTPCR */
+  system_regs()->prcr =
+    (k_prcr_key << k_prcr_key_shift) | k_prcr_lock_all; /* Lock MSTPCR */
 
   /* Stop timer before configuration */
   rx_mtu_stop(channel);

--- a/star-rx72n-firmware/lib/rx_encoder/src/rx_mtu_encoder.c
+++ b/star-rx72n-firmware/lib/rx_encoder/src/rx_mtu_encoder.c
@@ -97,19 +97,19 @@ static volatile rx_mtu_channel_regs_t* internal_get_mtu_base(rx_mtu_channel_t ch
 {
   switch (channel) {
     case k_mtu_channel_0:
-      return (volatile rx_mtu_channel_regs_t*)MTU0_BASE;
+      return (volatile rx_mtu_channel_regs_t*)mtu0();
     case k_mtu_channel_1:
-      return (volatile rx_mtu_channel_regs_t*)MTU1_BASE;
+      return (volatile rx_mtu_channel_regs_t*)mtu1();
     case k_mtu_channel_2:
-      return (volatile rx_mtu_channel_regs_t*)MTU2_BASE;
+      return (volatile rx_mtu_channel_regs_t*)mtu2();
     case k_mtu_channel_3:
-      return (volatile rx_mtu_channel_regs_t*)((volatile uint8_t*)MTU3_BASE);
+      return (volatile rx_mtu_channel_regs_t*)((volatile uint8_t*)mtu3());
     case k_mtu_channel_4:
-      return (volatile rx_mtu_channel_regs_t*)((volatile uint8_t*)MTU4_BASE);
+      return (volatile rx_mtu_channel_regs_t*)((volatile uint8_t*)mtu4());
     case k_mtu_channel_6:
-      return (volatile rx_mtu_channel_regs_t*)MTU6_BASE;
+      return (volatile rx_mtu_channel_regs_t*)mtu6();
     case k_mtu_channel_7:
-      return (volatile rx_mtu_channel_regs_t*)MTU7_BASE;
+      return (volatile rx_mtu_channel_regs_t*)mtu7();
     default:
       return NULL;
   }

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_adc_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_adc_regs.h
@@ -25,6 +25,12 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief S12ADFa base addresses */
+typedef enum {
+  k_s12ad0_base_addr = 0x00089000, /**< S12AD0 register base address */
+  k_s12ad1_base_addr = 0x00089100, /**< S12AD1 register base address */
+} rx_s12ad_addresses_t;
+
 /** @brief S12ADFa register reserved field sizes */
 typedef enum {
   k_s12ad_reserved_after_adcsr_bytes   = 2, /**< Reserved bytes after ADCSR */
@@ -62,11 +68,23 @@ typedef struct {
   volatile uint16_t addr7; /**< A/D Data Register 7 (conversion result for AN7) */
 } rx_s12ad_regs_t;
 
-#define S12AD0_BASE ((rx_s12ad_regs_t*)0x00089000)
-#define S12AD1_BASE ((rx_s12ad_regs_t*)0x00089100)
+/**
+ * @brief Get pointer to S12AD0 registers
+ * @return Volatile pointer to S12AD0 register structure
+ */
+static inline volatile rx_s12ad_regs_t* s12ad0(void)
+{
+  return (volatile rx_s12ad_regs_t*)k_s12ad0_base_addr;
+}
 
-#define S12AD0 (*S12AD0_BASE)
-#define S12AD1 (*S12AD1_BASE)
+/**
+ * @brief Get pointer to S12AD1 registers
+ * @return Volatile pointer to S12AD1 register structure
+ */
+static inline volatile rx_s12ad_regs_t* s12ad1(void)
+{
+  return (volatile rx_s12ad_regs_t*)k_s12ad1_base_addr;
+}
 
 #ifdef __cplusplus
 }

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_cmt_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_cmt_regs.h
@@ -25,6 +25,15 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief CMT base addresses */
+typedef enum {
+  k_cmt0_base_addr      = 0x00088000, /**< CMT0 register base address */
+  k_cmt1_base_addr      = 0x00088008, /**< CMT1 register base address */
+  k_cmt2_base_addr      = 0x00088010, /**< CMT2 register base address */
+  k_cmt3_base_addr      = 0x00088018, /**< CMT3 register base address */
+  k_cmt_ctrl_base_addr  = 0x00088002, /**< CMT control register base address */
+} rx_cmt_addresses_t;
+
 /**
  * @brief CMT Channel Register Map
  * @details
@@ -53,17 +62,50 @@ typedef struct {
   volatile uint16_t cmstr1; /**< Compare Match Timer Start Register 1 (CMT2/3) */
 } rx_cmt_control_regs_t;
 
-#define CMT0_BASE     ((rx_cmt_channel_regs_t*)0x00088000)
-#define CMT1_BASE     ((rx_cmt_channel_regs_t*)0x00088008)
-#define CMT2_BASE     ((rx_cmt_channel_regs_t*)0x00088010)
-#define CMT3_BASE     ((rx_cmt_channel_regs_t*)0x00088018)
-#define CMT_CTRL_BASE ((rx_cmt_control_regs_t*)0x00088002)
+/**
+ * @brief Get pointer to CMT0 registers
+ * @return Volatile pointer to CMT0 register structure
+ */
+static inline volatile rx_cmt_channel_regs_t* cmt0(void)
+{
+  return (volatile rx_cmt_channel_regs_t*)k_cmt0_base_addr;
+}
 
-#define CMT0     (*CMT0_BASE)
-#define CMT1     (*CMT1_BASE)
-#define CMT2     (*CMT2_BASE)
-#define CMT3     (*CMT3_BASE)
-#define CMT_CTRL (*CMT_CTRL_BASE)
+/**
+ * @brief Get pointer to CMT1 registers
+ * @return Volatile pointer to CMT1 register structure
+ */
+static inline volatile rx_cmt_channel_regs_t* cmt1(void)
+{
+  return (volatile rx_cmt_channel_regs_t*)k_cmt1_base_addr;
+}
+
+/**
+ * @brief Get pointer to CMT2 registers
+ * @return Volatile pointer to CMT2 register structure
+ */
+static inline volatile rx_cmt_channel_regs_t* cmt2(void)
+{
+  return (volatile rx_cmt_channel_regs_t*)k_cmt2_base_addr;
+}
+
+/**
+ * @brief Get pointer to CMT3 registers
+ * @return Volatile pointer to CMT3 register structure
+ */
+static inline volatile rx_cmt_channel_regs_t* cmt3(void)
+{
+  return (volatile rx_cmt_channel_regs_t*)k_cmt3_base_addr;
+}
+
+/**
+ * @brief Get pointer to CMT control registers
+ * @return Volatile pointer to CMT control register structure
+ */
+static inline volatile rx_cmt_control_regs_t* cmt_ctrl(void)
+{
+  return (volatile rx_cmt_control_regs_t*)k_cmt_ctrl_base_addr;
+}
 
 #ifdef __cplusplus
 }

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_crc_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_crc_regs.h
@@ -35,6 +35,11 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief CRC base address */
+typedef enum {
+  k_crc_base_addr = 0x00088280, /**< CRC register base address */
+} rx_crc_addresses_t;
+
 /** @brief CRC register reserved field sizes */
 typedef enum {
   k_crc_reserved_after_crccr_bytes = 3, /**< Reserved bytes after CRCCR */
@@ -54,8 +59,14 @@ typedef struct {
   volatile uint32_t crcdor; /**< CRC Data Output Register (32-bit CRC result) */
 } rx_crc_regs_t;
 
-#define CRC_BASE ((rx_crc_regs_t*)0x00088280)
-#define CRC      (*CRC_BASE)
+/**
+ * @brief Get pointer to CRC registers
+ * @return Volatile pointer to CRC register structure
+ */
+static inline volatile rx_crc_regs_t* crc_regs(void)
+{
+  return (volatile rx_crc_regs_t*)k_crc_base_addr;
+}
 
 /* CRC Control Register (CRCCR) bit definitions - CRC-32 only */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_icu_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_icu_regs.h
@@ -25,6 +25,11 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief ICU base address */
+typedef enum {
+  k_icu_base_addr = 0x00087000, /**< ICU register base address */
+} rx_icu_addresses_t;
+
 /** @brief ICU register reserved field sizes */
 typedef enum {
   k_icu_reserved_after_ier_bytes     = 192, /**< Reserved bytes after IER */
@@ -79,8 +84,14 @@ typedef struct {
   volatile uint8_t  nmiflt; /**< NMI Filter Control Register */
 } rx_icu_regs_t;
 
-#define ICU_BASE_ADDR ((rx_icu_regs_t*)0x00087000)
-#define ICU           (*ICU_BASE_ADDR)
+/**
+ * @brief Get pointer to ICU registers
+ * @return Volatile pointer to ICU register structure
+ */
+static inline volatile rx_icu_regs_t* icu(void)
+{
+  return (volatile rx_icu_regs_t*)k_icu_base_addr;
+}
 
 /* Vector numbers */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_iwdt_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_iwdt_regs.h
@@ -37,6 +37,11 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief IWDT base address */
+typedef enum {
+  k_iwdt_base_addr = 0x00088030, /**< IWDT register base address */
+} rx_iwdt_addresses_t;
+
 /** @brief IWDT register reserved field sizes */
 typedef enum {
   k_iwdt_reserved_after_iwdtrr_bytes  = 1, /**< Reserved byte after IWDTRR */
@@ -60,8 +65,14 @@ typedef struct {
   volatile uint8_t  iwdtcstpr; /**< Count Stop Control Register (sleep mode) */
 } rx_iwdt_regs_t;
 
-#define IWDT_BASE ((rx_iwdt_regs_t*)0x00088030)
-#define IWDT      (*IWDT_BASE)
+/**
+ * @brief Get pointer to IWDT registers
+ * @return Volatile pointer to IWDT register structure
+ */
+static inline volatile rx_iwdt_regs_t* iwdt(void)
+{
+  return (volatile rx_iwdt_regs_t*)k_iwdt_base_addr;
+}
 
 /* IWDT Refresh Register (IWDTRR) - Write sequence to refresh */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_mpc_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_mpc_regs.h
@@ -25,6 +25,11 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief MPC base address */
+typedef enum {
+  k_mpc_base_addr = 0x0008C100, /**< MPC register base address */
+} rx_mpc_addresses_t;
+
 /** @brief MPC register reserved field sizes */
 typedef enum {
   k_mpc_reserved_after_pwpr_bytes = 32, /**< Reserved bytes after PWPR */
@@ -121,8 +126,14 @@ typedef struct {
   /* Simplified for common motor control pins */
 } rx_mpc_regs_t;
 
-#define MPC_BASE ((rx_mpc_regs_t*)0x0008C100)
-#define MPC      (*MPC_BASE)
+/**
+ * @brief Get pointer to MPC registers
+ * @return Volatile pointer to MPC register structure
+ */
+static inline volatile rx_mpc_regs_t* mpc(void)
+{
+  return (volatile rx_mpc_regs_t*)k_mpc_base_addr;
+}
 
 /* MPC Write Protect Register (PWPR) bits */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_mtu_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_mtu_regs.h
@@ -25,6 +25,18 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief MTU base addresses */
+typedef enum {
+  k_mtu0_base_addr    = 0x000D0600, /**< MTU0 register base address */
+  k_mtu1_base_addr    = 0x000D0680, /**< MTU1 register base address */
+  k_mtu2_base_addr    = 0x000D0700, /**< MTU2 register base address */
+  k_mtu3_base_addr    = 0x000D0200, /**< MTU3 register base address */
+  k_mtu4_base_addr    = 0x000D0201, /**< MTU4 register base address */
+  k_mtu6_base_addr    = 0x000D0A00, /**< MTU6 register base address */
+  k_mtu7_base_addr    = 0x000D0A80, /**< MTU7 register base address */
+  k_mtu_tstr_base_addr = 0x000D0880, /**< MTU TSTR register base address */
+} rx_mtu_addresses_t;
+
 /**
  * @brief MTU Channel Register Map (MTU0-MTU2, MTU6-MTU7)
  * @details
@@ -87,24 +99,77 @@ typedef struct {
   volatile uint8_t tstr; /**< Timer Start Register (channel enable bits) */
 } rx_mtu_tstr_regs_t;
 
-#define MTU0_BASE ((rx_mtu_channel_regs_t*)0x000D0600)
-#define MTU1_BASE ((rx_mtu_channel_regs_t*)0x000D0680)
-#define MTU2_BASE ((rx_mtu_channel_regs_t*)0x000D0700)
-#define MTU3_BASE ((rx_mtu34_channel_regs_t*)0x000D0200)
-#define MTU4_BASE ((rx_mtu34_channel_regs_t*)0x000D0201)
-#define MTU6_BASE ((rx_mtu_channel_regs_t*)0x000D0A00)
-#define MTU7_BASE ((rx_mtu_channel_regs_t*)0x000D0A80)
+/**
+ * @brief Get pointer to MTU0 registers
+ * @return Volatile pointer to MTU0 register structure
+ */
+static inline volatile rx_mtu_channel_regs_t* mtu0(void)
+{
+  return (volatile rx_mtu_channel_regs_t*)k_mtu0_base_addr;
+}
 
-#define MTU0 (*MTU0_BASE)
-#define MTU1 (*MTU1_BASE)
-#define MTU2 (*MTU2_BASE)
-#define MTU3 (*MTU3_BASE)
-#define MTU4 (*MTU4_BASE)
-#define MTU6 (*MTU6_BASE)
-#define MTU7 (*MTU7_BASE)
+/**
+ * @brief Get pointer to MTU1 registers
+ * @return Volatile pointer to MTU1 register structure
+ */
+static inline volatile rx_mtu_channel_regs_t* mtu1(void)
+{
+  return (volatile rx_mtu_channel_regs_t*)k_mtu1_base_addr;
+}
 
-#define MTU_TSTR_BASE ((rx_mtu_tstr_regs_t*)0x000D0880)
-#define MTU_TSTR      (*MTU_TSTR_BASE)
+/**
+ * @brief Get pointer to MTU2 registers
+ * @return Volatile pointer to MTU2 register structure
+ */
+static inline volatile rx_mtu_channel_regs_t* mtu2(void)
+{
+  return (volatile rx_mtu_channel_regs_t*)k_mtu2_base_addr;
+}
+
+/**
+ * @brief Get pointer to MTU3 registers
+ * @return Volatile pointer to MTU3 register structure
+ */
+static inline volatile rx_mtu34_channel_regs_t* mtu3(void)
+{
+  return (volatile rx_mtu34_channel_regs_t*)k_mtu3_base_addr;
+}
+
+/**
+ * @brief Get pointer to MTU4 registers
+ * @return Volatile pointer to MTU4 register structure
+ */
+static inline volatile rx_mtu34_channel_regs_t* mtu4(void)
+{
+  return (volatile rx_mtu34_channel_regs_t*)k_mtu4_base_addr;
+}
+
+/**
+ * @brief Get pointer to MTU6 registers
+ * @return Volatile pointer to MTU6 register structure
+ */
+static inline volatile rx_mtu_channel_regs_t* mtu6(void)
+{
+  return (volatile rx_mtu_channel_regs_t*)k_mtu6_base_addr;
+}
+
+/**
+ * @brief Get pointer to MTU7 registers
+ * @return Volatile pointer to MTU7 register structure
+ */
+static inline volatile rx_mtu_channel_regs_t* mtu7(void)
+{
+  return (volatile rx_mtu_channel_regs_t*)k_mtu7_base_addr;
+}
+
+/**
+ * @brief Get pointer to MTU TSTR registers
+ * @return Volatile pointer to MTU TSTR register structure
+ */
+static inline volatile rx_mtu_tstr_regs_t* mtu_tstr(void)
+{
+  return (volatile rx_mtu_tstr_regs_t*)k_mtu_tstr_base_addr;
+}
 
 /* Timer Control Register (TCR) bits */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_port_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_port_regs.h
@@ -24,6 +24,28 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief Port base addresses */
+typedef enum {
+  k_port0_base_addr = 0x0008C000, /**< PORT0 register base address */
+  k_port1_base_addr = 0x0008C008, /**< PORT1 register base address */
+  k_port2_base_addr = 0x0008C010, /**< PORT2 register base address */
+  k_port3_base_addr = 0x0008C018, /**< PORT3 register base address */
+  k_port4_base_addr = 0x0008C020, /**< PORT4 register base address */
+  k_port5_base_addr = 0x0008C028, /**< PORT5 register base address */
+  k_port6_base_addr = 0x0008C030, /**< PORT6 register base address */
+  k_port7_base_addr = 0x0008C038, /**< PORT7 register base address */
+  k_port8_base_addr = 0x0008C040, /**< PORT8 register base address */
+  k_port9_base_addr = 0x0008C048, /**< PORT9 register base address */
+  k_porta_base_addr = 0x0008C050, /**< PORTA register base address */
+  k_portb_base_addr = 0x0008C058, /**< PORTB register base address */
+  k_portc_base_addr = 0x0008C060, /**< PORTC register base address */
+  k_portd_base_addr = 0x0008C068, /**< PORTD register base address */
+  k_porte_base_addr = 0x0008C070, /**< PORTE register base address */
+  k_portf_base_addr = 0x0008C078, /**< PORTF register base address */
+  k_portg_base_addr = 0x0008C080, /**< PORTG register base address */
+  k_portj_base_addr = 0x0008C098, /**< PORTJ register base address */
+} rx_port_addresses_t;
+
 /**
  * @brief Port Register Map
  * @details
@@ -46,44 +68,167 @@ typedef struct {
   volatile uint8_t dscr; /**< Drive Capacity Control Register (drive strength) */
 } rx_port_regs_t;
 
-/* Port base addresses */
-#define PORT0_BASE ((rx_port_regs_t*)0x0008C000)
-#define PORT1_BASE ((rx_port_regs_t*)0x0008C008)
-#define PORT2_BASE ((rx_port_regs_t*)0x0008C010)
-#define PORT3_BASE ((rx_port_regs_t*)0x0008C018)
-#define PORT4_BASE ((rx_port_regs_t*)0x0008C020)
-#define PORT5_BASE ((rx_port_regs_t*)0x0008C028)
-#define PORT6_BASE ((rx_port_regs_t*)0x0008C030)
-#define PORT7_BASE ((rx_port_regs_t*)0x0008C038)
-#define PORT8_BASE ((rx_port_regs_t*)0x0008C040)
-#define PORT9_BASE ((rx_port_regs_t*)0x0008C048)
-#define PORTA_BASE ((rx_port_regs_t*)0x0008C050)
-#define PORTB_BASE ((rx_port_regs_t*)0x0008C058)
-#define PORTC_BASE ((rx_port_regs_t*)0x0008C060)
-#define PORTD_BASE ((rx_port_regs_t*)0x0008C068)
-#define PORTE_BASE ((rx_port_regs_t*)0x0008C070)
-#define PORTF_BASE ((rx_port_regs_t*)0x0008C078)
-#define PORTG_BASE ((rx_port_regs_t*)0x0008C080)
-#define PORTJ_BASE ((rx_port_regs_t*)0x0008C098)
+/**
+ * @brief Get pointer to PORT0 registers
+ * @return Volatile pointer to PORT0 register structure
+ */
+static inline volatile rx_port_regs_t* port0(void)
+{
+  return (volatile rx_port_regs_t*)k_port0_base_addr;
+}
 
-#define PORT0 (*PORT0_BASE)
-#define PORT1 (*PORT1_BASE)
-#define PORT2 (*PORT2_BASE)
-#define PORT3 (*PORT3_BASE)
-#define PORT4 (*PORT4_BASE)
-#define PORT5 (*PORT5_BASE)
-#define PORT6 (*PORT6_BASE)
-#define PORT7 (*PORT7_BASE)
-#define PORT8 (*PORT8_BASE)
-#define PORT9 (*PORT9_BASE)
-#define PORTA (*PORTA_BASE)
-#define PORTB (*PORTB_BASE)
-#define PORTC (*PORTC_BASE)
-#define PORTD (*PORTD_BASE)
-#define PORTE (*PORTE_BASE)
-#define PORTF (*PORTF_BASE)
-#define PORTG (*PORTG_BASE)
-#define PORTJ (*PORTJ_BASE)
+/**
+ * @brief Get pointer to PORT1 registers
+ * @return Volatile pointer to PORT1 register structure
+ */
+static inline volatile rx_port_regs_t* port1(void)
+{
+  return (volatile rx_port_regs_t*)k_port1_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT2 registers
+ * @return Volatile pointer to PORT2 register structure
+ */
+static inline volatile rx_port_regs_t* port2(void)
+{
+  return (volatile rx_port_regs_t*)k_port2_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT3 registers
+ * @return Volatile pointer to PORT3 register structure
+ */
+static inline volatile rx_port_regs_t* port3(void)
+{
+  return (volatile rx_port_regs_t*)k_port3_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT4 registers
+ * @return Volatile pointer to PORT4 register structure
+ */
+static inline volatile rx_port_regs_t* port4(void)
+{
+  return (volatile rx_port_regs_t*)k_port4_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT5 registers
+ * @return Volatile pointer to PORT5 register structure
+ */
+static inline volatile rx_port_regs_t* port5(void)
+{
+  return (volatile rx_port_regs_t*)k_port5_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT6 registers
+ * @return Volatile pointer to PORT6 register structure
+ */
+static inline volatile rx_port_regs_t* port6(void)
+{
+  return (volatile rx_port_regs_t*)k_port6_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT7 registers
+ * @return Volatile pointer to PORT7 register structure
+ */
+static inline volatile rx_port_regs_t* port7(void)
+{
+  return (volatile rx_port_regs_t*)k_port7_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT8 registers
+ * @return Volatile pointer to PORT8 register structure
+ */
+static inline volatile rx_port_regs_t* port8(void)
+{
+  return (volatile rx_port_regs_t*)k_port8_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORT9 registers
+ * @return Volatile pointer to PORT9 register structure
+ */
+static inline volatile rx_port_regs_t* port9(void)
+{
+  return (volatile rx_port_regs_t*)k_port9_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTA registers
+ * @return Volatile pointer to PORTA register structure
+ */
+static inline volatile rx_port_regs_t* porta(void)
+{
+  return (volatile rx_port_regs_t*)k_porta_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTB registers
+ * @return Volatile pointer to PORTB register structure
+ */
+static inline volatile rx_port_regs_t* portb(void)
+{
+  return (volatile rx_port_regs_t*)k_portb_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTC registers
+ * @return Volatile pointer to PORTC register structure
+ */
+static inline volatile rx_port_regs_t* portc(void)
+{
+  return (volatile rx_port_regs_t*)k_portc_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTD registers
+ * @return Volatile pointer to PORTD register structure
+ */
+static inline volatile rx_port_regs_t* portd(void)
+{
+  return (volatile rx_port_regs_t*)k_portd_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTE registers
+ * @return Volatile pointer to PORTE register structure
+ */
+static inline volatile rx_port_regs_t* porte(void)
+{
+  return (volatile rx_port_regs_t*)k_porte_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTF registers
+ * @return Volatile pointer to PORTF register structure
+ */
+static inline volatile rx_port_regs_t* portf(void)
+{
+  return (volatile rx_port_regs_t*)k_portf_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTG registers
+ * @return Volatile pointer to PORTG register structure
+ */
+static inline volatile rx_port_regs_t* portg(void)
+{
+  return (volatile rx_port_regs_t*)k_portg_base_addr;
+}
+
+/**
+ * @brief Get pointer to PORTJ registers
+ * @return Volatile pointer to PORTJ register structure
+ */
+static inline volatile rx_port_regs_t* portj(void)
+{
+  return (volatile rx_port_regs_t*)k_portj_base_addr;
+}
 
 #ifdef __cplusplus
 }

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_riic_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_riic_regs.h
@@ -25,6 +25,13 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief RIIC base addresses */
+typedef enum {
+  k_riic0_base_addr = 0x00088300, /**< RIIC0 register base address */
+  k_riic1_base_addr = 0x00088320, /**< RIIC1 register base address */
+  k_riic2_base_addr = 0x00088340, /**< RIIC2 register base address */
+} rx_riic_addresses_t;
+
 /**
  * @brief RIIC Register Map
  * @details
@@ -57,13 +64,32 @@ typedef struct {
   volatile uint8_t icdrr; /**< I2C Bus Receive Data Register */
 } rx_riic_regs_t;
 
-#define RIIC0_BASE ((rx_riic_regs_t*)0x00088300)
-#define RIIC1_BASE ((rx_riic_regs_t*)0x00088320)
-#define RIIC2_BASE ((rx_riic_regs_t*)0x00088340)
+/**
+ * @brief Get pointer to RIIC0 registers
+ * @return Volatile pointer to RIIC0 register structure
+ */
+static inline volatile rx_riic_regs_t* riic0(void)
+{
+  return (volatile rx_riic_regs_t*)k_riic0_base_addr;
+}
 
-#define RIIC0 (*RIIC0_BASE)
-#define RIIC1 (*RIIC1_BASE)
-#define RIIC2 (*RIIC2_BASE)
+/**
+ * @brief Get pointer to RIIC1 registers
+ * @return Volatile pointer to RIIC1 register structure
+ */
+static inline volatile rx_riic_regs_t* riic1(void)
+{
+  return (volatile rx_riic_regs_t*)k_riic1_base_addr;
+}
+
+/**
+ * @brief Get pointer to RIIC2 registers
+ * @return Volatile pointer to RIIC2 register structure
+ */
+static inline volatile rx_riic_regs_t* riic2(void)
+{
+  return (volatile rx_riic_regs_t*)k_riic2_base_addr;
+}
 
 /* RIIC Control Register 1 (ICCR1) Bit Definitions */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_rspi_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_rspi_regs.h
@@ -25,6 +25,13 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief RSPI base addresses */
+typedef enum {
+  k_rspi0_base_addr = 0x000D0000, /**< RSPI0 register base address */
+  k_rspi1_base_addr = 0x000D0100, /**< RSPI1 register base address */
+  k_rspi2_base_addr = 0x000D0200, /**< RSPI2 register base address */
+} rx_rspi_addresses_t;
+
 /**
  * @brief RSPI Register Map
  * @details
@@ -52,13 +59,32 @@ typedef struct {
   volatile uint16_t spcmd0; /**< SPI Command Register 0 (data length, phase, etc.) */
 } rx_rspi_regs_t;
 
-#define RSPI0_BASE ((rx_rspi_regs_t*)0x000D0000)
-#define RSPI1_BASE ((rx_rspi_regs_t*)0x000D0100)
-#define RSPI2_BASE ((rx_rspi_regs_t*)0x000D0200)
+/**
+ * @brief Get pointer to RSPI0 registers
+ * @return Volatile pointer to RSPI0 register structure
+ */
+static inline volatile rx_rspi_regs_t* rspi0(void)
+{
+  return (volatile rx_rspi_regs_t*)k_rspi0_base_addr;
+}
 
-#define RSPI0 (*RSPI0_BASE)
-#define RSPI1 (*RSPI1_BASE)
-#define RSPI2 (*RSPI2_BASE)
+/**
+ * @brief Get pointer to RSPI1 registers
+ * @return Volatile pointer to RSPI1 register structure
+ */
+static inline volatile rx_rspi_regs_t* rspi1(void)
+{
+  return (volatile rx_rspi_regs_t*)k_rspi1_base_addr;
+}
+
+/**
+ * @brief Get pointer to RSPI2 registers
+ * @return Volatile pointer to RSPI2 register structure
+ */
+static inline volatile rx_rspi_regs_t* rspi2(void)
+{
+  return (volatile rx_rspi_regs_t*)k_rspi2_base_addr;
+}
 
 /* RSPI Control Register (SPCR) Bit Definitions */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_sci_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_sci_regs.h
@@ -25,6 +25,15 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief SCI base addresses */
+typedef enum {
+  k_sci0_base_addr = 0x0008A000, /**< SCI0 register base address */
+  k_sci1_base_addr = 0x0008A020, /**< SCI1 register base address */
+  k_sci2_base_addr = 0x0008A040, /**< SCI2 register base address */
+  k_sci5_base_addr = 0x0008A0A0, /**< SCI5 register base address */
+  k_sci6_base_addr = 0x0008A0C0, /**< SCI6 register base address */
+} rx_sci_addresses_t;
+
 /**
  * @brief SCI Register Map
  * @details
@@ -47,17 +56,50 @@ typedef struct {
   volatile uint8_t semr; /**< Serial Extended Mode Register (noise filter, etc.) */
 } rx_sci_regs_t;
 
-#define SCI0_BASE ((rx_sci_regs_t*)0x0008A000)
-#define SCI1_BASE ((rx_sci_regs_t*)0x0008A020)
-#define SCI2_BASE ((rx_sci_regs_t*)0x0008A040)
-#define SCI5_BASE ((rx_sci_regs_t*)0x0008A0A0)
-#define SCI6_BASE ((rx_sci_regs_t*)0x0008A0C0)
+/**
+ * @brief Get pointer to SCI0 registers
+ * @return Volatile pointer to SCI0 register structure
+ */
+static inline volatile rx_sci_regs_t* sci0(void)
+{
+  return (volatile rx_sci_regs_t*)k_sci0_base_addr;
+}
 
-#define SCI0 (*SCI0_BASE)
-#define SCI1 (*SCI1_BASE)
-#define SCI2 (*SCI2_BASE)
-#define SCI5 (*SCI5_BASE)
-#define SCI6 (*SCI6_BASE)
+/**
+ * @brief Get pointer to SCI1 registers
+ * @return Volatile pointer to SCI1 register structure
+ */
+static inline volatile rx_sci_regs_t* sci1(void)
+{
+  return (volatile rx_sci_regs_t*)k_sci1_base_addr;
+}
+
+/**
+ * @brief Get pointer to SCI2 registers
+ * @return Volatile pointer to SCI2 register structure
+ */
+static inline volatile rx_sci_regs_t* sci2(void)
+{
+  return (volatile rx_sci_regs_t*)k_sci2_base_addr;
+}
+
+/**
+ * @brief Get pointer to SCI5 registers
+ * @return Volatile pointer to SCI5 register structure
+ */
+static inline volatile rx_sci_regs_t* sci5(void)
+{
+  return (volatile rx_sci_regs_t*)k_sci5_base_addr;
+}
+
+/**
+ * @brief Get pointer to SCI6 registers
+ * @return Volatile pointer to SCI6 register structure
+ */
+static inline volatile rx_sci_regs_t* sci6(void)
+{
+  return (volatile rx_sci_regs_t*)k_sci6_base_addr;
+}
 
 #ifdef __cplusplus
 }

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_system_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_system_regs.h
@@ -24,6 +24,11 @@ extern "C" {
  * =============================================================================
  */
 
+/** @brief System register base address */
+typedef enum {
+  k_system_base_addr = 0x00080000, /**< System register base address */
+} rx_system_addresses_t;
+
 /** @brief System register reserved field sizes */
 typedef enum {
   k_system_reserved_after_syscr1_bytes   = 2, /**< Reserved bytes after SYSCR1 */
@@ -75,8 +80,15 @@ typedef struct {
   volatile uint8_t  ostdsr; /**< Oscillation Stop Detection Status */
 } rx_system_regs_t;
 
-#define SYSTEM_BASE ((rx_system_regs_t*)0x00080000)
-#define SYSTEM      (*SYSTEM_BASE)
+/**
+ * @brief Get pointer to system registers
+ * @return Volatile pointer to system register structure
+ * @note Named system_regs() instead of system() to avoid naming conflicts
+ */
+static inline volatile rx_system_regs_t* system_regs(void)
+{
+  return (volatile rx_system_regs_t*)k_system_base_addr;
+}
 
 /* Module stop bits for MSTPCRB register */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx72n_usb_regs.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx72n_usb_regs.h
@@ -147,8 +147,19 @@ typedef struct {
   volatile uint16_t lpsts;  /**< Low Power Status Register */
 } rx_usb_regs_t;
 
-#define USB0_BASE ((rx_usb_regs_t*)0x000A0000)
-#define USB0      (*USB0_BASE)
+/** @brief USB base address */
+typedef enum {
+  k_usb0_base_addr = 0x000A0000, /**< USB0 register base address */
+} rx_usb_addresses_t;
+
+/**
+ * @brief Get pointer to USB0 registers
+ * @return Volatile pointer to USB0 register structure
+ */
+static inline volatile rx_usb_regs_t* usb0(void)
+{
+  return (volatile rx_usb_regs_t*)k_usb0_base_addr;
+}
 
 /* USB0 SYSCFG Register Bit Definitions */
 typedef enum {

--- a/star-rx72n-firmware/lib/rx_hal/src/adc.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/adc.c
@@ -100,10 +100,10 @@ static volatile rx_s12ad_regs_t* internal_get_adc_base(uint8_t unit)
 {
   switch (unit) {
     case 0: {
-      return &S12AD0;
+      return s12ad0();
     }
     case 1: {
-      return &S12AD1;
+      return s12ad1();
     }
     default: {
       return NULL;

--- a/star-rx72n-firmware/lib/rx_hal/src/adc.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/adc.c
@@ -163,17 +163,17 @@ rx_err_t adc_init(uint8_t unit, uint8_t channel, uint8_t bits)
   /* Initialize ADC unit if not already initialized */
   if (!s_adc_unit_initialized[unit]) {
     /* Unlock module stop control */
-    SYSTEM.prcr = k_adc_prcr_unlock;
+    system_regs()->prcr = k_adc_prcr_unlock;
 
     /* Enable ADC module (clear module stop bit) */
     if (unit == 0) {
-      SYSTEM.mstpcra &= ~(1UL << k_adc_mstpra_s12ad0);
+      system_regs()->mstpcra &= ~(1UL << k_adc_mstpra_s12ad0);
     } else {
-      SYSTEM.mstpcra &= ~(1UL << k_adc_mstpra_s12ad1);
+      system_regs()->mstpcra &= ~(1UL << k_adc_mstpra_s12ad1);
     }
 
     /* Lock module stop control */
-    SYSTEM.prcr = k_adc_prcr_lock;
+    system_regs()->prcr = k_adc_prcr_lock;
 
     /* Configure ADC resolution */
     uint16_t adcer = adc->adcer;

--- a/star-rx72n-firmware/lib/rx_hal/src/gpio.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/gpio.c
@@ -68,55 +68,55 @@ static volatile rx_port_regs_t* internal_get_port_base(uint8_t port)
 {
   switch (port) {
     case k_gpio_port_0: {
-      return PORT0_BASE;
+      return port0();
     }
     case k_gpio_port_1: {
-      return PORT1_BASE;
+      return port1();
     }
     case k_gpio_port_2: {
-      return PORT2_BASE;
+      return port2();
     }
     case k_gpio_port_3: {
-      return PORT3_BASE;
+      return port3();
     }
     case k_gpio_port_4: {
-      return PORT4_BASE;
+      return port4();
     }
     case k_gpio_port_5: {
-      return PORT5_BASE;
+      return port5();
     }
     case k_gpio_port_6: {
-      return PORT6_BASE;
+      return port6();
     }
     case k_gpio_port_7: {
-      return PORT7_BASE;
+      return port7();
     }
     case k_gpio_port_8: {
-      return PORT8_BASE;
+      return port8();
     }
     case k_gpio_port_9: {
-      return PORT9_BASE;
+      return port9();
     }
     case k_gpio_port_a: {
-      return PORTA_BASE;
+      return porta();
     }
     case k_gpio_port_b: {
-      return PORTB_BASE;
+      return portb();
     }
     case k_gpio_port_c: {
-      return PORTC_BASE;
+      return portc();
     }
     case k_gpio_port_d: {
-      return PORTD_BASE;
+      return portd();
     }
     case k_gpio_port_e: {
-      return PORTE_BASE;
+      return porte();
     }
     case k_gpio_port_f: {
-      return PORTF_BASE;
+      return portf();
     }
     case k_gpio_port_g: {
-      return PORTG_BASE;
+      return portg();
     }
     default: {
       return NULL; /* Invalid port */

--- a/star-rx72n-firmware/lib/rx_hal/src/riic.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/riic.c
@@ -338,17 +338,17 @@ rx_err_t riic_init(uint8_t channel, uint32_t frequency_hz)
   }
 
   /* Enable RIIC module (clear module stop bit) */
-  SYSTEM.prcr = k_riic_prcr_unlock;
+  system_regs()->prcr = k_riic_prcr_unlock;
 
   if (channel == k_riic_channel_0) {
-    SYSTEM.mstpcrb &= ~(1UL << k_riic_mstpb_riic0);
+    system_regs()->mstpcrb &= ~(1UL << k_riic_mstpb_riic0);
   } else if (channel == k_riic_channel_1) {
-    SYSTEM.mstpcrb &= ~(1UL << k_riic_mstpb_riic1);
+    system_regs()->mstpcrb &= ~(1UL << k_riic_mstpb_riic1);
   } else {
-    SYSTEM.mstpcrb &= ~(1UL << k_riic_mstpb_riic2);
+    system_regs()->mstpcrb &= ~(1UL << k_riic_mstpb_riic2);
   }
 
-  SYSTEM.prcr = k_riic_prcr_lock;
+  system_regs()->prcr = k_riic_prcr_lock;
 
   /* Reset RIIC */
   riic->iccr1 = k_riic_iccr1_iicrst;

--- a/star-rx72n-firmware/lib/rx_hal/src/riic.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/riic.c
@@ -110,13 +110,13 @@ static volatile rx_riic_regs_t* internal_get_riic_base(uint8_t channel)
 {
   switch (channel) {
     case k_riic_channel_0: {
-      return &RIIC0;
+      return riic0();
     }
     case k_riic_channel_1: {
-      return &RIIC1;
+      return riic1();
     }
     case k_riic_channel_2: {
-      return &RIIC2;
+      return riic2();
     }
     default: {
       return NULL;

--- a/star-rx72n-firmware/lib/rx_hal/src/rspi.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rspi.c
@@ -111,13 +111,13 @@ static volatile rx_rspi_regs_t* internal_get_rspi_base(uint8_t channel)
 {
   switch (channel) {
     case k_rspi_channel_0: {
-      return &RSPI0;
+      return rspi0();
     }
     case k_rspi_channel_1: {
-      return &RSPI1;
+      return rspi1();
     }
     case k_rspi_channel_2: {
-      return &RSPI2;
+      return rspi2();
     }
     default: {
       return NULL;

--- a/star-rx72n-firmware/lib/rx_hal/src/rspi.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rspi.c
@@ -151,17 +151,17 @@ rx_err_t rspi_init_peripheral(uint8_t channel, uint8_t mode, bool use_16bit)
   }
 
   /* Enable RSPI module (clear module stop bit) */
-  SYSTEM.prcr = k_rspi_prcr_unlock;
+  system_regs()->prcr = k_rspi_prcr_unlock;
 
   if (channel == k_rspi_channel_0) {
-    SYSTEM.mstpcrb &= ~(1UL << k_rspi_mstpb_rspi0);
+    system_regs()->mstpcrb &= ~(1UL << k_rspi_mstpb_rspi0);
   } else if (channel == k_rspi_channel_1) {
-    SYSTEM.mstpcrb &= ~(1UL << k_rspi_mstpb_rspi1);
+    system_regs()->mstpcrb &= ~(1UL << k_rspi_mstpb_rspi1);
   } else {
-    SYSTEM.mstpcrb &= ~(1UL << k_rspi_mstpb_rspi2);
+    system_regs()->mstpcrb &= ~(1UL << k_rspi_mstpb_rspi2);
   }
 
-  SYSTEM.prcr = k_rspi_prcr_lock;
+  system_regs()->prcr = k_rspi_prcr_lock;
 
   /* Disable SPI before configuration */
   rspi->spcr = k_rspi_spcr_disabled;
@@ -307,17 +307,17 @@ rx_err_t rspi_deinit(uint8_t channel)
   rspi->spcr = k_rspi_spcr_disabled;
 
   /* Disable RSPI module (set module stop bit) */
-  SYSTEM.prcr = k_rspi_prcr_unlock;
+  system_regs()->prcr = k_rspi_prcr_unlock;
 
   if (channel == k_rspi_channel_0) {
-    SYSTEM.mstpcrb |= (1UL << k_rspi_mstpb_rspi0);
+    system_regs()->mstpcrb |= (1UL << k_rspi_mstpb_rspi0);
   } else if (channel == k_rspi_channel_1) {
-    SYSTEM.mstpcrb |= (1UL << k_rspi_mstpb_rspi1);
+    system_regs()->mstpcrb |= (1UL << k_rspi_mstpb_rspi1);
   } else {
-    SYSTEM.mstpcrb |= (1UL << k_rspi_mstpb_rspi2);
+    system_regs()->mstpcrb |= (1UL << k_rspi_mstpb_rspi2);
   }
 
-  SYSTEM.prcr = k_rspi_prcr_lock;
+  system_regs()->prcr = k_rspi_prcr_lock;
 
   /* Mark channel as uninitialized */
   s_rspi_channel_initialized[channel] = false;

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_cmt.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_cmt.c
@@ -121,13 +121,13 @@ static volatile rx_cmt_channel_regs_t* internal_get_cmt_base(rx_cmt_channel_t ch
 {
   switch (channel) {
     case k_cmt_channel_0:
-      return &CMT0;
+      return cmt0();
     case k_cmt_channel_1:
-      return &CMT1;
+      return cmt1();
     case k_cmt_channel_2:
-      return &CMT2;
+      return cmt2();
     case k_cmt_channel_3:
-      return &CMT3;
+      return cmt3();
     default:
       return NULL;
   }
@@ -251,9 +251,9 @@ rx_err_t rx_cmt_init(rx_cmt_channel_t channel, const rx_cmt_config_t* config)
   rx_log_info(s_tag, "CMT initialized");
 
   /* Enable CMT module (clear module stop bit) */
-  SYSTEM.prcr = k_cmt_prcr_unlock;
-  SYSTEM.mstpcrb &= ~(1UL << k_cmt_mstpb_cmt);
-  SYSTEM.prcr = k_cmt_prcr_lock;
+  system_regs()->prcr = k_cmt_prcr_unlock;
+  system_regs()->mstpcrb &= ~(1UL << k_cmt_mstpb_cmt);
+  system_regs()->prcr = k_cmt_prcr_lock;
 
   /* Stop timer before configuration */
   rx_cmt_stop(channel);
@@ -275,15 +275,15 @@ rx_err_t rx_cmt_init(rx_cmt_channel_t channel, const rx_cmt_config_t* config)
   uint8_t vector = k_vect_cmt0_cmi0 + channel;
 
   /* Set interrupt priority */
-  ICU.ipr[vector] = config->priority;
+  icu()->ipr[vector] = config->priority;
 
   /* Enable interrupt in ICU */
   uint8_t ier_index = vector / k_cmt_ier_bits_per_reg;
   uint8_t ier_bit   = vector % k_cmt_ier_bits_per_reg;
-  ICU.ier[ier_index] |= (1 << ier_bit);
+  icu()->ier[ier_index] |= (1 << ier_bit);
 
   /* Clear interrupt flag */
-  ICU.ir[vector] = 0;
+  icu()->ir[vector] = 0;
 
   /* Save callback */
   s_cmt_callback[channel]    = config->callback;
@@ -307,16 +307,16 @@ rx_err_t rx_cmt_start(rx_cmt_channel_t channel)
   /* Set corresponding bit in CMSTR register */
   switch (channel) {
     case k_cmt_channel_0:
-      CMT_CTRL.cmstr0 |= (1 << k_cmt_cmstr_str0);
+      cmt_ctrl()->cmstr0 |= (1 << k_cmt_cmstr_str0);
       break;
     case k_cmt_channel_1:
-      CMT_CTRL.cmstr0 |= (1 << k_cmt_cmstr_str1);
+      cmt_ctrl()->cmstr0 |= (1 << k_cmt_cmstr_str1);
       break;
     case k_cmt_channel_2:
-      CMT_CTRL.cmstr1 |= (1 << k_cmt_cmstr_str0);
+      cmt_ctrl()->cmstr1 |= (1 << k_cmt_cmstr_str0);
       break;
     case k_cmt_channel_3:
-      CMT_CTRL.cmstr1 |= (1 << k_cmt_cmstr_str1);
+      cmt_ctrl()->cmstr1 |= (1 << k_cmt_cmstr_str1);
       break;
     default:
       return k_rx_err_invalid_arg;
@@ -334,16 +334,16 @@ rx_err_t rx_cmt_stop(rx_cmt_channel_t channel)
   /* Clear corresponding bit in CMSTR register */
   switch (channel) {
     case k_cmt_channel_0:
-      CMT_CTRL.cmstr0 &= ~(1 << k_cmt_cmstr_str0);
+      cmt_ctrl()->cmstr0 &= ~(1 << k_cmt_cmstr_str0);
       break;
     case k_cmt_channel_1:
-      CMT_CTRL.cmstr0 &= ~(1 << k_cmt_cmstr_str1);
+      cmt_ctrl()->cmstr0 &= ~(1 << k_cmt_cmstr_str1);
       break;
     case k_cmt_channel_2:
-      CMT_CTRL.cmstr1 &= ~(1 << k_cmt_cmstr_str0);
+      cmt_ctrl()->cmstr1 &= ~(1 << k_cmt_cmstr_str0);
       break;
     case k_cmt_channel_3:
-      CMT_CTRL.cmstr1 &= ~(1 << k_cmt_cmstr_str1);
+      cmt_ctrl()->cmstr1 &= ~(1 << k_cmt_cmstr_str1);
       break;
     default:
       return k_rx_err_invalid_arg;
@@ -382,7 +382,7 @@ rx_err_t rx_cmt_deinit(rx_cmt_channel_t channel)
   uint8_t vector    = k_vect_cmt0_cmi0 + channel;
   uint8_t ier_index = vector / k_cmt_ier_bits_per_reg;
   uint8_t ier_bit   = vector % k_cmt_ier_bits_per_reg;
-  ICU.ier[ier_index] &= ~(1 << ier_bit);
+  icu()->ier[ier_index] &= ~(1 << ier_bit);
 
   /* Clear callback */
   s_cmt_callback[channel]    = NULL;

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_irq_filter.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_irq_filter.c
@@ -71,7 +71,7 @@ rx_err_t rx_irq_filter_enable(uint8_t irq_num, rx_irq_filter_clk_t filter_clk)
   uint16_t clock_mask  = (uint16_t)(k_irq_filter_clock_mask << clock_pos);
   uint16_t clock_value = (uint16_t)(filter_clk << clock_pos);
 
-  ICU.irqfltc[reg_idx] = (ICU.irqfltc[reg_idx] & ~clock_mask) | clock_value;
+  icu()->irqfltc[reg_idx] = (icu()->irqfltc[reg_idx] & ~clock_mask) | clock_value;
 
   /*
    * Enable filter for this IRQ
@@ -81,7 +81,7 @@ rx_err_t rx_irq_filter_enable(uint8_t irq_num, rx_irq_filter_clk_t filter_clk)
    * - Bit 1: IRQ1/9 filter enable
    * - etc.
    */
-  ICU.irqflte[reg_idx] |= (uint8_t)(1 << bit_pos);
+  icu()->irqflte[reg_idx] |= (uint8_t)(1 << bit_pos);
 
 #else
   /* Host-side stub for unit testing */
@@ -102,7 +102,7 @@ rx_err_t rx_irq_filter_disable(uint8_t irq_num)
   uint8_t bit_pos = irq_num % k_irq_filter_irqs_per_reg;
 
   /* Clear filter enable bit */
-  ICU.irqflte[reg_idx] &= (uint8_t)~(1 << bit_pos);
+  icu()->irqflte[reg_idx] &= (uint8_t)~(1 << bit_pos);
 
 #endif
 
@@ -123,7 +123,7 @@ rx_err_t rx_irq_filter_is_enabled(uint8_t irq_num, bool* enabled)
   uint8_t reg_idx = irq_num / k_irq_filter_irqs_per_reg;
   uint8_t bit_pos = irq_num % k_irq_filter_irqs_per_reg;
 
-  *enabled = (ICU.irqflte[reg_idx] & (1 << bit_pos)) != 0;
+  *enabled = (icu()->irqflte[reg_idx] & (1 << bit_pos)) != 0;
 
 #else
   *enabled = false;
@@ -147,7 +147,7 @@ rx_err_t rx_irq_filter_get_clock(uint8_t irq_num, rx_irq_filter_clk_t* filter_cl
   uint8_t bit_pos   = irq_num % k_irq_filter_irqs_per_reg;
   uint8_t clock_pos = bit_pos * k_irq_filter_clock_bits;
 
-  uint16_t clock_value = (ICU.irqfltc[reg_idx] >> clock_pos) & k_irq_filter_clock_mask;
+  uint16_t clock_value = (icu()->irqfltc[reg_idx] >> clock_pos) & k_irq_filter_clock_mask;
   *filter_clk          = (rx_irq_filter_clk_t)clock_value;
 
 #else

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_iwdt.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_iwdt.c
@@ -155,7 +155,7 @@ rx_err_t rx_iwdt_init(uint32_t timeout_ms)
   iwdtcr |= k_iwdt_rpes_0;   /* Window end at 0% (disabled) */
   iwdtcr |= k_iwdt_rpss_100; /* Window start at 100% (full) */
 
-  IWDT.iwdtcr = iwdtcr;
+  iwdt()->iwdtcr = iwdtcr;
 
   /*
    * Configure Reset Control Register (IWDTRCR)
@@ -166,7 +166,7 @@ rx_err_t rx_iwdt_init(uint32_t timeout_ms)
    *
    * We use reset (1) for safety - NMI could be masked or ignored.
    */
-  IWDT.iwdtrcr = k_iwdt_rstirqs_reset;
+  iwdt()->iwdtrcr = k_iwdt_rstirqs_reset;
 
   /*
    * Configure Count Stop Control Register (IWDTCSTPR)
@@ -177,7 +177,7 @@ rx_err_t rx_iwdt_init(uint32_t timeout_ms)
    *
    * We continue counting during sleep for safety.
    */
-  IWDT.iwdtcstpr = k_iwdt_slcstp_continue;
+  iwdt()->iwdtcstpr = k_iwdt_slcstp_continue;
 
   /*
    * Start the IWDT by performing first refresh
@@ -220,8 +220,8 @@ void rx_iwdt_feed(void)
   __asm__ volatile("clrpsw i");
 
   /* Perform refresh sequence */
-  IWDT.iwdtrr = k_iwdt_refresh_start; /* Write 0x00 */
-  IWDT.iwdtrr = k_iwdt_refresh_end;   /* Write 0xFF */
+  iwdt()->iwdtrr = k_iwdt_refresh_start; /* Write 0x00 */
+  iwdt()->iwdtrr = k_iwdt_refresh_end;   /* Write 0xFF */
 
   /* Restore interrupt state */
   __asm__ volatile("mvtc %0, psw" : : "r"(psw));
@@ -243,7 +243,7 @@ bool rx_iwdt_was_reset(void)
    * Bit 15 REFEF - Refresh Error Flag
    *   1 = Refresh error occurred
    */
-  uint16_t status = IWDT.iwdtsr;
+  uint16_t status = iwdt()->iwdtsr;
   return ((status & k_iwdt_sr_undff) != 0) || ((status & k_iwdt_sr_refef) != 0);
 
 #else
@@ -254,7 +254,7 @@ bool rx_iwdt_was_reset(void)
 rx_iwdt_reset_cause_t rx_iwdt_get_reset_cause(void)
 {
 #ifdef __RX__
-  uint16_t status = IWDT.iwdtsr;
+  uint16_t status = iwdt()->iwdtsr;
 
   if (status & k_iwdt_sr_refef) {
     return k_iwdt_reset_refresh_error;
@@ -279,7 +279,7 @@ void rx_iwdt_clear_status(void)
    *
    * Bits 14-15 are write-0-to-clear
    */
-  IWDT.iwdtsr &= ~(k_iwdt_sr_undff | k_iwdt_sr_refef);
+  iwdt()->iwdtsr &= ~(k_iwdt_sr_undff | k_iwdt_sr_refef);
 
 #else
   /* Host-side stub - no operation */

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_mpc.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_mpc.c
@@ -117,7 +117,7 @@ static volatile uint8_t* internal_get_pfs_register(uint8_t port, uint8_t pin)
    * PFS registers start at MPC base + 0x21 (offset for P00PFS)
    * Each port has 8 pins, layout: P00-P07, P10-P17, P20-P27, etc.
    */
-  volatile uint8_t* pfs_base = (volatile uint8_t*)MPC_BASE + k_mpc_pfs_base_offset;
+  volatile uint8_t* pfs_base = (volatile uint8_t*)mpc() + k_mpc_pfs_base_offset;
 
   /* Port offset calculation */
   uint16_t port_offset = 0;
@@ -174,8 +174,8 @@ static void internal_mpc_unlock(void)
    * 1. Clear B0WI to allow PFSWE write
    * 2. Set PFSWE to allow PFS write
    */
-  MPC.pwpr = k_mpc_pwpr_clear; /* Clear B0WI */
-  MPC.pwpr = k_mpc_pwpr_pfswe; /* Set PFSWE */
+  mpc()->pwpr = k_mpc_pwpr_clear; /* Clear B0WI */
+  mpc()->pwpr = k_mpc_pwpr_pfswe; /* Set PFSWE */
 }
 
 /**
@@ -187,8 +187,8 @@ static void internal_mpc_lock(void)
    * 1. Clear PFSWE to protect PFS
    * 2. Set B0WI to protect PFSWE
    */
-  MPC.pwpr = k_mpc_pwpr_clear; /* Clear PFSWE */
-  MPC.pwpr = k_mpc_pwpr_b0wi;  /* Set B0WI */
+  mpc()->pwpr = k_mpc_pwpr_clear; /* Clear PFSWE */
+  mpc()->pwpr = k_mpc_pwpr_b0wi;  /* Set B0WI */
 }
 
 /**

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_mtu3a.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_mtu3a.c
@@ -110,19 +110,19 @@ static volatile void* internal_get_mtu_base(rx_mtu_channel_t channel)
 {
   switch (channel) {
     case k_mtu_channel_0:
-      return (volatile void*)MTU0_BASE;
+      return (volatile void*)mtu0();
     case k_mtu_channel_1:
-      return (volatile void*)MTU1_BASE;
+      return (volatile void*)mtu1();
     case k_mtu_channel_2:
-      return (volatile void*)MTU2_BASE;
+      return (volatile void*)mtu2();
     case k_mtu_channel_3:
-      return (volatile void*)MTU3_BASE;
+      return (volatile void*)mtu3();
     case k_mtu_channel_4:
-      return (volatile void*)MTU4_BASE;
+      return (volatile void*)mtu4();
     case k_mtu_channel_6:
-      return (volatile void*)MTU6_BASE;
+      return (volatile void*)mtu6();
     case k_mtu_channel_7:
-      return (volatile void*)MTU7_BASE;
+      return (volatile void*)mtu7();
     default:
       return NULL;
   }
@@ -408,19 +408,19 @@ rx_err_t rx_mtu_start(rx_mtu_channel_t channel)
   /* Set corresponding bit in TSTR register */
   switch (channel) {
     case k_mtu_channel_0:
-      MTU_TSTR.tstr |= k_mtu_tstr_cst0;
+      mtu_tstr()->tstr |= k_mtu_tstr_cst0;
       break;
     case k_mtu_channel_1:
-      MTU_TSTR.tstr |= k_mtu_tstr_cst1;
+      mtu_tstr()->tstr |= k_mtu_tstr_cst1;
       break;
     case k_mtu_channel_2:
-      MTU_TSTR.tstr |= k_mtu_tstr_cst2;
+      mtu_tstr()->tstr |= k_mtu_tstr_cst2;
       break;
     case k_mtu_channel_3:
-      MTU_TSTR.tstr |= k_mtu_tstr_cst3;
+      mtu_tstr()->tstr |= k_mtu_tstr_cst3;
       break;
     case k_mtu_channel_4:
-      MTU_TSTR.tstr |= k_mtu_tstr_cst4;
+      mtu_tstr()->tstr |= k_mtu_tstr_cst4;
       break;
     case k_mtu_channel_6:
     case k_mtu_channel_7:
@@ -443,19 +443,19 @@ rx_err_t rx_mtu_stop(rx_mtu_channel_t channel)
   /* Clear corresponding bit in TSTR register */
   switch (channel) {
     case k_mtu_channel_0:
-      MTU_TSTR.tstr &= ~k_mtu_tstr_cst0;
+      mtu_tstr()->tstr &= ~k_mtu_tstr_cst0;
       break;
     case k_mtu_channel_1:
-      MTU_TSTR.tstr &= ~k_mtu_tstr_cst1;
+      mtu_tstr()->tstr &= ~k_mtu_tstr_cst1;
       break;
     case k_mtu_channel_2:
-      MTU_TSTR.tstr &= ~k_mtu_tstr_cst2;
+      mtu_tstr()->tstr &= ~k_mtu_tstr_cst2;
       break;
     case k_mtu_channel_3:
-      MTU_TSTR.tstr &= ~k_mtu_tstr_cst3;
+      mtu_tstr()->tstr &= ~k_mtu_tstr_cst3;
       break;
     case k_mtu_channel_4:
-      MTU_TSTR.tstr &= ~k_mtu_tstr_cst4;
+      mtu_tstr()->tstr &= ~k_mtu_tstr_cst4;
       break;
     case k_mtu_channel_6:
     case k_mtu_channel_7:

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_mtu3a.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_mtu3a.c
@@ -220,15 +220,15 @@ rx_err_t rx_mtu_init_pwm(rx_mtu_channel_t channel, const rx_mtu_config_t* config
   rx_log_info(s_tag, "Initializing MTU");
 
   /* Enable MTU module (clear module stop bit) */
-  SYSTEM.prcr = k_mtu_prcr_unlock;
+  system_regs()->prcr = k_mtu_prcr_unlock;
 
   if (channel <= k_mtu_channel_4) {
-    SYSTEM.mstpcra &= ~(1UL << k_mtu_mstpa_mtu0_4);
+    system_regs()->mstpcra &= ~(1UL << k_mtu_mstpa_mtu0_4);
   } else {
-    SYSTEM.mstpcra &= ~(1UL << k_mtu_mstpa_mtu6_7);
+    system_regs()->mstpcra &= ~(1UL << k_mtu_mstpa_mtu6_7);
   }
 
-  SYSTEM.prcr = k_mtu_prcr_lock;
+  system_regs()->prcr = k_mtu_prcr_lock;
 
   /* Stop timer before configuration */
   rx_mtu_stop(channel);

--- a/star-rx72n-firmware/lib/rx_hal/src/system_init.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/system_init.c
@@ -94,13 +94,13 @@ typedef enum {
 static rx_err_t clock_init(void)
 {
   /* Unlock protection for clock registers */
-  SYSTEM.prcr = k_prcr_unlock;
+  system_regs()->prcr = k_prcr_unlock;
 
   /* Stop sub-clock oscillator (not used) */
-  SYSTEM.sosccr = k_sub_clock_stopped;
+  system_regs()->sosccr = k_sub_clock_stopped;
 
   /* Start main oscillator (16 MHz external crystal) */
-  SYSTEM.mosccr = k_main_osc_enabled;
+  system_regs()->mosccr = k_main_osc_enabled;
 
   /* Wait for main oscillator stabilization (typically 10ms) */
   /* NOTE: Busy-wait required - runs before ThreadX initialization */
@@ -111,32 +111,32 @@ static rx_err_t clock_init(void)
   /* Configure PLL */
   /* PLL = (Main OSC x PLIDIV) / PLLSTBY */
   /* 240 MHz = (16 MHz x 30) / 2 */
-  SYSTEM.pllcr  = k_pll_multiplier_30_div_2;
-  SYSTEM.pllcr2 = k_pll_enabled;
+  system_regs()->pllcr  = k_pll_multiplier_30_div_2;
+  system_regs()->pllcr2 = k_pll_enabled;
 
   /* Wait for PLL stabilization */
   /* NOTE: Busy-wait polling required - runs before ThreadX initialization */
   uint32_t timeout = k_pll_stabilization_timeout;
-  while ((SYSTEM.oscovfsr & k_pll_stable_flag) == 0 && timeout > 0) {
+  while ((system_regs()->oscovfsr & k_pll_stable_flag) == 0 && timeout > 0) {
     timeout--;
   }
 
   if (timeout == k_pll_stabilization_timeout_expired) {
     /* PLL failed to stabilize - but can't log yet (UART not initialized) */
-    SYSTEM.prcr = k_prcr_lock;
+    system_regs()->prcr = k_prcr_lock;
     return k_rx_err_hw_timeout;
   }
 
   /* Configure system clocks */
   /* ICLK=240MHz, PCLKA=120MHz, PCLKB=60MHz, PCLKC=60MHz,
      * PCLKD=60MHz, BCLK=120MHz, FCLK=60MHz */
-  SYSTEM.sckcr = k_system_clock_dividers;
+  system_regs()->sckcr = k_system_clock_dividers;
 
   /* Select PLL as system clock */
-  SYSTEM.sckcr3 = k_system_clock_source_pll;
+  system_regs()->sckcr3 = k_system_clock_source_pll;
 
   /* Lock protection */
-  SYSTEM.prcr = k_prcr_lock;
+  system_regs()->prcr = k_prcr_lock;
 
   return k_rx_ok;
 }
@@ -160,25 +160,25 @@ static rx_err_t clock_init(void)
 static rx_err_t module_stop_init(void)
 {
   /* Protect off */
-  SYSTEM.prcr = k_prcr_unlock;
+  system_regs()->prcr = k_prcr_unlock;
 
   /* Module Stop Control Register A */
-  SYSTEM.mstpcra &= ~((1UL << k_mstpcra_cmt) | /* CMT0, CMT1 */
-                      (1UL << k_mstpcra_mtu)   /* MTU */
+  system_regs()->mstpcra &= ~((1UL << k_mstpcra_cmt) | /* CMT0, CMT1 */
+                              (1UL << k_mstpcra_mtu)   /* MTU */
   );
 
   /* Module Stop Control Register B */
-  SYSTEM.mstpcrb &= ~((1UL << k_mstpcrb_sci5) |  /* SCI5 */
-                      (1UL << k_mstpcrb_rspi0) | /* RSPI0 */
-                      (1UL << k_mstpcrb_rspi1)   /* RSPI1 */
+  system_regs()->mstpcrb &= ~((1UL << k_mstpcrb_sci5) |  /* SCI5 */
+                              (1UL << k_mstpcrb_rspi0) | /* RSPI0 */
+                              (1UL << k_mstpcrb_rspi1)   /* RSPI1 */
   );
 
   /* Module Stop Control Register C */
-  SYSTEM.mstpcrc &= ~((1UL << k_mstpcrc_s12ad) /* S12AD */
+  system_regs()->mstpcrc &= ~((1UL << k_mstpcrc_s12ad) /* S12AD */
   );
 
   /* Protect on */
-  SYSTEM.prcr = k_prcr_lock;
+  system_regs()->prcr = k_prcr_lock;
 
   return k_rx_ok;
 }

--- a/star-rx72n-firmware/lib/rx_hal/src/timer.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/timer.c
@@ -76,7 +76,7 @@ extern void _tx_timer_interrupt(void);
 void cmt0_isr(void)
 {
   /* Clear interrupt flag (write 0 to BSR bit) */
-  CMT0.cmcr; /* Read to clear interrupt flag */
+  (void)cmt0()->cmcr; /* Read to clear interrupt flag */
 
   /* Call ThreadX timer interrupt handler */
   _tx_timer_interrupt();
@@ -105,32 +105,32 @@ rx_err_t timer_init(void)
   rx_log_info("TIMER", "Initializing CMT0 for ThreadX tick");
 
   /* Stop CMT0 if running */
-  CMT_CTRL.cmstr0 &= ~k_cmt0_cmstr_start_bit;
+  cmt_ctrl()->cmstr0 &= ~k_cmt0_cmstr_start_bit;
 
   /* Configure CMT0 */
   /* CMCR: Clock = PCLK/128, interrupt enabled */
-  CMT0.cmcr = k_cmt0_cmcr_config;
+  cmt0()->cmcr = k_cmt0_cmcr_config;
 
   /* Set compare match value for 100 Hz tick
      * CMCOR = (60,000,000 / 128 / 100) - 1 = 4687 */
-  CMT0.cmcor = k_cmt0_compare_match;
+  cmt0()->cmcor = k_cmt0_compare_match;
 
   /* Reset counter */
-  CMT0.cmcnt = k_cmt0_counter_init;
+  cmt0()->cmcnt = k_cmt0_counter_init;
 
   /* Configure interrupt controller (ICU) */
   /* Clear any pending interrupt */
-  ICU.ir[k_vect_cmt0_cmi0] = k_cmt0_counter_init;
+  icu()->ir[k_vect_cmt0_cmi0] = k_cmt0_counter_init;
 
   /* Set interrupt priority (3 out of 15) */
-  ICU.ipr[k_vect_cmt0_cmi0] = k_cmt0_irq_priority;
+  icu()->ipr[k_vect_cmt0_cmi0] = k_cmt0_irq_priority;
 
   /* Enable CMT0 interrupt in ICU */
-  ICU.ier[k_vect_cmt0_cmi0 / k_cmt0_ier_bits_per_reg] |=
+  icu()->ier[k_vect_cmt0_cmi0 / k_cmt0_ier_bits_per_reg] |=
     (1 << (k_vect_cmt0_cmi0 % k_cmt0_ier_bits_per_reg));
 
   /* Start CMT0 */
-  CMT_CTRL.cmstr0 |= k_cmt0_cmstr_start_bit;
+  cmt_ctrl()->cmstr0 |= k_cmt0_cmstr_start_bit;
 
   /* Enable interrupts globally (set I flag in PSW) */
   __asm__ volatile("setpsw i");
@@ -150,7 +150,7 @@ rx_err_t timer_stop(void)
   rx_log_info("TIMER", "Stopping CMT0");
 
   /* Stop CMT0 */
-  CMT_CTRL.cmstr0 &= ~k_cmt0_cmstr_start_bit;
+  cmt_ctrl()->cmstr0 &= ~k_cmt0_cmstr_start_bit;
 
   return k_rx_ok;
 }
@@ -167,7 +167,7 @@ rx_err_t timer_get_count(uint16_t* count)
 {
   RX_CHECK_NULL_PTR(count, "TIMER", "Count pointer is NULL");
 
-  *count = CMT0.cmcnt;
+  *count = cmt0()->cmcnt;
 
   return k_rx_ok;
 }

--- a/star-rx72n-firmware/lib/rx_hal/src/uart.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/uart.c
@@ -77,13 +77,13 @@ typedef enum {
 rx_err_t uart_init(void)
 {
   /* Disable SCI5 transmit/receive */
-  SCI5.scr = k_sci_scr_disabled;
+  sci5()->scr = k_sci_scr_disabled;
 
   /* Configure serial mode: Async, 8-bit, no parity, 1 stop, PCLK/1 */
-  SCI5.smr = k_sci_smr_async_8n1;
+  sci5()->smr = k_sci_smr_async_8n1;
 
   /* Set baud rate */
-  SCI5.brr = k_uart_brr_value;
+  sci5()->brr = k_uart_brr_value;
 
   /* Wait for at least 1 bit time (at least 8.68us at 115200 bps) */
   /* NOTE: Busy-wait required - may run before ThreadX initialization */
@@ -92,10 +92,10 @@ rx_err_t uart_init(void)
   }
 
   /* Configure serial control: Enable transmit */
-  SCI5.scr = k_sci_scr_tx_enabled;
+  sci5()->scr = k_sci_scr_tx_enabled;
 
   /* Configure serial extended mode */
-  SCI5.semr = k_sci_semr_default;
+  sci5()->semr = k_sci_semr_default;
 
   /* Note: GPIO pins for SCI5 TX/RX need to be configured in PMR/MPC
      * This would require MPC (Multi-Function Pin Controller) registers
@@ -120,16 +120,16 @@ rx_err_t uart_init(void)
 void uart_putc(char data)
 {
   /* Wait for transmit buffer to be empty (TDRE flag) */
-  while ((SCI5.ssr & k_sci_ssr_tdre_flag) == 0) {
+  while ((sci5()->ssr & k_sci_ssr_tdre_flag) == 0) {
     /* Wait */
   }
 
   /* Write data to transmit register */
-  SCI5.tdr = (uint8_t)data;
+  sci5()->tdr = (uint8_t)data;
 
   /* Clear TDRE flag by reading SSR then writing 0 */
-  (void)SCI5.ssr;
-  SCI5.ssr &= ~k_sci_ssr_tdre_flag;
+  (void)sci5()->ssr;
+  sci5()->ssr &= ~k_sci_ssr_tdre_flag;
 }
 
 /**

--- a/star-rx72n-firmware/lib/rx_usb/src/rx_usb.c
+++ b/star-rx72n-firmware/lib/rx_usb/src/rx_usb.c
@@ -179,7 +179,7 @@ static void internal_trigger_tx_if_idle(void)
   }
 
   /* Check if Pipe 1 is not busy (PBUSY bit = 0 means idle) */
-  if ((USB0.pipe1ctr & k_usb_pipectr_pbusy) == 0) {
+  if ((usb0()->pipe1ctr & k_usb_pipectr_pbusy) == 0) {
     /* Pipe is idle, trigger transmission */
     rx_usb_cdc_handle_bulk_in();
   }

--- a/star-rx72n-firmware/lib/rx_usb/src/rx_usb_cdc.c
+++ b/star-rx72n-firmware/lib/rx_usb/src/rx_usb_cdc.c
@@ -622,14 +622,14 @@ static void internal_handle_get_descriptor(uint16_t w_value, uint16_t w_length)
           break;
         default:
           /* STALL for unknown string index */
-          USB0.dcpctr |= k_usb_dcpctr_pid_stall;
+          usb0()->dcpctr |= k_usb_dcpctr_pid_stall;
           break;
       }
       break;
 
     default:
       /* STALL for unknown descriptor type */
-      USB0.dcpctr |= k_usb_dcpctr_pid_stall;
+      usb0()->dcpctr |= k_usb_dcpctr_pid_stall;
       break;
   }
 }
@@ -642,7 +642,7 @@ static void internal_handle_set_address(uint16_t w_value)
   uint8_t address = w_value & k_usb_address_mask;
 
   /* Send zero-length status packet first */
-  USB0.dcpctr |= k_usb_dcpctr_ccpl;
+  usb0()->dcpctr |= k_usb_dcpctr_ccpl;
 
   /* Then set the address */
   rx_usb_hw_set_address(address);
@@ -685,10 +685,10 @@ static void internal_handle_set_configuration(uint16_t w_value)
                              k_usb_interrupt_packet_size);
 
     /* Enable BRDY interrupt for Pipe 2 (receive from host) */
-    USB0.brdyenb |= (1 << k_usb_pipe_2);
+    usb0()->brdyenb |= (1 << k_usb_pipe_2);
 
     /* Enable BEMP interrupt for Pipe 1 (transmit complete) */
-    USB0.bempenb |= (1 << k_usb_pipe_1);
+    usb0()->bempenb |= (1 << k_usb_pipe_1);
 
     rx_usb_set_state(k_usb_state_configured);
     rx_log_info(s_tag, "Device configured");
@@ -697,7 +697,7 @@ static void internal_handle_set_configuration(uint16_t w_value)
   }
 
   /* Send zero-length status packet */
-  USB0.dcpctr |= k_usb_dcpctr_ccpl;
+  usb0()->dcpctr |= k_usb_dcpctr_ccpl;
 }
 
 /**
@@ -726,7 +726,7 @@ static void internal_handle_set_line_coding(void)
   }
 
   /* Send zero-length status packet */
-  USB0.dcpctr |= k_usb_dcpctr_ccpl;
+  usb0()->dcpctr |= k_usb_dcpctr_ccpl;
 }
 
 /**
@@ -762,7 +762,7 @@ static void internal_handle_set_control_line_state(uint16_t w_value)
   rx_log_debug(s_tag, "Control line state set");
 
   /* Send zero-length status packet */
-  USB0.dcpctr |= k_usb_dcpctr_ccpl;
+  usb0()->dcpctr |= k_usb_dcpctr_ccpl;
 }
 
 /* =============================================================================
@@ -801,10 +801,10 @@ rx_err_t rx_usb_cdc_init(void)
 void rx_usb_cdc_handle_setup(void)
 {
   /* Read SETUP packet from registers */
-  uint16_t bm_request_type_b_request = USB0.usbreq;
-  uint16_t w_value                   = USB0.usbval;
-  uint16_t w_index                   = USB0.usbindx;
-  uint16_t w_length                  = USB0.usbleng;
+  uint16_t bm_request_type_b_request = usb0()->usbreq;
+  uint16_t w_value                   = usb0()->usbval;
+  uint16_t w_index                   = usb0()->usbindx;
+  uint16_t w_length                  = usb0()->usbleng;
 
   uint8_t bm_request_type = bm_request_type_b_request & k_byte_mask;
   uint8_t b_request       = (bm_request_type_b_request >> k_bit_shift_byte_1) & k_byte_mask;
@@ -838,7 +838,7 @@ void rx_usb_cdc_handle_setup(void)
 
       default:
         /* STALL unknown standard requests */
-        USB0.dcpctr |= k_usb_dcpctr_pid_stall;
+        usb0()->dcpctr |= k_usb_dcpctr_pid_stall;
         break;
     }
   } else if (type == k_usb_req_type_class) {
@@ -858,12 +858,12 @@ void rx_usb_cdc_handle_setup(void)
 
       default:
         /* STALL unknown class requests */
-        USB0.dcpctr |= k_usb_dcpctr_pid_stall;
+        usb0()->dcpctr |= k_usb_dcpctr_pid_stall;
         break;
     }
   } else {
     /* STALL vendor and reserved requests */
-    USB0.dcpctr |= k_usb_dcpctr_pid_stall;
+    usb0()->dcpctr |= k_usb_dcpctr_pid_stall;
   }
 }
 

--- a/star-rx72n-firmware/lib/rx_usb/src/rx_usb_hw.c
+++ b/star-rx72n-firmware/lib/rx_usb/src/rx_usb_hw.c
@@ -93,16 +93,16 @@ rx_err_t rx_usb_hw_init(void)
 
   /* 1. Enable USB0 module clock */
   /* Unlock protection */
-  SYSTEM.prcr = k_prcr_unlock;
+  system_regs()->prcr = k_prcr_unlock;
 
   /* Clear module stop bit for USB0 (bit 19 in MSTPCRB) */
-  SYSTEM.mstpcrb &= ~(1UL << k_mstpb_usb0);
+  system_regs()->mstpcrb &= ~(1UL << k_mstpb_usb0);
 
   /* Lock protection */
-  SYSTEM.prcr = k_prcr_lock;
+  system_regs()->prcr = k_prcr_lock;
 
   /* 2. Disable USB module before configuration */
-  USB0.syscfg = k_usb_syscfg_disabled;
+  usb0()->syscfg = k_usb_syscfg_disabled;
 
   /* 3. Wait for USB PLL to stabilize */
   /* Note: USB requires 48 MHz clock from main PLL */
@@ -117,11 +117,11 @@ rx_err_t rx_usb_hw_init(void)
   /* DRPD = 0: Disable D+/D- pull-down (function mode) */
   /* DPRPU = 0: D+ pull-up disabled initially (enabled on attach) */
   /* USBE = 0: USB module disabled initially */
-  USB0.syscfg = k_usb_syscfg_disabled;
+  usb0()->syscfg = k_usb_syscfg_disabled;
 
   /* 5. Configure USB clock */
   /* SCKE = 1: Enable USB clock */
-  USB0.syscfg |= k_usb_syscfg_scke;
+  usb0()->syscfg |= k_usb_syscfg_scke;
 
   /* Wait for clock to stabilize */
   uint32_t clock_ticks = k_usb_clock_stabilization_ms / k_threadx_ms_per_tick;
@@ -131,26 +131,26 @@ rx_err_t rx_usb_hw_init(void)
   tx_thread_sleep(clock_ticks);
 
   /* 6. Enable USB module */
-  USB0.syscfg |= k_usb_syscfg_usbe;
+  usb0()->syscfg |= k_usb_syscfg_usbe;
 
   /* 7. Configure interrupts */
   /* Enable: VBUS, device state, control transfer, buffer ready/empty */
-  USB0.intenb0 = k_usb_intenb0_vbse | k_usb_intenb0_dvse | k_usb_intenb0_ctre |
+  usb0()->intenb0 = k_usb_intenb0_vbse | k_usb_intenb0_dvse | k_usb_intenb0_ctre |
                  k_usb_intenb0_brdye | k_usb_intenb0_bempe;
 
   /* 8. Configure Interrupt Controller (ICU) */
   /* Clear pending interrupt */
-  ICU.ir[k_vect_usb0_usbi] = 0;
+  icu()->ir[k_vect_usb0_usbi] = 0;
 
   /* Set interrupt priority */
-  ICU.ipr[k_vect_usb0_usbi] = k_usb_interrupt_priority;
+  icu()->ipr[k_vect_usb0_usbi] = k_usb_interrupt_priority;
 
   /* Enable interrupt in IER */
-  ICU.ier[k_vect_usb0_usbi / k_icu_bits_per_ier_register] |=
+  icu()->ier[k_vect_usb0_usbi / k_icu_bits_per_ier_register] |=
     (1 << (k_vect_usb0_usbi % k_icu_bits_per_ier_register));
 
   /* 9. Set default control pipe max packet size (64 bytes for FS) */
-  USB0.dcpmaxp = k_usb_cdc_max_packet_fs;
+  usb0()->dcpmaxp = k_usb_cdc_max_packet_fs;
 
   s_hw_initialized = true;
 
@@ -171,17 +171,17 @@ rx_err_t rx_usb_hw_deinit(void)
   rx_log_debug(s_tag, "Deinitializing USB0 hardware");
 
   /* Disable USB module */
-  USB0.syscfg = k_usb_syscfg_disabled;
+  usb0()->syscfg = k_usb_syscfg_disabled;
 
   /* Disable interrupt in ICU */
-  ICU.ier[k_vect_usb0_usbi / k_icu_bits_per_ier_register] &=
+  icu()->ier[k_vect_usb0_usbi / k_icu_bits_per_ier_register] &=
     ~(1 << (k_vect_usb0_usbi % k_icu_bits_per_ier_register));
-  ICU.ir[k_vect_usb0_usbi] = 0;
+  icu()->ir[k_vect_usb0_usbi] = 0;
 
   /* Disable USB0 module clock */
-  SYSTEM.prcr = k_prcr_unlock;
-  SYSTEM.mstpcrb |= (1UL << k_mstpb_usb0);
-  SYSTEM.prcr = k_prcr_lock;
+  system_regs()->prcr = k_prcr_unlock;
+  system_regs()->mstpcrb |= (1UL << k_mstpb_usb0);
+  system_regs()->prcr = k_prcr_lock;
 
   s_hw_initialized = false;
 
@@ -202,7 +202,7 @@ rx_err_t rx_usb_hw_attach(void)
   rx_log_debug(s_tag, "Attaching to USB bus");
 
   /* Enable D+ pull-up resistor to signal device presence */
-  USB0.syscfg |= k_usb_syscfg_dprpu;
+  usb0()->syscfg |= k_usb_syscfg_dprpu;
 
   return k_rx_ok;
 }
@@ -219,7 +219,7 @@ rx_err_t rx_usb_hw_detach(void)
   rx_log_debug(s_tag, "Detaching from USB bus");
 
   /* Disable D+ pull-up resistor */
-  USB0.syscfg &= ~k_usb_syscfg_dprpu;
+  usb0()->syscfg &= ~k_usb_syscfg_dprpu;
 
   return k_rx_ok;
 }
@@ -239,12 +239,12 @@ uint32_t rx_usb_hw_fifo_read(uint8_t pipe, uint8_t* data, uint32_t max_len)
   }
 
   /* Select pipe for CFIFO access */
-  USB0.cfifosel = (pipe & k_usb_fifosel_curpipe_mask);
+  usb0()->cfifosel = (pipe & k_usb_fifosel_curpipe_mask);
 
   /* Wait for FIFO ready (hardware polling) */
   /* NOTE: Busy-wait appropriate - microsecond-scale hardware readiness check */
   volatile uint32_t timeout = k_usb_fifo_timeout_iterations;
-  while (!(USB0.cfifoctr & k_usb_fifoctr_frdy) && timeout--) {
+  while (!(usb0()->cfifoctr & k_usb_fifoctr_frdy) && timeout--) {
     __asm__ volatile("nop");
   }
 
@@ -253,18 +253,18 @@ uint32_t rx_usb_hw_fifo_read(uint8_t pipe, uint8_t* data, uint32_t max_len)
   }
 
   /* Get received data length */
-  uint32_t len = USB0.cfifoctr & k_usb_fifoctr_dtln_mask;
+  uint32_t len = usb0()->cfifoctr & k_usb_fifoctr_dtln_mask;
   if (len > max_len) {
     len = max_len;
   }
 
   /* Read data from FIFO */
   for (uint32_t i = 0; i < len; i++) {
-    data[i] = (uint8_t)(USB0.cfifo & k_usb_fifo_byte_mask);
+    data[i] = (uint8_t)(usb0()->cfifo & k_usb_fifo_byte_mask);
   }
 
   /* Clear buffer */
-  USB0.cfifoctr |= k_usb_fifoctr_bclr;
+  usb0()->cfifoctr |= k_usb_fifoctr_bclr;
 
   return len;
 }
@@ -284,12 +284,12 @@ uint32_t rx_usb_hw_fifo_write(uint8_t pipe, const uint8_t* data, uint32_t len)
   }
 
   /* Select pipe for CFIFO access with write direction */
-  USB0.cfifosel = (pipe & k_usb_fifosel_curpipe_mask) | k_usb_fifosel_isel;
+  usb0()->cfifosel = (pipe & k_usb_fifosel_curpipe_mask) | k_usb_fifosel_isel;
 
   /* Wait for FIFO ready (hardware polling) */
   /* NOTE: Busy-wait appropriate - microsecond-scale hardware readiness check */
   volatile uint32_t timeout = k_usb_fifo_timeout_iterations;
-  while (!(USB0.cfifoctr & k_usb_fifoctr_frdy) && timeout--) {
+  while (!(usb0()->cfifoctr & k_usb_fifoctr_frdy) && timeout--) {
     __asm__ volatile("nop");
   }
 
@@ -299,11 +299,11 @@ uint32_t rx_usb_hw_fifo_write(uint8_t pipe, const uint8_t* data, uint32_t len)
 
   /* Write data to FIFO */
   for (uint32_t i = 0; i < len; i++) {
-    USB0.cfifo = data[i];
+    usb0()->cfifo = data[i];
   }
 
   /* Set buffer valid to signal data ready for transmission */
-  USB0.cfifoctr |= k_usb_fifoctr_bval;
+  usb0()->cfifoctr |= k_usb_fifoctr_bval;
 
   return len;
 }
@@ -313,7 +313,7 @@ uint32_t rx_usb_hw_fifo_write(uint8_t pipe, const uint8_t* data, uint32_t len)
  */
 rx_usb_state_t rx_usb_hw_get_bus_state(void)
 {
-  uint16_t intsts0 = USB0.intsts0;
+  uint16_t intsts0 = usb0()->intsts0;
   uint16_t dvsq    = (intsts0 & k_usb_intsts0_dvsq_mask);
 
   switch (dvsq) {
@@ -337,7 +337,7 @@ rx_usb_state_t rx_usb_hw_get_bus_state(void)
  */
 void rx_usb_hw_set_address(uint8_t address)
 {
-  USB0.usbaddr = address & k_usb_address_mask_hw;
+  usb0()->usbaddr = address & k_usb_address_mask_hw;
   rx_log_debug(s_tag, "USB address set");
 }
 
@@ -355,7 +355,7 @@ rx_err_t rx_usb_hw_configure_pipe(uint8_t  pipe,
   }
 
   /* Select pipe for configuration */
-  USB0.pipesel = pipe;
+  usb0()->pipesel = pipe;
 
   /* Configure pipe */
   uint16_t cfg = (endpoint & k_usb_pipecfg_epnum_mask) | type;
@@ -364,11 +364,11 @@ rx_err_t rx_usb_hw_configure_pipe(uint8_t  pipe,
     cfg |= k_usb_pipecfg_dir; /* DIR=1 for IN (device to host) */
   }
 
-  USB0.pipecfg  = cfg;
-  USB0.pipemaxp = max_packet;
+  usb0()->pipecfg  = cfg;
+  usb0()->pipemaxp = max_packet;
 
   /* Clear pipe */
-  volatile uint16_t* pipe_ctr = &USB0.pipe1ctr + (pipe - 1);
+  volatile uint16_t* pipe_ctr = &usb0()->pipe1ctr + (pipe - 1);
   *pipe_ctr |= k_usb_pipectr_aclrm;
   *pipe_ctr &= ~k_usb_pipectr_aclrm;
 

--- a/star-rx72n-firmware/lib/rx_usb/src/rx_usb_isr.c
+++ b/star-rx72n-firmware/lib/rx_usb/src/rx_usb_isr.c
@@ -59,7 +59,7 @@ extern rx_usb_state_t rx_usb_hw_get_bus_state(void);
  */
 static void internal_handle_vbus_interrupt(void)
 {
-  uint16_t syssts = USB0.syssts0;
+  uint16_t syssts = usb0()->syssts0;
 
   /* Check line state to determine if cable is connected */
   uint16_t lnst = syssts & k_usb_syssts0_lnst_mask;
@@ -74,7 +74,7 @@ static void internal_handle_vbus_interrupt(void)
   }
 
   /* Clear VBUS interrupt flag */
-  USB0.intsts0 = (uint16_t)~k_usb_intsts0_vbint;
+  usb0()->intsts0 = (uint16_t)~k_usb_intsts0_vbint;
 }
 
 /**
@@ -82,7 +82,7 @@ static void internal_handle_vbus_interrupt(void)
  */
 static void internal_handle_dvst_interrupt(void)
 {
-  uint16_t intsts0 = USB0.intsts0;
+  uint16_t intsts0 = usb0()->intsts0;
   uint16_t dvsq    = intsts0 & k_usb_intsts0_dvsq_mask;
 
   switch (dvsq) {
@@ -119,7 +119,7 @@ static void internal_handle_dvst_interrupt(void)
   }
 
   /* Clear DVST interrupt flag */
-  USB0.intsts0 = (uint16_t)~k_usb_intsts0_dvst;
+  usb0()->intsts0 = (uint16_t)~k_usb_intsts0_dvst;
 }
 
 /**
@@ -127,7 +127,7 @@ static void internal_handle_dvst_interrupt(void)
  */
 static void internal_handle_ctrt_interrupt(void)
 {
-  uint16_t intsts0 = USB0.intsts0;
+  uint16_t intsts0 = usb0()->intsts0;
   uint16_t ctsq    = intsts0 & k_usb_intsts0_ctsq_mask;
 
   switch (ctsq) {
@@ -136,7 +136,7 @@ static void internal_handle_ctrt_interrupt(void)
       if (intsts0 & k_usb_intsts0_valid) {
         rx_usb_cdc_handle_setup();
         /* Clear VALID flag */
-        USB0.intsts0 = (uint16_t)~k_usb_intsts0_valid;
+        usb0()->intsts0 = (uint16_t)~k_usb_intsts0_valid;
       }
       break;
 
@@ -148,7 +148,7 @@ static void internal_handle_ctrt_interrupt(void)
     case k_usb_intsts0_ctsq_rd_status:
       /* Control read status stage - host sends ZLP ACK */
       /* Complete the control transfer */
-      USB0.dcpctr |= k_usb_dcpctr_ccpl;
+      usb0()->dcpctr |= k_usb_dcpctr_ccpl;
       break;
 
     case k_usb_intsts0_ctsq_wr_data:
@@ -159,18 +159,18 @@ static void internal_handle_ctrt_interrupt(void)
     case k_usb_intsts0_ctsq_wr_status:
       /* Control write status stage - send ZLP ACK */
       /* Complete the control transfer */
-      USB0.dcpctr |= k_usb_dcpctr_ccpl;
+      usb0()->dcpctr |= k_usb_dcpctr_ccpl;
       break;
 
     case k_usb_intsts0_ctsq_wr_nd:
       /* Control write with no data - status stage */
-      USB0.dcpctr |= k_usb_dcpctr_ccpl;
+      usb0()->dcpctr |= k_usb_dcpctr_ccpl;
       break;
 
     case k_usb_intsts0_ctsq_seq_err:
       /* Sequence error - stall the pipe */
       rx_log_warn(s_tag, "CTRT: Sequence error");
-      USB0.dcpctr = (USB0.dcpctr & ~k_usb_dcpctr_pid_mask) | k_usb_dcpctr_pid_stall;
+      usb0()->dcpctr = (usb0()->dcpctr & ~k_usb_dcpctr_pid_mask) | k_usb_dcpctr_pid_stall;
       break;
 
     default:
@@ -178,7 +178,7 @@ static void internal_handle_ctrt_interrupt(void)
   }
 
   /* Clear CTRT interrupt flag */
-  USB0.intsts0 = (uint16_t)~k_usb_intsts0_ctrt;
+  usb0()->intsts0 = (uint16_t)~k_usb_intsts0_ctrt;
 }
 
 /**
@@ -186,7 +186,7 @@ static void internal_handle_ctrt_interrupt(void)
  */
 static void internal_handle_brdy_interrupt(void)
 {
-  uint16_t brdysts = USB0.brdysts;
+  uint16_t brdysts = usb0()->brdysts;
 
   /* Check each pipe for buffer ready */
   for (uint8_t pipe = k_usb_pipe_dcp; pipe <= k_usb_pipe_max; pipe++) {
@@ -200,7 +200,7 @@ static void internal_handle_brdy_interrupt(void)
       }
 
       /* Clear pipe buffer ready flag */
-      USB0.brdysts = (uint16_t)~(1U << pipe);
+      usb0()->brdysts = (uint16_t)~(1U << pipe);
     }
   }
 }
@@ -210,7 +210,7 @@ static void internal_handle_brdy_interrupt(void)
  */
 static void internal_handle_bemp_interrupt(void)
 {
-  uint16_t bempsts = USB0.bempsts;
+  uint16_t bempsts = usb0()->bempsts;
 
   /* Check each pipe for buffer empty */
   for (uint8_t pipe = k_usb_pipe_dcp; pipe <= k_usb_pipe_max; pipe++) {
@@ -224,7 +224,7 @@ static void internal_handle_bemp_interrupt(void)
       }
 
       /* Clear pipe buffer empty flag */
-      USB0.bempsts = (uint16_t)~(1U << pipe);
+      usb0()->bempsts = (uint16_t)~(1U << pipe);
     }
   }
 }
@@ -241,7 +241,7 @@ static void internal_handle_resume_interrupt(void)
   rx_usb_set_state(state);
 
   /* Clear resume interrupt flag */
-  USB0.intsts0 = (uint16_t)~k_usb_intsts0_resm;
+  usb0()->intsts0 = (uint16_t)~k_usb_intsts0_resm;
 }
 
 /* =============================================================================
@@ -258,8 +258,8 @@ static void internal_handle_resume_interrupt(void)
  */
 void rx_usb_isr_handler(void)
 {
-  uint16_t intsts0 = USB0.intsts0;
-  uint16_t intenb0 = USB0.intenb0;
+  uint16_t intsts0 = usb0()->intsts0;
+  uint16_t intenb0 = usb0()->intenb0;
 
   /* Only process enabled interrupts */
   uint16_t active = intsts0 & intenb0;
@@ -304,7 +304,7 @@ void rx_usb_isr_handler(void)
 void usb0_usbi_isr(void)
 {
   /* Clear interrupt request flag in ICU */
-  ICU.ir[k_vect_usb0_usbi] = 0;
+  icu()->ir[k_vect_usb0_usbi] = 0;
 
   /* Call main USB handler */
   rx_usb_isr_handler();
@@ -318,7 +318,7 @@ void usb0_usbi_isr(void)
 void usb0_d0fifo_isr(void)
 {
   /* Clear interrupt request flag */
-  ICU.ir[k_vect_usb0_d0fifo] = 0;
+  icu()->ir[k_vect_usb0_d0fifo] = 0;
 
   /* D0FIFO DMA not implemented - clear and ignore */
 }
@@ -331,7 +331,7 @@ void usb0_d0fifo_isr(void)
 void usb0_d1fifo_isr(void)
 {
   /* Clear interrupt request flag */
-  ICU.ir[k_vect_usb0_d1fifo] = 0;
+  icu()->ir[k_vect_usb0_d1fifo] = 0;
 
   /* D1FIFO DMA not implemented - clear and ignore */
 }
@@ -344,7 +344,7 @@ void usb0_d1fifo_isr(void)
 void usb0_usbr_isr(void)
 {
   /* Clear interrupt request flag */
-  ICU.ir[k_vect_usb0_usbr] = 0;
+  icu()->ir[k_vect_usb0_usbr] = 0;
 
   /* Handle resume */
   internal_handle_resume_interrupt();

--- a/star-rx72n-firmware/tests/mocks/mock_usb0_regs.h
+++ b/star-rx72n-firmware/tests/mocks/mock_usb0_regs.h
@@ -130,14 +130,25 @@ extern mock_icu_regs_t    g_mock_icu;
 extern mock_system_regs_t g_mock_system;
 
 /* =============================================================================
- * Macros to Map Hardware Names to Mock Instances
- * Allows code to use USB0.xxx syntax with mock registers
+ * Inline Accessor Functions for Mock Registers
+ * Matches production code pattern (inline accessors instead of macros)
  * =============================================================================
  */
 
-#define USB0   g_mock_usb0
-#define ICU    g_mock_icu
-#define SYSTEM g_mock_system
+static inline volatile mock_usb0_regs_t* usb0(void)
+{
+  return &g_mock_usb0;
+}
+
+static inline volatile mock_icu_regs_t* icu(void)
+{
+  return &g_mock_icu;
+}
+
+static inline volatile mock_system_regs_t* system_regs(void)
+{
+  return &g_mock_system;
+}
 
 /* =============================================================================
  * Pipe Control Register Bits (from rx72n_regs.h)


### PR DESCRIPTION
## Summary

This PR eliminates **all** hardware register address macros in favor of type-safe inline accessor functions, completing the architectural improvement discussed in #90.

### Motivation

Hardware register addresses were previously defined using macros:
```c
#define CMT0_BASE ((rx_cmt_channel_regs_t*)0x00088000)
#define CMT0 (*CMT0_BASE)
```

This approach has several drawbacks:
- No type safety (preprocessor text substitution)
- Not visible in debugger
- Can't step into or inspect
- No scoping/namespacing

### Solution

Replace with inline accessor functions:
```c
typedef enum {
    k_cmt0_base_addr = 0x00088000,
} rx_cmt_addresses_t;

static inline volatile rx_cmt_channel_regs_t* cmt0(void) {
    return (volatile rx_cmt_channel_regs_t*)k_cmt0_base_addr;
}
```

**Benefits:**
✅ Type-safe (function returns typed pointer)  
✅ Debugger-friendly (can step into, inspect)  
✅ Zero runtime overhead (compiler optimizes to same code)  
✅ Addresses are named enum constants (searchable)  
✅ Can add validation in debug builds  
✅ Consistent pattern across all peripherals  

---

## Changes

### Documentation Updates (4 files)
- Updated SKILL.md, STANDARDS.md, CLAUDE.md, GEMINI.md
- Macros now ONLY allowed for 3 specific cases (down from 4):
  1. Reducing duplicated code (function-like macros)
  2. Conditional compilation
  3. Build configuration flags
- Hardware register access: Use inline accessors (never macros)

### Phase 1: Low-Risk Peripherals (6 files)
- IWDT (Independent Watchdog Timer)
- ADC (12-bit A/D Converter)
- MPC (Multi-Function Pin Controller)

### Phase 2: Medium-Risk Peripherals (11 files)
- CRC (CRC Calculator)
- SCI (Serial Communication Interface) - 5 channels
- RSPI (Renesas SPI) - 3 channels
- RIIC (I2C Interface) - 3 channels
- MTU (Multi-Function Timer Unit) - 7 channels

### Phase 3: High-Risk Peripherals (23 files)
- CMT (Compare Match Timer) - ThreadX system tick
- ICU (Interrupt Controller)
- SYSTEM (System Control Registers)
- PORT (GPIO) - 18 ports
- USB (USB 2.0 Host/Function)

### Test Infrastructure
- Updated test mocks to use inline accessor pattern
- All unit tests passing ✅

---

## Testing

### Build Verification
```
✓ Firmware compiles successfully
  Text:  9,123 bytes
  Data:     12 bytes
  BSS:  51,860 bytes
```

### Unit Tests
```
✓ All 8 tests passing (100% pass rate)
  - test_rx_crc32
  - test_rx_frame
  - test_rx_fec
  - test_rx_harq
  - test_rx_usb
  - test_rx_usb_comm
  - test_rx_time
  - test_rx_hcsr04
```

---

## Statistics

- **Files changed:** 39 files
- **Lines added:** 975
- **Lines removed:** 457
- **Net change:** +518 lines
- **Peripherals refactored:** 13 peripheral types
- **Register accessor functions:** 40+ inline functions

---

## Breaking Changes

⚠️ **This is a breaking change for any external code that directly accesses hardware registers.**

**Migration guide:**
```c
// Old (macro-based):
CMT0.cmcr = 0x42;
ICU.ipr[28] = 3;
SYSTEM.prcr = 0xA50F;

// New (inline accessor):
cmt0()->cmcr = 0x42;
icu()->ipr[28] = 3;
system_regs()->prcr = 0xA50F;
```

All internal code has been updated. No action required for typical firmware usage.

---

## Checklist

- [x] Code follows project style guidelines
- [x] Documentation updated (SKILL.md, STANDARDS.md, CLAUDE.md, GEMINI.md)
- [x] All phases completed (low/medium/high risk peripherals)
- [x] Firmware compiles without errors
- [x] All unit tests passing (8/8)
- [x] Test mocks updated
- [x] Commit messages follow conventional commits
- [x] No magic numbers (addresses in enums)
- [x] Volatile qualifier preserved on all pointers

---

## Related Issues

Closes #90 (code review agent discussion led to this architectural improvement)