### PR TITLE
feat(control): Implement basic obstacle detection

### DIFF
--- a/star-rx72n-firmware/CMakeLists.txt
+++ b/star-rx72n-firmware/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(rx_hal STATIC
     lib/rx_hal/src/rx_gptw.c
     lib/rx_hal/src/rx_cmt.c
     lib/rx_hal/src/rx_mpc.c
+    lib/rx_hal/src/rx_obstacle_detect.c
 )
 target_include_directories(rx_hal PUBLIC
     lib/rx_hal/inc

--- a/star-rx72n-firmware/lib/rx_hal/inc/rx_obstacle_detect.h
+++ b/star-rx72n-firmware/lib/rx_hal/inc/rx_obstacle_detect.h
@@ -1,0 +1,82 @@
+/**
+ * @file rx_obstacle_detect.h
+ * @brief Basic obstacle detection and emergency stop using HC-SR04 sensors.
+ *
+ * This module monitors a set of HC-SR04 ultrasonic sensors and triggers an
+ * emergency stop if an obstacle is detected within a configurable threshold.
+ * It is designed as a simple safety mechanism to prevent collisions.
+ *
+ * @date 2026-01-06
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#ifndef RX_OBSTACLE_DETECT_H
+#define RX_OBSTACLE_DETECT_H
+
+#include "rx_hcsr04.h"
+#include "rx_error.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+/**
+ * @brief Maximum number of sensors that can be managed by this module.
+ */
+#define RX_OBSTACLE_DETECT_MAX_SENSORS 4
+
+/**
+ * @brief Callback function type for when an obstacle is detected.
+ *
+ * @param sensor_index The index of the sensor that detected the obstacle.
+ * @param distance_cm The measured distance in centimeters.
+ * @param user_data Optional user data passed to the init function.
+ */
+typedef void (*rx_obstacle_detect_callback_t)(uint8_t sensor_index, float distance_cm, void* user_data);
+
+/**
+ * @brief Configuration for the obstacle detection module.
+ */
+typedef struct {
+    rx_hcsr04_t* sensors[RX_OBSTACLE_DETECT_MAX_SENSORS]; ///< Array of pointers to initialized HC-SR04 handles.
+    uint8_t num_sensors;                                 ///< Number of sensors in the `sensors` array.
+    rx_motor_handle_t* motors[RX_OBSTACLE_DETECT_MAX_SENSORS]; ///< Array of pointers to initialized motor handles.
+    uint8_t num_motors;                                  ///< Number of motors in the `motors` array.
+    float detection_threshold_cm;                        ///< Distance in cm to trigger an obstacle detection.
+    uint8_t debounce_samples;                            ///< Number of consecutive readings required to confirm an obstacle.
+    uint32_t poll_interval_ms;                           ///< Interval in milliseconds to poll the sensors.
+    rx_obstacle_detect_callback_t callback;              ///< Callback function to invoke when an obstacle is detected.
+    void* user_data;                                     ///< Optional user data for the callback.
+} rx_obstacle_detect_config_t;
+
+/**
+ * @brief Initializes the obstacle detection module.
+ *
+ * This function sets up the polling task and prepares the module for operation.
+ * It does not start the sensor measurements automatically.
+ *
+ * @param config Pointer to the configuration structure.
+ * @return k_rx_ok on success, or an error code on failure.
+ */
+rx_err_t rx_obstacle_detect_init(const rx_obstacle_detect_config_t* config);
+
+/**
+ * @brief Starts the obstacle detection polling.
+ *
+ * @return k_rx_ok on success, or an error code on failure.
+ */
+rx_err_t rx_obstacle_detect_start(void);
+
+/**
+ * @brief Stops the obstacle detection polling.
+ *
+ * @return k_rx_ok on success, or an error code on failure.
+ */
+rx_err_t rx_obstacle_detect_stop(void);
+
+/**
+ * @brief Checks if an obstacle is currently detected.
+ *
+ * @return True if an obstacle is present, false otherwise.
+ */
+bool rx_obstacle_detect_is_obstacle_present(void);
+
+#endif // RX_OBSTACLE_DETECT_H

--- a/star-rx72n-firmware/lib/rx_hal/src/rx_obstacle_detect.c
+++ b/star-rx72n-firmware/lib/rx_hal/src/rx_obstacle_detect.c
@@ -1,0 +1,137 @@
+/**
+ * @file rx_obstacle_detect.c
+ * @brief Basic obstacle detection and emergency stop using HC-SR04 sensors.
+ *
+ * @date 2026-01-06
+ * @copyright Copyright (c) 2026 STAR Project
+ */
+
+#include "rx_obstacle_detect.h"
+#include "tx_api.h"
+#include "rx_motor.h"
+#include "rx_log.h"
+
+#define OBSTACLE_DETECT_TASK_STACK_SIZE 2048
+#define OBSTACLE_DETECT_TASK_PRIORITY   10
+
+static TX_THREAD                       s_obstacle_detect_thread;
+static UCHAR                           s_obstacle_detect_stack[OBSTACLE_DETECT_TASK_STACK_SIZE];
+static bool                            s_initialized = false;
+static bool                            s_running = false;
+static bool                            s_obstacle_present = false;
+static rx_obstacle_detect_config_t     s_config;
+static uint8_t                         s_consecutive_detections[RX_OBSTACLE_DETECT_MAX_SENSORS];
+
+// Forward declaration
+static void obstacle_detect_task_entry(ULONG thread_input);
+
+rx_err_t rx_obstacle_detect_init(const rx_obstacle_detect_config_t* config) {
+    if (config == NULL || config->num_sensors == 0 || config->num_sensors > RX_OBSTACLE_DETECT_MAX_SENSORS || config->num_motors == 0) {
+        return k_rx_err_invalid_argument;
+    }
+
+    s_config = *config;
+    for (uint8_t i = 0; i < s_config.num_sensors; ++i) {
+        if (s_config.sensors[i] == NULL) {
+            return k_rx_err_invalid_argument;
+        }
+        s_consecutive_detections[i] = 0;
+    }
+    for (uint8_t i = 0; i < s_config.num_motors; ++i) {
+        if (s_config.motors[i] == NULL) {
+            return k_rx_err_invalid_argument;
+        }
+    }
+
+    UINT tx_status = tx_thread_create(&s_obstacle_detect_thread,
+                                      "ObstacleDetect",
+                                      obstacle_detect_task_entry,
+                                      0,
+                                      s_obstacle_detect_stack,
+                                      OBSTACLE_DETECT_TASK_STACK_SIZE,
+                                      OBSTACLE_DETECT_TASK_PRIORITY,
+                                      OBSTACLE_DETECT_TASK_PRIORITY,
+                                      TX_NO_TIME_SLICE,
+                                      TX_DONT_START);
+    if (tx_status != TX_SUCCESS) {
+        return k_rx_err_os_failure;
+    }
+
+    s_initialized = true;
+    return k_rx_ok;
+}
+
+rx_err_t rx_obstacle_detect_start(void) {
+    if (!s_initialized) {
+        return k_rx_err_not_initialized;
+    }
+    if (s_running) {
+        return k_rx_ok; // Already running
+    }
+    s_running = true;
+    UINT tx_status = tx_thread_resume(&s_obstacle_detect_thread);
+    return (tx_status == TX_SUCCESS) ? k_rx_ok : k_rx_err_os_failure;
+}
+
+rx_err_t rx_obstacle_detect_stop(void) {
+    if (!s_initialized || !s_running) {
+        return k_rx_ok;
+    }
+    s_running = false;
+    UINT tx_status = tx_thread_suspend(&s_obstacle_detect_thread);
+    return (tx_status == TX_SUCCESS) ? k_rx_ok : k_rx_err_os_failure;
+}
+
+bool rx_obstacle_detect_is_obstacle_present(void) {
+    return s_obstacle_present;
+}
+
+static void internal_stop_all_motors(void) {
+    for (uint8_t i = 0; i < s_config.num_motors; ++i) {
+        rx_motor_stop(s_config.motors[i], true); // true for brake
+    }
+}
+
+static void obstacle_detect_task_entry(ULONG thread_input) {
+    (void)thread_input;
+
+    while (1) {
+        if (!s_running) {
+            tx_thread_suspend(&s_obstacle_detect_thread);
+            continue;
+        }
+
+        bool an_obstacle_was_detected = false;
+        for (uint8_t i = 0; i < s_config.num_sensors; ++i) {
+            float distance_cm = 0.0f;
+            rx_err_t err = rx_hcsr04_measure_blocking(s_config.sensors[i], &distance_cm);
+
+            if (err == k_rx_ok && distance_cm < s_config.detection_threshold_cm) {
+                s_consecutive_detections[i]++;
+                if (s_consecutive_detections[i] >= s_config.debounce_samples) {
+                    an_obstacle_was_detected = true;
+                    if (!s_obstacle_present) {
+                        s_obstacle_present = true;
+                        rx_log_warn("Obstacle", "Obstacle detected. Stopping motors.");
+                        rx_log_warn_val("Obstacle", "Sensor index", i);
+                        rx_log_warn_val("Obstacle", "Distance (cm)", (int32_t)distance_cm);
+                        internal_stop_all_motors();
+                        if (s_config.callback) {
+                            s_config.callback(i, distance_cm, s_config.user_data);
+                        }
+                    }
+                }
+            } else {
+                s_consecutive_detections[i] = 0;
+            }
+        }
+        
+        if (!an_obstacle_was_detected && s_obstacle_present) {
+            s_obstacle_present = false;
+            rx_log_info("Obstacle", "Obstacle cleared.");
+            // Motors remain stopped until a manual override.
+        }
+
+        tx_thread_sleep(s_config.poll_interval_ms / 10); // Convert ms to ticks (assuming 10ms/tick)
+    }
+}


### PR DESCRIPTION
This PR implements basic obstacle detection and emergency stop functionality as described in issue #41. 
>
> It introduces the 'rx_obstacle_detect' module, which monitors HC-SR04 sensors and stops all configured motors if an object is detected within a specified threshold.
>
> ### Key Features:
> - **Polling Task**: A new ThreadX task polls sensors periodically.
> - **Configurable**: Detection threshold, debounce samples, and poll interval are all configurable.
> - **Motor Control**: Stops all registered motors upon detection.
> - **Callback**: An optional callback can be registered to be invoked on obstacle detection.
>
> Closes #41