### PR TITLE
test: Add comprehensive unit tests for rx_spi_comm layer

### DIFF
--- a/star-rx72n-firmware/tests/CMakeLists.txt
+++ b/star-rx72n-firmware/tests/CMakeLists.txt
@@ -97,6 +97,16 @@ set(MOCK_GPTW_SRC
     ${CMAKE_SOURCE_DIR}/mocks/mock_rx_gptw.c
 )
 
+# Mock RSPI source for SPI communication testing
+set(MOCK_RSPI_SRC
+    ${CMAKE_SOURCE_DIR}/mocks/mock_rspi.c
+)
+
+# rx_spi_comm source
+set(RX_SPI_COMM_SRC
+    ${CMAKE_SOURCE_DIR}/../lib/rx_spi_comm/src/rx_spi_comm.c
+)
+
 # rx_motor source
 set(RX_MOTOR_SRC
     ${CMAKE_SOURCE_DIR}/../lib/rx_motor/src/rx_motor.c
@@ -112,6 +122,7 @@ include_directories(
     ${CMAKE_SOURCE_DIR}/../lib/rx_core/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_usb_comm/inc
+    ${CMAKE_SOURCE_DIR}/../lib/rx_spi_comm/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/inc
     ${CMAKE_SOURCE_DIR}/../lib/rx_hcsr04/src
     ${CMAKE_SOURCE_DIR}/../lib/rx_hal/inc
@@ -228,6 +239,17 @@ add_executable(test_rx_motor
 target_compile_definitions(test_rx_motor PRIVATE UNIT_TEST)
 target_link_libraries(test_rx_motor m)
 
+# Test: SPI Communication Layer
+add_executable(test_rx_spi_comm
+    test_rx_spi_comm.c
+    ${RX_SPI_COMM_SRC}
+    ${RX_FRAME_SRC}
+    ${MOCK_RSPI_SRC}
+    ${MOCK_LOG_SRC}
+)
+target_compile_definitions(test_rx_spi_comm PRIVATE UNIT_TEST)
+target_link_libraries(test_rx_spi_comm unity)
+
 # =============================================================================
 # CTest Integration
 # =============================================================================
@@ -245,6 +267,7 @@ add_test(NAME test_rx_hcsr04 COMMAND test_rx_hcsr04)
 add_test(NAME test_uart_hal COMMAND test_uart_hal)
 add_test(NAME test_rx_bus_uart COMMAND test_rx_bus_uart)
 add_test(NAME test_rx_motor COMMAND test_rx_motor)
+add_test(NAME test_rx_spi_comm COMMAND test_rx_spi_comm)
 
 # =============================================================================
 # Convenience Targets
@@ -252,7 +275,7 @@ add_test(NAME test_rx_motor COMMAND test_rx_motor)
 
 add_custom_target(run_all_tests
     COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-    DEPENDS test_rx_crc32 test_rx_frame test_rx_fec test_rx_harq test_rx_usb test_rx_usb_comm test_rx_time test_rx_hcsr04 test_uart_hal test_rx_bus_uart test_rx_motor
+    DEPENDS test_rx_crc32 test_rx_frame test_rx_fec test_rx_harq test_rx_usb test_rx_usb_comm test_rx_time test_rx_hcsr04 test_uart_hal test_rx_bus_uart test_rx_motor test_rx_spi_comm
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Running all unit tests..."
 )

--- a/star-rx72n-firmware/tests/mocks/mock_rspi.c
+++ b/star-rx72n-firmware/tests/mocks/mock_rspi.c
@@ -1,0 +1,535 @@
+/* tests/mocks/mock_rspi.c */
+
+/**
+ * @file mock_rspi.c
+ * @brief Mock RSPI Hardware Layer Implementation for Host-Side Testing
+ *
+ * Mock implementation of the RSPI (SPI) hardware layer.
+ * Provides call tracking, error injection, and data injection capabilities
+ * for testing the SPI communication layer.
+ *
+ * @date 2026-01-05
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "mock_rspi.h"
+
+#include <string.h>
+
+/* =============================================================================
+ * Global Mock Instance
+ * =============================================================================
+ */
+
+mock_rspi_t g_mock_rspi;
+
+/* =============================================================================
+ * Internal Helpers
+ * =============================================================================
+ */
+
+/**
+ * @brief Get mock instance, using global if NULL provided
+ */
+static mock_rspi_t* internal_get_mock(mock_rspi_t* mock)
+{
+    return (mock != NULL) ? mock : &g_mock_rspi;
+}
+
+/* =============================================================================
+ * Initialization Functions
+ * =============================================================================
+ */
+
+rx_err_t mock_rspi_init(mock_rspi_t* mock)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    memset(m, 0, sizeof(mock_rspi_t));
+
+    /* Set default return values */
+    m->next_init_return      = k_rx_ok;
+    m->next_transfer_return  = k_rx_ok;
+    m->next_available_return = k_rx_ok;
+    m->next_ready_return     = k_rx_ok;
+    m->next_deinit_return    = k_rx_ok;
+
+    /* Default all channels to write ready */
+    for (uint8_t i = 0; i < k_mock_rspi_max_channels; i++) {
+        m->channels[i].write_ready = true;
+    }
+
+    return k_rx_ok;
+}
+
+rx_err_t mock_rspi_deinit(mock_rspi_t* mock)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    memset(m, 0, sizeof(mock_rspi_t));
+
+    return k_rx_ok;
+}
+
+rx_err_t mock_rspi_clear(mock_rspi_t* mock)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    /* Clear channel states but preserve return value settings */
+    rx_err_t saved_init      = m->next_init_return;
+    rx_err_t saved_transfer  = m->next_transfer_return;
+    rx_err_t saved_available = m->next_available_return;
+    rx_err_t saved_ready     = m->next_ready_return;
+    rx_err_t saved_deinit    = m->next_deinit_return;
+
+    memset(m->channels, 0, sizeof(m->channels));
+
+    /* Clear call history */
+    memset(m->call_history, 0, sizeof(m->call_history));
+    m->call_count       = 0;
+    m->call_write_index = 0;
+
+    /* Clear statistics */
+    m->init_calls      = 0;
+    m->deinit_calls    = 0;
+    m->transfer_calls  = 0;
+    m->available_calls = 0;
+    m->ready_calls     = 0;
+
+    /* Restore return value settings */
+    m->next_init_return      = saved_init;
+    m->next_transfer_return  = saved_transfer;
+    m->next_available_return = saved_available;
+    m->next_ready_return     = saved_ready;
+    m->next_deinit_return    = saved_deinit;
+
+    /* Default all channels to write ready */
+    for (uint8_t i = 0; i < k_mock_rspi_max_channels; i++) {
+        m->channels[i].write_ready = true;
+    }
+
+    return k_rx_ok;
+}
+
+/* =============================================================================
+ * Error Injection Functions
+ * =============================================================================
+ */
+
+void mock_rspi_set_init_return(mock_rspi_t* mock, rx_err_t ret)
+{
+    mock_rspi_t* m        = internal_get_mock(mock);
+    m->next_init_return = ret;
+}
+
+void mock_rspi_set_transfer_return(mock_rspi_t* mock, rx_err_t ret)
+{
+    mock_rspi_t* m            = internal_get_mock(mock);
+    m->next_transfer_return = ret;
+}
+
+void mock_rspi_set_available_return(mock_rspi_t* mock, rx_err_t ret)
+{
+    mock_rspi_t* m             = internal_get_mock(mock);
+    m->next_available_return = ret;
+}
+
+void mock_rspi_set_ready_return(mock_rspi_t* mock, rx_err_t ret)
+{
+    mock_rspi_t* m         = internal_get_mock(mock);
+    m->next_ready_return = ret;
+}
+
+void mock_rspi_set_deinit_return(mock_rspi_t* mock, rx_err_t ret)
+{
+    mock_rspi_t* m          = internal_get_mock(mock);
+    m->next_deinit_return = ret;
+}
+
+/* =============================================================================
+ * Data Injection/Extraction Functions
+ * =============================================================================
+ */
+
+rx_err_t mock_rspi_inject_rx_data(mock_rspi_t*   mock,
+                                  uint8_t        channel,
+                                  const uint8_t* data,
+                                  uint32_t       len)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    if (channel >= k_mock_rspi_max_channels) {
+        return k_rx_err_invalid_arg;
+    }
+
+    if (data == NULL && len > 0) {
+        return k_rx_err_invalid_arg;
+    }
+
+    if (len > k_mock_rspi_buffer_size) {
+        return k_rx_err_invalid_size;
+    }
+
+    mock_rspi_channel_t* ch = &m->channels[channel];
+
+    if (data != NULL && len > 0) {
+        memcpy(ch->rx_data, data, len);
+    }
+    ch->rx_len        = len;
+    ch->rx_pos        = 0;
+    ch->data_available = (len > 0);
+
+    return k_rx_ok;
+}
+
+rx_err_t mock_rspi_get_tx_data(mock_rspi_t* mock,
+                               uint8_t      channel,
+                               uint8_t*     data,
+                               uint32_t     max_len,
+                               uint32_t*    actual_len)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    if (channel >= k_mock_rspi_max_channels) {
+        return k_rx_err_invalid_arg;
+    }
+
+    if (data == NULL || actual_len == NULL) {
+        return k_rx_err_invalid_arg;
+    }
+
+    mock_rspi_channel_t* ch = &m->channels[channel];
+
+    uint32_t copy_len = (ch->tx_len < max_len) ? ch->tx_len : max_len;
+    memcpy(data, ch->tx_data, copy_len);
+    *actual_len = copy_len;
+
+    return k_rx_ok;
+}
+
+void mock_rspi_set_data_available(mock_rspi_t* mock, uint8_t channel, bool available)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    if (channel < k_mock_rspi_max_channels) {
+        m->channels[channel].data_available = available;
+    }
+}
+
+void mock_rspi_set_write_ready(mock_rspi_t* mock, uint8_t channel, bool ready)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    if (channel < k_mock_rspi_max_channels) {
+        m->channels[channel].write_ready = ready;
+    }
+}
+
+void mock_rspi_clear_channel(mock_rspi_t* mock, uint8_t channel)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    if (channel < k_mock_rspi_max_channels) {
+        mock_rspi_channel_t* ch = &m->channels[channel];
+
+        memset(ch->rx_data, 0, sizeof(ch->rx_data));
+        memset(ch->tx_data, 0, sizeof(ch->tx_data));
+        ch->rx_len         = 0;
+        ch->rx_pos         = 0;
+        ch->tx_len         = 0;
+        ch->data_available = false;
+        ch->write_ready    = true;
+    }
+}
+
+/* =============================================================================
+ * Call Tracking Functions
+ * =============================================================================
+ */
+
+bool mock_rspi_was_called(mock_rspi_t* mock, const char* func)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    for (uint32_t i = 0; i < m->call_count && i < k_mock_rspi_call_history_max; i++) {
+        if (strncmp(m->call_history[i].function, func, k_mock_rspi_func_name_max) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+uint32_t mock_rspi_get_call_count(mock_rspi_t* mock, const char* func)
+{
+    mock_rspi_t* m     = internal_get_mock(mock);
+    uint32_t     count = 0;
+
+    for (uint32_t i = 0; i < m->call_count && i < k_mock_rspi_call_history_max; i++) {
+        if (strncmp(m->call_history[i].function, func, k_mock_rspi_func_name_max) == 0) {
+            count++;
+        }
+    }
+
+    return count;
+}
+
+rx_err_t mock_rspi_get_last_call(mock_rspi_t*      mock,
+                                 const char*       func,
+                                 mock_rspi_call_t* out_call)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    if (out_call == NULL || func == NULL) {
+        return k_rx_err_invalid_arg;
+    }
+
+    /* Search backwards through call history */
+    for (int32_t i = (int32_t)m->call_count - 1; i >= 0 && i < (int32_t)k_mock_rspi_call_history_max; i--) {
+        uint32_t idx = (uint32_t)i % k_mock_rspi_call_history_max;
+        if (strncmp(m->call_history[idx].function, func, k_mock_rspi_func_name_max) == 0) {
+            memcpy(out_call, &m->call_history[idx], sizeof(mock_rspi_call_t));
+            return k_rx_ok;
+        }
+    }
+
+    return k_rx_err_not_found;
+}
+
+void mock_rspi_clear_calls(mock_rspi_t* mock)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    memset(m->call_history, 0, sizeof(m->call_history));
+    m->call_count       = 0;
+    m->call_write_index = 0;
+}
+
+void mock_rspi_record_call(mock_rspi_t* mock,
+                           const char*  func,
+                           uint8_t      channel,
+                           uint32_t     arg1,
+                           uint32_t     arg2,
+                           rx_err_t     ret)
+{
+    mock_rspi_t* m = internal_get_mock(mock);
+
+    mock_rspi_call_t* call = &m->call_history[m->call_write_index];
+
+    strncpy(call->function, func, k_mock_rspi_func_name_max - 1);
+    call->function[k_mock_rspi_func_name_max - 1] = '\0';
+    call->channel                                  = channel;
+    call->arg1                                     = arg1;
+    call->arg2                                     = arg2;
+    call->return_value                             = ret;
+
+    m->call_write_index = (m->call_write_index + 1) % k_mock_rspi_call_history_max;
+    m->call_count++;
+}
+
+/* =============================================================================
+ * Mock HAL Function Implementations
+ * =============================================================================
+ */
+
+rx_err_t rspi_init_peripheral(uint8_t channel, uint8_t mode, bool use_16bit)
+{
+    mock_rspi_t* m = &g_mock_rspi;
+
+    m->init_calls++;
+
+    if (channel >= k_mock_rspi_max_channels) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_init_peripheral", channel, mode, use_16bit, ret);
+        return ret;
+    }
+
+    rx_err_t ret = m->next_init_return;
+
+    if (ret == k_rx_ok) {
+        m->channels[channel].initialized  = true;
+        m->channels[channel].spi_mode     = mode;
+        m->channels[channel].use_16bit    = use_16bit;
+        m->channels[channel].write_ready  = true;
+    }
+
+    mock_rspi_record_call(m, "rspi_init_peripheral", channel, mode, use_16bit, ret);
+
+    /* Reset to default for next call */
+    m->next_init_return = k_rx_ok;
+
+    return ret;
+}
+
+rx_err_t rspi_peripheral_transfer(uint8_t        channel,
+                                  const uint8_t* tx_data,
+                                  uint8_t*       rx_data,
+                                  uint16_t       length)
+{
+    mock_rspi_t* m = &g_mock_rspi;
+
+    m->transfer_calls++;
+
+    if (channel >= k_mock_rspi_max_channels) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_peripheral_transfer", channel, length, 0, ret);
+        return ret;
+    }
+
+    mock_rspi_channel_t* ch = &m->channels[channel];
+
+    if (!ch->initialized) {
+        rx_err_t ret = k_rx_err_invalid_state;
+        mock_rspi_record_call(m, "rspi_peripheral_transfer", channel, length, 0, ret);
+        return ret;
+    }
+
+    rx_err_t ret = m->next_transfer_return;
+
+    if (ret == k_rx_ok) {
+        /* Capture TX data */
+        if (tx_data != NULL && length > 0) {
+            uint32_t copy_len = (length < k_mock_rspi_buffer_size) ? length : k_mock_rspi_buffer_size;
+            memcpy(ch->tx_data, tx_data, copy_len);
+            ch->tx_len = copy_len;
+        }
+
+        /* Provide RX data from injected buffer */
+        if (rx_data != NULL && length > 0) {
+            uint32_t avail     = (ch->rx_len > ch->rx_pos) ? (ch->rx_len - ch->rx_pos) : 0;
+            uint32_t copy_len  = (length < avail) ? length : avail;
+
+            if (copy_len > 0) {
+                memcpy(rx_data, &ch->rx_data[ch->rx_pos], copy_len);
+                ch->rx_pos += copy_len;
+            }
+
+            /* Zero-fill any remaining bytes if not enough RX data */
+            if (copy_len < length) {
+                memset(rx_data + copy_len, 0, length - copy_len);
+            }
+
+            /* Update data available flag */
+            if (ch->rx_pos >= ch->rx_len) {
+                ch->data_available = false;
+            }
+        }
+    }
+
+    mock_rspi_record_call(m, "rspi_peripheral_transfer", channel, length, 0, ret);
+
+    /* Reset to default for next call */
+    m->next_transfer_return = k_rx_ok;
+
+    return ret;
+}
+
+rx_err_t rspi_peripheral_read_available(uint8_t channel, bool* available)
+{
+    mock_rspi_t* m = &g_mock_rspi;
+
+    m->available_calls++;
+
+    if (available == NULL) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_peripheral_read_available", channel, 0, 0, ret);
+        return ret;
+    }
+
+    if (channel >= k_mock_rspi_max_channels) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_peripheral_read_available", channel, 0, 0, ret);
+        return ret;
+    }
+
+    mock_rspi_channel_t* ch = &m->channels[channel];
+
+    if (!ch->initialized) {
+        rx_err_t ret = k_rx_err_invalid_state;
+        mock_rspi_record_call(m, "rspi_peripheral_read_available", channel, 0, 0, ret);
+        return ret;
+    }
+
+    rx_err_t ret = m->next_available_return;
+
+    if (ret == k_rx_ok) {
+        *available = ch->data_available;
+    }
+
+    mock_rspi_record_call(m, "rspi_peripheral_read_available", channel, 0, 0, ret);
+
+    /* Reset to default for next call */
+    m->next_available_return = k_rx_ok;
+
+    return ret;
+}
+
+rx_err_t rspi_peripheral_write_ready(uint8_t channel, bool* ready)
+{
+    mock_rspi_t* m = &g_mock_rspi;
+
+    m->ready_calls++;
+
+    if (ready == NULL) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_peripheral_write_ready", channel, 0, 0, ret);
+        return ret;
+    }
+
+    if (channel >= k_mock_rspi_max_channels) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_peripheral_write_ready", channel, 0, 0, ret);
+        return ret;
+    }
+
+    mock_rspi_channel_t* ch = &m->channels[channel];
+
+    if (!ch->initialized) {
+        rx_err_t ret = k_rx_err_invalid_state;
+        mock_rspi_record_call(m, "rspi_peripheral_write_ready", channel, 0, 0, ret);
+        return ret;
+    }
+
+    rx_err_t ret = m->next_ready_return;
+
+    if (ret == k_rx_ok) {
+        *ready = ch->write_ready;
+    }
+
+    mock_rspi_record_call(m, "rspi_peripheral_write_ready", channel, 0, 0, ret);
+
+    /* Reset to default for next call */
+    m->next_ready_return = k_rx_ok;
+
+    return ret;
+}
+
+rx_err_t rspi_deinit(uint8_t channel)
+{
+    mock_rspi_t* m = &g_mock_rspi;
+
+    m->deinit_calls++;
+
+    if (channel >= k_mock_rspi_max_channels) {
+        rx_err_t ret = k_rx_err_invalid_arg;
+        mock_rspi_record_call(m, "rspi_deinit", channel, 0, 0, ret);
+        return ret;
+    }
+
+    rx_err_t ret = m->next_deinit_return;
+
+    if (ret == k_rx_ok) {
+        mock_rspi_channel_t* ch = &m->channels[channel];
+
+        ch->initialized    = false;
+        ch->data_available = false;
+        ch->write_ready    = false;
+    }
+
+    mock_rspi_record_call(m, "rspi_deinit", channel, 0, 0, ret);
+
+    /* Reset to default for next call */
+    m->next_deinit_return = k_rx_ok;
+
+    return ret;
+}

