### PR TITLE
Add SPI ACK timeout handling and tests

### DIFF
--- a/star-rx72n-firmware/.gitignore
+++ b/star-rx72n-firmware/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 build/
 build-local/
+build-host/
 cmake-build-*/
 Testing/
 *.elf

--- a/star-rx72n-firmware/lib/rx_spi_comm/src/rx_spi_comm.c
+++ b/star-rx72n-firmware/lib/rx_spi_comm/src/rx_spi_comm.c
@@ -63,6 +63,11 @@ typedef enum {
   k_poll_sleep_ticks     = 1,   /**< Sleep duration for polling loop (1 tick) */
 } threadx_timing_t;
 
+/** @brief ACK/ready wait timing constants */
+typedef enum {
+  k_ack_wait_timeout_ms = 50, /**< Abort if host doesn't ACK within 50 ms */
+} ack_wait_t;
+
 /* =============================================================================
  * Internal Helpers
  * =============================================================================
@@ -109,6 +114,36 @@ static rx_err_t internal_spi_transfer(rx_spi_comm_handle_t* handle,
   }
 
   return k_rx_ok;
+}
+
+/**
+ * @brief Wait for host ACK/ready signal before transmitting
+ *
+ * Prevents infinite wait states when host never signals readiness.
+ */
+static rx_err_t internal_wait_for_ack(rx_spi_comm_handle_t* handle, uint32_t timeout_ms)
+{
+  uint32_t elapsed_ms = 0;
+
+  while (elapsed_ms < timeout_ms) {
+    bool     ready = false;
+    rx_err_t err   = rspi_peripheral_write_ready(handle->channel, &ready);
+    if (err != k_rx_ok) {
+      return err;
+    }
+
+    if (ready) {
+      return k_rx_ok;
+    }
+
+#ifdef __RX__
+    tx_thread_sleep(k_poll_sleep_ticks);
+#endif
+    elapsed_ms += k_threadx_ms_per_tick;
+  }
+
+  rx_log_error(s_tag, "SPI ACK timeout waiting for host ready");
+  return k_rx_err_timeout;
 }
 
 /* =============================================================================
@@ -232,6 +267,11 @@ rx_err_t rx_spi_comm_send(rx_spi_comm_handle_t* handle,
     return err;
   }
 
+  err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
   /* Transfer via SPI */
   err = internal_spi_transfer(handle, wire_buffer, wire_len, NULL, 0);
   if (err != k_rx_ok) {
@@ -271,6 +311,11 @@ rx_err_t rx_spi_comm_send_ack(rx_spi_comm_handle_t* handle, uint16_t sequence)
     return err;
   }
 
+  err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
   return internal_spi_transfer(handle, wire_buffer, wire_len, NULL, 0);
 }
 