--- a/star-rx72n-firmware/tests/mocks/mock_rspi.h
+++ b/star-rx72n-firmware/tests/mocks/mock_rspi.h
@@ -1,0 +1,315 @@
+/* tests/mocks/mock_rspi.h */
+
+/**
+ * @file mock_rspi.h
+ * @brief Mock RSPI Hardware Layer for Host-Side Testing
+ *
+ * Mock implementation of the RSPI (SPI) hardware layer for testing.
+ * Provides call tracking, error injection, and data injection capabilities.
+ *
+ * @date 2026-01-05
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef MOCK_RSPI_H
+#define MOCK_RSPI_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "rx_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Configuration Constants
+ * =============================================================================
+ */
+
+/** @brief Mock RSPI buffer and tracking constants */
+typedef enum {
+  k_mock_rspi_max_channels     = 3,    /**< RSPI0, RSPI1, RSPI2 */
+  k_mock_rspi_buffer_size      = 2048, /**< Max transfer buffer size */
+  k_mock_rspi_call_history_max = 64,   /**< Max recorded calls */
+  k_mock_rspi_func_name_max    = 48,   /**< Max function name length */
+} mock_rspi_constants_t;
+
+/* =============================================================================
+ * Call Record Structure
+ * =============================================================================
+ */
+
+/**
+ * @brief Record of a single function call
+ */
+typedef struct {
+  char     function[k_mock_rspi_func_name_max]; /**< Function name */
+  uint8_t  channel;                             /**< RSPI channel */
+  uint32_t arg1;                                /**< First argument */
+  uint32_t arg2;                                /**< Second argument */
+  rx_err_t return_value;                        /**< Return value */
+} mock_rspi_call_t;
+
+/* =============================================================================
+ * Channel State Structure
+ * =============================================================================
+ */
+
+/**
+ * @brief State of a single RSPI channel
+ */
+typedef struct {
+  bool     initialized;                              /**< Channel initialized */
+  uint8_t  spi_mode;                                 /**< Configured SPI mode */
+  bool     use_16bit;                                /**< 16-bit frame mode */
+  bool     data_available;                           /**< RX data available */
+  bool     write_ready;                              /**< TX ready */
+  uint8_t  rx_data[k_mock_rspi_buffer_size];         /**< RX buffer for injection */
+  uint32_t rx_len;                                   /**< RX data length */
+  uint32_t rx_pos;                                   /**< RX read position */
+  uint8_t  tx_data[k_mock_rspi_buffer_size];         /**< TX buffer for capture */
+  uint32_t tx_len;                                   /**< TX data length */
+} mock_rspi_channel_t;
+
+/* =============================================================================
+ * Mock RSPI State Structure
+ * =============================================================================
+ */
+
+/**
+ * @brief Mock RSPI state structure
+ */
+typedef struct {
+  /* Channel states */
+  mock_rspi_channel_t channels[k_mock_rspi_max_channels]; /**< Channel states */
+
+  /* Call tracking */
+  mock_rspi_call_t call_history[k_mock_rspi_call_history_max]; /**< Call history */
+  uint32_t         call_count;                                 /**< Total calls */
+  uint32_t         call_write_index;                           /**< Next index */
+
+  /* Configurable return values for error injection */
+  rx_err_t next_init_return;       /**< Return for next init call */
+  rx_err_t next_transfer_return;   /**< Return for next transfer call */
+  rx_err_t next_available_return;  /**< Return for next available call */
+  rx_err_t next_ready_return;      /**< Return for next ready call */
+  rx_err_t next_deinit_return;     /**< Return for next deinit call */
+
+  /* Statistics */
+  uint32_t init_calls;      /**< Number of init calls */
+  uint32_t deinit_calls;    /**< Number of deinit calls */
+  uint32_t transfer_calls;  /**< Number of transfer calls */
+  uint32_t available_calls; /**< Number of available check calls */
+  uint32_t ready_calls;     /**< Number of ready check calls */
+} mock_rspi_t;
+
+/* =============================================================================
+ * Global Mock Instance
+ * =============================================================================
+ */
+
+extern mock_rspi_t g_mock_rspi;
+
+/* =============================================================================
+ * Initialization Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Initialize the mock RSPI
+ *
+ * Clears all state and sets default return values.
+ *
+ * @param mock Mock instance (use NULL for global g_mock_rspi)
+ * @return k_rx_ok on success
+ */
+rx_err_t mock_rspi_init(mock_rspi_t* mock);
+
+/**
+ * @brief Deinitialize the mock RSPI
+ *
+ * @param mock Mock instance (use NULL for global g_mock_rspi)
+ * @return k_rx_ok on success
+ */
+rx_err_t mock_rspi_deinit(mock_rspi_t* mock);
+
+/**
+ * @brief Clear all mock state without full reinitialization
+ *
+ * @param mock Mock instance (use NULL for global g_mock_rspi)
+ * @return k_rx_ok on success
+ */
+rx_err_t mock_rspi_clear(mock_rspi_t* mock);
+
+/* =============================================================================
+ * Error Injection Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Set return value for next rspi_init_peripheral call
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param ret Return value to use
+ */
+void mock_rspi_set_init_return(mock_rspi_t* mock, rx_err_t ret);
+
+/**
+ * @brief Set return value for next rspi_peripheral_transfer call
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param ret Return value to use
+ */
+void mock_rspi_set_transfer_return(mock_rspi_t* mock, rx_err_t ret);
+
+/**
+ * @brief Set return value for next rspi_peripheral_read_available call
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param ret Return value to use
+ */
+void mock_rspi_set_available_return(mock_rspi_t* mock, rx_err_t ret);
+
+/**
+ * @brief Set return value for next rspi_peripheral_write_ready call
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param ret Return value to use
+ */
+void mock_rspi_set_ready_return(mock_rspi_t* mock, rx_err_t ret);
+
+/**
+ * @brief Set return value for next rspi_deinit call
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param ret Return value to use
+ */
+void mock_rspi_set_deinit_return(mock_rspi_t* mock, rx_err_t ret);
+
+/* =============================================================================
+ * Data Injection/Extraction Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Inject data for the next SPI receive
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param channel RSPI channel (0-2)
+ * @param data Data to inject
+ * @param len Data length
+ * @return k_rx_ok on success
+ */
+rx_err_t mock_rspi_inject_rx_data(mock_rspi_t*   mock,
+                                  uint8_t        channel,
+                                  const uint8_t* data,
+                                  uint32_t       len);
+
+/**
+ * @brief Get data that was transmitted via SPI
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param channel RSPI channel (0-2)
+ * @param data Output buffer
+ * @param max_len Maximum bytes to read
+ * @param actual_len Actual bytes read
+ * @return k_rx_ok on success
+ */
+rx_err_t mock_rspi_get_tx_data(mock_rspi_t* mock,
+                               uint8_t      channel,
+                               uint8_t*     data,
+                               uint32_t     max_len,
+                               uint32_t*    actual_len);
+
+/**
+ * @brief Set data availability for a channel
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param channel RSPI channel (0-2)
+ * @param available True if data is available
+ */
+void mock_rspi_set_data_available(mock_rspi_t* mock, uint8_t channel, bool available);
+
+/**
+ * @brief Set write ready status for a channel
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param channel RSPI channel (0-2)
+ * @param ready True if write ready
+ */
+void mock_rspi_set_write_ready(mock_rspi_t* mock, uint8_t channel, bool ready);
+
+/**
+ * @brief Clear a channel's buffers
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param channel RSPI channel (0-2)
+ */
+void mock_rspi_clear_channel(mock_rspi_t* mock, uint8_t channel);
+
+/* =============================================================================
+ * Call Tracking Functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Check if a function was called
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param func Function name to check
+ * @return true if function was called at least once
+ */
+bool mock_rspi_was_called(mock_rspi_t* mock, const char* func);
+
+/**
+ * @brief Get number of times a function was called
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param func Function name to check
+ * @return Number of calls
+ */
+uint32_t mock_rspi_get_call_count(mock_rspi_t* mock, const char* func);
+
+/**
+ * @brief Get the last call record for a function
+ *
+ * @param mock Mock instance (use NULL for global)
+ * @param func Function name
+ * @param out_call Output call record
+ * @return k_rx_ok on success, k_rx_err_not_found if never called
+ */
+rx_err_t mock_rspi_get_last_call(mock_rspi_t*     mock,
+                                 const char*      func,
+                                 mock_rspi_call_t* out_call);
+
+/**
+ * @brief Clear call history
+ *
+ * @param mock Mock instance (use NULL for global)
+ */
+void mock_rspi_clear_calls(mock_rspi_t* mock);
+
+/**
+ * @brief Record a function call (internal use)
+ *
+ * @param mock Mock instance
+ * @param func Function name
+ * @param channel RSPI channel
+ * @param arg1 First argument
+ * @param arg2 Second argument
+ * @param ret Return value
+ */
+void mock_rspi_record_call(mock_rspi_t* mock,
+                           const char*  func,
+                           uint8_t      channel,
+                           uint32_t     arg1,
+                           uint32_t     arg2,
+                           rx_err_t     ret);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOCK_RSPI_H */