@@ -296,6 +341,11 @@ rx_err_t rx_spi_comm_send_nack(rx_spi_comm_handle_t* handle, uint16_t sequence, 
   uint32_t wire_len = 0;
 
   err = rx_frame_encode(&handle->encoder, &nack_frame, wire_buffer, &wire_len);
+  if (err != k_rx_ok) {
+    return err;
+  }
+
+  err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
   if (err != k_rx_ok) {
     return err;
   }

--- a/star-rx72n-firmware/lib/rx_spi_comm/src/rx_spi_comm.c
+++ b/star-rx72n-firmware/lib/rx_spi_comm/src/rx_spi_comm.c
@@ -74,7 +74,61 @@ typedef enum {
  */
 
 /**
+ * @brief Wait for host ACK/ready signal before transmitting
+ *
+ * Prevents infinite wait states when host never signals readiness.
+ * Uses precise time measurement on RX72N and iteration count for host tests.
+ */
+static rx_err_t internal_wait_for_ack(rx_spi_comm_handle_t* handle, uint32_t timeout_ms)
+{
+#ifdef __RX__
+  /* RX72N: Use ThreadX time measurement for precise timeout */
+  ULONG timeout_ticks = (timeout_ms + k_threadx_ms_per_tick - 1) / k_threadx_ms_per_tick;
+  ULONG start_ticks   = tx_time_get();
+
+  while ((tx_time_get() - start_ticks) < timeout_ticks) {
+    bool     ready = false;
+    rx_err_t err   = rspi_peripheral_write_ready(handle->channel, &ready);
+    if (err != k_rx_ok) {
+      return err;
+    }
+
+    if (ready) {
+      return k_rx_ok;
+    }
+
+    /* Yield to other threads while waiting */
+    tx_thread_sleep(k_poll_sleep_ticks);
+  }
+#else
+  /* Host build (testing): Use iteration counter to simulate time */
+  uint32_t elapsed_ms = 0;
+
+  while (elapsed_ms < timeout_ms) {
+    bool     ready = false;
+    rx_err_t err   = rspi_peripheral_write_ready(handle->channel, &ready);
+    if (err != k_rx_ok) {
+      return err;
+    }
+
+    if (ready) {
+      return k_rx_ok;
+    }
+
+    /* Simulate time passing in tests */
+    elapsed_ms += k_threadx_ms_per_tick;
+  }
+#endif
+
+  rx_log_error(s_tag, "SPI ACK timeout waiting for host ready");
+  return k_rx_err_timeout;
+}
+
+/**
  * @brief Perform raw SPI transfer using staging buffers
+ *
+ * For transmit operations (tx_data != NULL), waits for host ready signal
+ * before transferring to prevent infinite wait states.
  */
 static rx_err_t internal_spi_transfer(rx_spi_comm_handle_t* handle,
                                       const uint8_t*        tx_data,
@@ -82,6 +136,14 @@ static rx_err_t internal_spi_transfer(rx_spi_comm_handle_t* handle,
                                       uint8_t*              rx_data,
                                       uint32_t              rx_len)
 {
+  /* Wait for host ready signal before transmit operations */
+  if (tx_data != NULL && tx_len > 0) {
+    rx_err_t wait_err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
+    if (wait_err != k_rx_ok) {
+      return wait_err;
+    }
+  }
+
   /* Prepare TX buffer (pad with zeros if RX is larger) */
   uint32_t transfer_len = (tx_len > rx_len) ? tx_len : rx_len;
 
@@ -114,36 +176,6 @@ static rx_err_t internal_spi_transfer(rx_spi_comm_handle_t* handle,
   }
 
   return k_rx_ok;
-}
-
-/**
- * @brief Wait for host ACK/ready signal before transmitting
- *
- * Prevents infinite wait states when host never signals readiness.
- */
-static rx_err_t internal_wait_for_ack(rx_spi_comm_handle_t* handle, uint32_t timeout_ms)
-{
-  uint32_t elapsed_ms = 0;
-
-  while (elapsed_ms < timeout_ms) {
-    bool     ready = false;
-    rx_err_t err   = rspi_peripheral_write_ready(handle->channel, &ready);
-    if (err != k_rx_ok) {
-      return err;
-    }
-
-    if (ready) {
-      return k_rx_ok;
-    }
-
-#ifdef __RX__
-    tx_thread_sleep(k_poll_sleep_ticks);
-#endif
-    elapsed_ms += k_threadx_ms_per_tick;
-  }
-
-  rx_log_error(s_tag, "SPI ACK timeout waiting for host ready");
-  return k_rx_err_timeout;
 }
 
 /* =============================================================================
@@ -267,12 +299,7 @@ rx_err_t rx_spi_comm_send(rx_spi_comm_handle_t* handle,
     return err;
   }
 
-  err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
-  if (err != k_rx_ok) {
-    return err;
-  }
-
-  /* Transfer via SPI */
+  /* Transfer via SPI (waits for host ACK internally) */
   err = internal_spi_transfer(handle, wire_buffer, wire_len, NULL, 0);
   if (err != k_rx_ok) {
     rx_log_error(s_tag, "SPI transfer failed");
@@ -311,11 +338,7 @@ rx_err_t rx_spi_comm_send_ack(rx_spi_comm_handle_t* handle, uint16_t sequence)
     return err;
   }
 
-  err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
-  if (err != k_rx_ok) {
-    return err;
-  }
-
+  /* Transfer via SPI (waits for host ACK internally) */
   return internal_spi_transfer(handle, wire_buffer, wire_len, NULL, 0);
 }
 
@@ -345,11 +368,7 @@ rx_err_t rx_spi_comm_send_nack(rx_spi_comm_handle_t* handle, uint16_t sequence, 
     return err;
   }
 
-  err = internal_wait_for_ack(handle, k_ack_wait_timeout_ms);
-  if (err != k_rx_ok) {
-    return err;
-  }
-
+  /* Transfer via SPI (waits for host ACK internally) */
   return internal_spi_transfer(handle, wire_buffer, wire_len, NULL, 0);
 }
 

--- a/star-rx72n-firmware/tests/test_rx_spi_comm.c
+++ b/star-rx72n-firmware/tests/test_rx_spi_comm.c
@@ -326,6 +326,26 @@ void test_spi_comm_send_large_payload(void)
   TEST_ASSERT_EQUAL(k_rx_ok, err);
 }
 
+void test_spi_comm_send_missing_host_ack_times_out(void)
+{
+  rx_spi_comm_init(&s_handle, NULL);
+  helper_init_rspi_channel(k_test_channel_default);
+  mock_rspi_clear_calls(NULL);
+  mock_rspi_set_write_ready(NULL, k_test_channel_default, false);
+
+  uint8_t data[] = "test";
+
+  rx_err_t err = rx_spi_comm_send(&s_handle, k_frame_type_response, 0, data, 4);
+
+  TEST_ASSERT_EQUAL(k_rx_err_timeout, err);
+
+  uint32_t transfer_calls = mock_rspi_get_call_count(NULL, "rspi_peripheral_transfer");
+  TEST_ASSERT_EQUAL_UINT32(0, transfer_calls);
+
+  uint32_t ready_calls = mock_rspi_get_call_count(NULL, "rspi_peripheral_write_ready");
+  TEST_ASSERT_TRUE(ready_calls > 0);
+}
+
 /* =============================================================================
  * Send ACK/NACK Tests
  * =============================================================================
@@ -864,6 +884,7 @@ int main(void)
   RUN_TEST(test_spi_comm_send_with_fec_flag);
   RUN_TEST(test_spi_comm_send_transfer_error_propagates);
   RUN_TEST(test_spi_comm_send_large_payload);
+  RUN_TEST(test_spi_comm_send_missing_host_ack_times_out);
 
   /* Send ACK/NACK tests */
   RUN_TEST(test_spi_comm_send_ack_null_handle_fails);


### PR DESCRIPTION
## Summary
- add a host-ready wait helper so SPI send paths timeout if the Raspberry Pi never ACKs
- include regression test that simulates a dropped ACK
- ignore the host-only build directory so local cmake runs stay clean

## Testing
-  *(fails: AppleClang cannot assemble RX-specific tx_initialize_low_level.S; requires Renesas toolchain)*