--- a/star-rx72n-firmware/tests/test_rx_spi_comm.c
+++ b/star-rx72n-firmware/tests/test_rx_spi_comm.c
@@ -1,0 +1,908 @@
+/* tests/test_rx_spi_comm.c */
+
+/**
+ * @file test_rx_spi_comm.c
+ * @brief Unit Tests for SPI Communication Layer
+ *
+ * Tests the high-level SPI communication layer that integrates
+ * frame encoding/decoding with the SPI HAL for RPi5 to RX72N communication.
+ *
+ * @date 2026-01-05
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "unity.h"
+
+#include <string.h>
+
+#include "hardware.h"
+#include "mock_rspi.h"
+#include "rx_frame.h"
+#include "rx_spi_comm.h"
+
+/* =============================================================================
+ * Test Constants
+ * =============================================================================
+ */
+
+/** @brief Test constant values */
+typedef enum {
+    k_test_channel_default = 0,
+    k_test_channel_alt     = 1,
+    k_test_channel_invalid = 5,
+    k_test_sequence_a      = 42,
+    k_test_sequence_b      = 123,
+    k_test_sequence_max    = 0xFFFF,
+    k_test_timeout_zero    = 0,
+    k_test_timeout_short   = 100,
+    k_test_payload_small   = 4,
+    k_test_payload_medium  = 64,
+    k_test_payload_large   = 256,
+} test_constants_t;
+
+/* =============================================================================
+ * Test Fixtures
+ * =============================================================================
+ */
+
+static rx_spi_comm_handle_t s_handle;
+
+/**
+ * @brief Initialize RSPI channel via mock so channel is ready
+ */
+static void helper_init_rspi_channel(uint8_t channel)
+{
+    rspi_init_peripheral(channel, k_spi_comm_default_mode, false);
+}
+
+/**
+ * @brief Create and encode a valid frame for injection
+ *
+ * @param type Frame type
+ * @param sequence Sequence number
+ * @param payload Payload data (can be NULL)
+ * @param payload_len Payload length
+ * @param out_buffer Output buffer
+ * @param out_len Output length
+ */
+static void helper_create_encoded_frame(rx_frame_type_t type,
+                                         uint16_t        sequence,
+                                         const uint8_t*  payload,
+                                         uint32_t        payload_len,
+                                         uint8_t*        out_buffer,
+                                         uint32_t*       out_len)
+{
+    rx_frame_encoder_t encoder;
+    rx_frame_encoder_init(&encoder);
+
+    rx_frame_t frame;
+    memset(&frame, 0, sizeof(frame));
+    frame.header.sequence = sequence;
+    frame.header.length   = (uint16_t)payload_len;
+    frame.header.type     = (uint8_t)type;
+    frame.header.flags    = k_frame_flag_none;
+
+    if (payload != NULL && payload_len > 0) {
+        memcpy(frame.payload, payload, payload_len);
+    }
+
+    rx_frame_encode(&encoder, &frame, out_buffer, out_len);
+    rx_frame_encoder_deinit(&encoder);
+}
+
+void setUp(void)
+{
+    /* Initialize mock hardware */
+    mock_rspi_init(NULL);
+
+    /* Clear handle */
+    memset(&s_handle, 0, sizeof(s_handle));
+}
+
+void tearDown(void)
+{
+    /* Deinitialize comm layer if initialized */
+    rx_spi_comm_deinit(&s_handle);
+
+    /* Clear mock state */
+    mock_rspi_deinit(NULL);
+}
+
+/* =============================================================================
+ * Initialization Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_init_null_handle_fails(void)
+{
+    rx_err_t err = rx_spi_comm_init(NULL, NULL);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_init_success_default_config(void)
+{
+    rx_err_t err = rx_spi_comm_init(&s_handle, NULL);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_TRUE(s_handle.initialized);
+    TEST_ASSERT_EQUAL_UINT8(k_spi_comm_default_channel, s_handle.channel);
+    TEST_ASSERT_EQUAL_UINT8(0, s_handle.fec_enabled);
+    TEST_ASSERT_EQUAL_UINT16(0, s_handle.tx_sequence);
+    TEST_ASSERT_EQUAL_UINT16(0, s_handle.rx_sequence);
+}
+
+void test_spi_comm_init_with_custom_channel(void)
+{
+    rx_spi_comm_config_t config = {
+        .channel     = k_test_channel_alt,
+        .spi_mode    = 0,
+        .fec_enabled = 0,
+    };
+
+    rx_err_t err = rx_spi_comm_init(&s_handle, &config);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL_UINT8(k_test_channel_alt, s_handle.channel);
+}
+
+void test_spi_comm_init_with_fec_enabled(void)
+{
+    rx_spi_comm_config_t config = {
+        .channel     = 0,
+        .spi_mode    = 0,
+        .fec_enabled = 1,
+    };
+
+    rx_err_t err = rx_spi_comm_init(&s_handle, &config);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_TRUE(s_handle.fec_enabled);
+}
+
+void test_spi_comm_deinit_null_handle_fails(void)
+{
+    rx_err_t err = rx_spi_comm_deinit(NULL);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_deinit_success(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+
+    rx_err_t err = rx_spi_comm_deinit(&s_handle);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_FALSE(s_handle.initialized);
+}
+
+void test_spi_comm_deinit_not_initialized_succeeds(void)
+{
+    /* Deinit on uninitialized handle should succeed gracefully */
+    rx_err_t err = rx_spi_comm_deinit(&s_handle);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+}
+
+/* =============================================================================
+ * Send Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_send_null_handle_fails(void)
+{
+    uint8_t data[] = "test";
+
+    rx_err_t err = rx_spi_comm_send(NULL, k_frame_type_response, 0, data, 4);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_send_not_initialized_fails(void)
+{
+    uint8_t data[] = "test";
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+void test_spi_comm_send_null_payload_with_len_fails(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, NULL, 10);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_send_payload_too_large_fails(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    uint8_t data[k_frame_max_payload + 1];
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, sizeof(data));
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_size, err);
+}
+
+void test_spi_comm_send_empty_payload_succeeds(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, NULL, 0);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL_UINT16(1, s_handle.tx_sequence);
+}
+
+void test_spi_comm_send_with_payload_succeeds(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    uint8_t data[] = "Hello SPI!";
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 10);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL_UINT16(1, s_handle.tx_sequence);
+}
+
+void test_spi_comm_send_increments_sequence(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    uint8_t data[] = "test";
+
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    TEST_ASSERT_EQUAL_UINT16(3, s_handle.tx_sequence);
+}
+
+void test_spi_comm_send_sequence_wraps(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    s_handle.tx_sequence = k_test_sequence_max;
+    uint8_t data[]       = "test";
+
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    /* 0xFFFF + 1 wraps to 0x0000 */
+    TEST_ASSERT_EQUAL_UINT16(0, s_handle.tx_sequence);
+}
+
+void test_spi_comm_send_with_fec_flag(void)
+{
+    rx_spi_comm_config_t config = {.channel = 0, .spi_mode = 0, .fec_enabled = 1};
+    rx_spi_comm_init(&s_handle, &config);
+    helper_init_rspi_channel(k_test_channel_default);
+    uint8_t data[] = "test";
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+
+    /* Verify FEC flag is set in the transmitted frame */
+    uint8_t  tx_data[64];
+    uint32_t tx_len = 0;
+    mock_rspi_get_tx_data(NULL, k_test_channel_default, tx_data, sizeof(tx_data), &tx_len);
+
+    /* Frame: [SYNC(2)][SEQ(2)][LEN(2)][TYPE(1)][FLAGS(1)]... */
+    /* Flags are at offset 7 (0-based) */
+    TEST_ASSERT_GREATER_THAN(8, tx_len);
+    TEST_ASSERT_EQUAL_HEX8(k_frame_flag_fec_enabled, tx_data[7] & k_frame_flag_fec_enabled);
+}
+
+void test_spi_comm_send_transfer_error_propagates(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_set_transfer_return(NULL, k_rx_err_timeout);
+    uint8_t data[] = "test";
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
+}
+
+void test_spi_comm_send_large_payload(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    uint8_t data[k_test_payload_large];
+    for (uint32_t i = 0; i < k_test_payload_large; i++) {
+        data[i] = (uint8_t)(i & 0xFF);
+    }
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, k_test_payload_large);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+}
+
+/* =============================================================================
+ * Send ACK/NACK Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_send_ack_null_handle_fails(void)
+{
+    rx_err_t err = rx_spi_comm_send_ack(NULL, k_test_sequence_a);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_send_ack_not_initialized_fails(void)
+{
+    rx_err_t err = rx_spi_comm_send_ack(&s_handle, k_test_sequence_a);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+void test_spi_comm_send_ack_success(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    rx_err_t err = rx_spi_comm_send_ack(&s_handle, k_test_sequence_a);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+
+    /* Verify ACK frame was transmitted */
+    uint8_t  tx_data[32];
+    uint32_t tx_len = 0;
+    mock_rspi_get_tx_data(NULL, k_test_channel_default, tx_data, sizeof(tx_data), &tx_len);
+
+    TEST_ASSERT_EQUAL(k_frame_min_size, tx_len);
+    TEST_ASSERT_EQUAL_HEX8(k_frame_type_ack, tx_data[6]);
+}
+
+void test_spi_comm_send_ack_transfer_error_propagates(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_set_transfer_return(NULL, k_rx_err_timeout);
+
+    rx_err_t err = rx_spi_comm_send_ack(&s_handle, k_test_sequence_a);
+
+    TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
+}
+
+void test_spi_comm_send_nack_null_handle_fails(void)
+{
+    rx_err_t err = rx_spi_comm_send_nack(NULL, k_test_sequence_a, 0);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_send_nack_not_initialized_fails(void)
+{
+    rx_err_t err = rx_spi_comm_send_nack(&s_handle, k_test_sequence_a, 0);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+void test_spi_comm_send_nack_success(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    rx_err_t err = rx_spi_comm_send_nack(&s_handle, k_test_sequence_b, k_frame_flag_soft_nack);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+
+    /* Verify NACK frame was transmitted */
+    uint8_t  tx_data[32];
+    uint32_t tx_len = 0;
+    mock_rspi_get_tx_data(NULL, k_test_channel_default, tx_data, sizeof(tx_data), &tx_len);
+
+    TEST_ASSERT_EQUAL(k_frame_min_size, tx_len);
+    TEST_ASSERT_EQUAL_HEX8(k_frame_type_nack, tx_data[6]);
+    TEST_ASSERT_EQUAL_HEX8(k_frame_flag_soft_nack, tx_data[7] & k_frame_flag_soft_nack);
+}
+
+void test_spi_comm_send_nack_transfer_error_propagates(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_set_transfer_return(NULL, k_rx_err_timeout);
+
+    rx_err_t err = rx_spi_comm_send_nack(&s_handle, k_test_sequence_a, 0);
+
+    TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
+}
+
+/* =============================================================================
+ * Receive Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_receive_null_handle_fails(void)
+{
+    rx_frame_t frame;
+
+    rx_err_t err = rx_spi_comm_receive(NULL, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_receive_null_frame_fails(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+
+    rx_err_t err = rx_spi_comm_receive(&s_handle, NULL, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_receive_not_initialized_fails(void)
+{
+    rx_frame_t frame;
+
+    rx_err_t err = rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+void test_spi_comm_receive_no_data_timeout(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    rx_frame_t frame;
+
+    /* No data injected, should timeout immediately */
+    rx_err_t err = rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
+}
+
+void test_spi_comm_receive_available_check_error_propagates(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_set_available_return(NULL, k_rx_err_spi_error);
+    rx_frame_t frame;
+
+    rx_err_t err = rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_spi_error, err);
+}
+
+void test_spi_comm_receive_valid_frame_success(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    /* Create and inject a valid frame */
+    uint8_t  payload[]          = "TEST";
+    uint8_t  encoded_frame[64];
+    uint32_t encoded_len        = 0;
+    helper_create_encoded_frame(k_frame_type_command, k_test_sequence_a, payload, 4, encoded_frame, &encoded_len);
+
+    mock_rspi_inject_rx_data(NULL, k_test_channel_default, encoded_frame, encoded_len);
+
+    rx_frame_t frame;
+    rx_err_t   err = rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL_UINT16(k_test_sequence_a, frame.header.sequence);
+    TEST_ASSERT_EQUAL_UINT8(k_frame_type_command, frame.header.type);
+    TEST_ASSERT_EQUAL_UINT16(4, frame.header.length);
+    TEST_ASSERT_EQUAL_MEMORY(payload, frame.payload, 4);
+}
+
+void test_spi_comm_receive_updates_rx_sequence(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    uint8_t  encoded_frame[64];
+    uint32_t encoded_len = 0;
+    helper_create_encoded_frame(k_frame_type_command, 100, NULL, 0, encoded_frame, &encoded_len);
+
+    mock_rspi_inject_rx_data(NULL, k_test_channel_default, encoded_frame, encoded_len);
+
+    rx_frame_t frame;
+    rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    /* RX sequence should be updated to received sequence + 1 */
+    TEST_ASSERT_EQUAL_UINT16(101, s_handle.rx_sequence);
+}
+
+void test_spi_comm_receive_invalid_sync_word(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    /* Create a frame with invalid sync word */
+    uint8_t bad_frame[k_frame_min_size] = {
+        0x00, 0x00, /* Invalid SYNC */
+        0x00, 0x01, /* SEQ = 1 */
+        0x00, 0x00, /* LEN = 0 */
+        0x01,       /* TYPE = command */
+        0x00,       /* FLAGS = none */
+        0x00, 0x00, 0x00, 0x00, /* CRC (invalid) */
+    };
+
+    mock_rspi_inject_rx_data(NULL, k_test_channel_default, bad_frame, sizeof(bad_frame));
+
+    rx_frame_t frame;
+    rx_err_t   err = rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_protocol_error, err);
+}
+
+void test_spi_comm_receive_transfer_error_propagates(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    /* Inject valid frame to pass availability check */
+    uint8_t  encoded_frame[64];
+    uint32_t encoded_len = 0;
+    helper_create_encoded_frame(k_frame_type_command, 0, NULL, 0, encoded_frame, &encoded_len);
+    mock_rspi_inject_rx_data(NULL, k_test_channel_default, encoded_frame, encoded_len);
+
+    /* But make transfer fail */
+    mock_rspi_set_transfer_return(NULL, k_rx_err_spi_error);
+
+    rx_frame_t frame;
+    rx_err_t   err = rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_EQUAL(k_rx_err_spi_error, err);
+}
+
+/* =============================================================================
+ * Data Available Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_data_available_null_handle_fails(void)
+{
+    bool available;
+
+    rx_err_t err = rx_spi_comm_data_available(NULL, &available);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_data_available_null_available_fails(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+
+    rx_err_t err = rx_spi_comm_data_available(&s_handle, NULL);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_arg, err);
+}
+
+void test_spi_comm_data_available_not_initialized_fails(void)
+{
+    bool available;
+
+    rx_err_t err = rx_spi_comm_data_available(&s_handle, &available);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+void test_spi_comm_data_available_empty(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    bool available = true;
+
+    rx_err_t err = rx_spi_comm_data_available(&s_handle, &available);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_FALSE(available);
+}
+
+void test_spi_comm_data_available_with_data(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_set_data_available(NULL, k_test_channel_default, true);
+    bool available = false;
+
+    rx_err_t err = rx_spi_comm_data_available(&s_handle, &available);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_TRUE(available);
+}
+
+void test_spi_comm_data_available_hal_error_propagates(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_set_available_return(NULL, k_rx_err_spi_error);
+    bool available;
+
+    rx_err_t err = rx_spi_comm_data_available(&s_handle, &available);
+
+    TEST_ASSERT_EQUAL(k_rx_err_spi_error, err);
+}
+
+/* =============================================================================
+ * Utility Function Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_reset_sequence(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    s_handle.tx_sequence = 100;
+    s_handle.rx_sequence = 200;
+
+    rx_spi_comm_reset_sequence(&s_handle);
+
+    TEST_ASSERT_EQUAL_UINT16(0, s_handle.tx_sequence);
+    TEST_ASSERT_EQUAL_UINT16(0, s_handle.rx_sequence);
+}
+
+void test_spi_comm_reset_sequence_null_handle(void)
+{
+    /* Should not crash on NULL */
+    rx_spi_comm_reset_sequence(NULL);
+}
+
+void test_spi_comm_get_tx_sequence(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    s_handle.tx_sequence = 0xBEEF;
+
+    uint16_t seq = rx_spi_comm_get_tx_sequence(&s_handle);
+
+    TEST_ASSERT_EQUAL_UINT16(0xBEEF, seq);
+}
+
+void test_spi_comm_get_tx_sequence_null_handle(void)
+{
+    uint16_t seq = rx_spi_comm_get_tx_sequence(NULL);
+
+    TEST_ASSERT_EQUAL_UINT16(0, seq);
+}
+
+void test_spi_comm_get_rx_sequence(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    s_handle.rx_sequence = 0xCAFE;
+
+    uint16_t seq = rx_spi_comm_get_rx_sequence(&s_handle);
+
+    TEST_ASSERT_EQUAL_UINT16(0xCAFE, seq);
+}
+
+void test_spi_comm_get_rx_sequence_null_handle(void)
+{
+    uint16_t seq = rx_spi_comm_get_rx_sequence(NULL);
+
+    TEST_ASSERT_EQUAL_UINT16(0, seq);
+}
+
+/* =============================================================================
+ * Sequence Number Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_sequence_starts_at_zero(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+
+    TEST_ASSERT_EQUAL_UINT16(0, rx_spi_comm_get_tx_sequence(&s_handle));
+    TEST_ASSERT_EQUAL_UINT16(0, rx_spi_comm_get_rx_sequence(&s_handle));
+}
+
+void test_spi_comm_sequence_max_value(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    s_handle.tx_sequence = k_test_sequence_max;
+    s_handle.rx_sequence = k_test_sequence_max;
+
+    TEST_ASSERT_EQUAL_UINT16(k_test_sequence_max, rx_spi_comm_get_tx_sequence(&s_handle));
+    TEST_ASSERT_EQUAL_UINT16(k_test_sequence_max, rx_spi_comm_get_rx_sequence(&s_handle));
+}
+
+void test_spi_comm_rx_sequence_wraparound(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    /* Receive a frame with sequence 0xFFFF */
+    uint8_t  encoded_frame[64];
+    uint32_t encoded_len = 0;
+    helper_create_encoded_frame(k_frame_type_command, k_test_sequence_max, NULL, 0, encoded_frame, &encoded_len);
+    mock_rspi_inject_rx_data(NULL, k_test_channel_default, encoded_frame, encoded_len);
+
+    rx_frame_t frame;
+    rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    /* RX sequence should wrap to 0 (0xFFFF + 1 = 0x0000) */
+    TEST_ASSERT_EQUAL_UINT16(0, s_handle.rx_sequence);
+}
+
+/* =============================================================================
+ * Channel Configuration Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_uses_configured_channel(void)
+{
+    rx_spi_comm_config_t config = {.channel = k_test_channel_alt, .spi_mode = 0, .fec_enabled = 0};
+    rx_spi_comm_init(&s_handle, &config);
+    helper_init_rspi_channel(k_test_channel_alt);
+    uint8_t data[] = "test";
+
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    /* Verify transfer was called on channel 1 */
+    mock_rspi_call_t call;
+    rx_err_t         err = mock_rspi_get_last_call(NULL, "rspi_peripheral_transfer", &call);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL_UINT8(k_test_channel_alt, call.channel);
+}
+
+/* =============================================================================
+ * Buffer Size Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_buffer_size_constants(void)
+{
+    /* Verify buffer size constants are reasonable */
+    TEST_ASSERT_EQUAL(2048, k_spi_comm_rx_buffer_size);
+    TEST_ASSERT_EQUAL(2048, k_spi_comm_tx_buffer_size);
+    TEST_ASSERT_GREATER_OR_EQUAL(k_frame_max_size, k_spi_comm_tx_buffer_size);
+}
+
+void test_spi_comm_max_payload_fits_in_buffer(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+
+    /* Create maximum size payload */
+    uint8_t data[k_frame_max_payload];
+    memset(data, 0xAA, k_frame_max_payload);
+
+    rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, k_frame_max_payload);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+}
+
+/* =============================================================================
+ * Mock Verification Tests
+ * =============================================================================
+ */
+
+void test_spi_comm_transfer_is_called_on_send(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_clear_calls(NULL);
+    uint8_t data[] = "test";
+
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    TEST_ASSERT_TRUE(mock_rspi_was_called(NULL, "rspi_peripheral_transfer"));
+}
+
+void test_spi_comm_available_is_called_on_receive(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    mock_rspi_clear_calls(NULL);
+    rx_frame_t frame;
+
+    rx_spi_comm_receive(&s_handle, &frame, k_test_timeout_zero);
+
+    TEST_ASSERT_TRUE(mock_rspi_was_called(NULL, "rspi_peripheral_read_available"));
+}
+
+void test_spi_comm_transfer_count(void)
+{
+    rx_spi_comm_init(&s_handle, NULL);
+    helper_init_rspi_channel(k_test_channel_default);
+    uint8_t data[] = "test";
+
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+    rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+    /* Each send calls transfer once */
+    uint32_t count = mock_rspi_get_call_count(NULL, "rspi_peripheral_transfer");
+    TEST_ASSERT_EQUAL_UINT32(3, count);
+}
+
+/* =============================================================================
+ * Main
+ * =============================================================================
+ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    /* Initialization tests */
+    RUN_TEST(test_spi_comm_init_null_handle_fails);
+    RUN_TEST(test_spi_comm_init_success_default_config);
+    RUN_TEST(test_spi_comm_init_with_custom_channel);
+    RUN_TEST(test_spi_comm_init_with_fec_enabled);
+    RUN_TEST(test_spi_comm_deinit_null_handle_fails);
+    RUN_TEST(test_spi_comm_deinit_success);
+    RUN_TEST(test_spi_comm_deinit_not_initialized_succeeds);
+
+    /* Send tests */
+    RUN_TEST(test_spi_comm_send_null_handle_fails);
+    RUN_TEST(test_spi_comm_send_not_initialized_fails);
+    RUN_TEST(test_spi_comm_send_null_payload_with_len_fails);
+    RUN_TEST(test_spi_comm_send_payload_too_large_fails);
+    RUN_TEST(test_spi_comm_send_empty_payload_succeeds);
+    RUN_TEST(test_spi_comm_send_with_payload_succeeds);
+    RUN_TEST(test_spi_comm_send_increments_sequence);
+    RUN_TEST(test_spi_comm_send_sequence_wraps);
+    RUN_TEST(test_spi_comm_send_with_fec_flag);
+    RUN_TEST(test_spi_comm_send_transfer_error_propagates);
+    RUN_TEST(test_spi_comm_send_large_payload);
+
+    /* Send ACK/NACK tests */
+    RUN_TEST(test_spi_comm_send_ack_null_handle_fails);
+    RUN_TEST(test_spi_comm_send_ack_not_initialized_fails);
+    RUN_TEST(test_spi_comm_send_ack_success);
+    RUN_TEST(test_spi_comm_send_ack_transfer_error_propagates);
+    RUN_TEST(test_spi_comm_send_nack_null_handle_fails);
+    RUN_TEST(test_spi_comm_send_nack_not_initialized_fails);
+    RUN_TEST(test_spi_comm_send_nack_success);
+    RUN_TEST(test_spi_comm_send_nack_transfer_error_propagates);
+
+    /* Receive tests */
+    RUN_TEST(test_spi_comm_receive_null_handle_fails);
+    RUN_TEST(test_spi_comm_receive_null_frame_fails);
+    RUN_TEST(test_spi_comm_receive_not_initialized_fails);
+    RUN_TEST(test_spi_comm_receive_no_data_timeout);
+    RUN_TEST(test_spi_comm_receive_available_check_error_propagates);
+    RUN_TEST(test_spi_comm_receive_valid_frame_success);
+    RUN_TEST(test_spi_comm_receive_updates_rx_sequence);
+    RUN_TEST(test_spi_comm_receive_invalid_sync_word);
+    RUN_TEST(test_spi_comm_receive_transfer_error_propagates);
+
+    /* Data available tests */
+    RUN_TEST(test_spi_comm_data_available_null_handle_fails);
+    RUN_TEST(test_spi_comm_data_available_null_available_fails);
+    RUN_TEST(test_spi_comm_data_available_not_initialized_fails);
+    RUN_TEST(test_spi_comm_data_available_empty);
+    RUN_TEST(test_spi_comm_data_available_with_data);
+    RUN_TEST(test_spi_comm_data_available_hal_error_propagates);
+
+    /* Utility function tests */
+    RUN_TEST(test_spi_comm_reset_sequence);
+    RUN_TEST(test_spi_comm_reset_sequence_null_handle);
+    RUN_TEST(test_spi_comm_get_tx_sequence);
+    RUN_TEST(test_spi_comm_get_tx_sequence_null_handle);
+    RUN_TEST(test_spi_comm_get_rx_sequence);
+    RUN_TEST(test_spi_comm_get_rx_sequence_null_handle);
+
+    /* Sequence number tests */
+    RUN_TEST(test_spi_comm_sequence_starts_at_zero);
+    RUN_TEST(test_spi_comm_sequence_max_value);
+    RUN_TEST(test_spi_comm_rx_sequence_wraparound);
+
+    /* Channel configuration tests */
+    RUN_TEST(test_spi_comm_uses_configured_channel);
+
+    /* Buffer size tests */
+    RUN_TEST(test_spi_comm_buffer_size_constants);
+    RUN_TEST(test_spi_comm_max_payload_fits_in_buffer);
+
+    /* Mock verification tests */
+    RUN_TEST(test_spi_comm_transfer_is_called_on_send);
+    RUN_TEST(test_spi_comm_available_is_called_on_receive);
+    RUN_TEST(test_spi_comm_transfer_count);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Implement 56 unit tests for the SPI communication layer (rx_spi_comm), covering all 9 public functions:

- **Initialization:** rx_spi_comm_init(), rx_spi_comm_deinit()
- **Send API:** rx_spi_comm_send(), rx_spi_comm_send_ack(), rx_spi_comm_send_nack()
- **Receive API:** rx_spi_comm_receive(), rx_spi_comm_data_available()
- **Utilities:** rx_spi_comm_reset_sequence(), rx_spi_comm_get_tx_sequence(), rx_spi_comm_get_rx_sequence()

### Test Coverage

- Parameter validation (NULL checks for all functions)
- State validation (uninitialized handle detection)
- Sequence number tracking and wraparound at 0xFFFF
- FEC flag propagation in transmitted frames
- ACK/NACK frame generation
- Frame receive with valid encoded frames
- Error propagation from SPI HAL layer
- Buffer size limit enforcement
- Channel configuration

### Mock Infrastructure

Add mock_rspi.c/h implementing RSPI HAL mocks with:
- Call tracking and verification
- Error injection for testing error paths
- RX data injection for receive testing
- TX data capture for transmitted frame verification
- Channel state management

## Test Plan

- [x] All 56 tests compile without errors or warnings (-Wall -Wextra -Werror)
- [x] All 56 tests pass
- [x] Integrated with CTest
- [x] Follows NASA Power of 10 rules
- [x] Follows SOLID principles
- [x] Uses inclusive terminology (Controller/Peripheral)

Closes #62