### PR TITLE
Add priority support to HARQ send operations

### DIFF
--- a/star-gateway/internal/harq/harq.go
+++ b/star-gateway/internal/harq/harq.go
@@ -81,13 +81,22 @@ func (s State) String() string {
 	}
 }
 
+// Priority represents the priority level of a HARQ transmission.
+type Priority uint8
+
+const (
+	PriorityEmergency Priority = 0
+	PriorityHigh      Priority = 1
+	PriorityNormal    Priority = 2
+)
+
 // HARQ defines the interface for the HARQ protocol handler.
 type HARQ interface {
 	// Send transmits data with HARQ reliability.
 	// Applies FEC encoding before transmission.
 	// Handles retransmission on timeout or NACK.
 	// Returns an error if max retries exceeded.
-	Send(ctx context.Context, data []byte) error
+	Send(ctx context.Context, data []byte, p ...Priority) error
 
 	// Receive waits for data with HARQ handling.
 	// Applies FEC decoding and soft bit combining on retransmissions.
@@ -233,7 +242,8 @@ func NewChaseCombining(
 // Send transmits data with HARQ reliability.
 // Applies FEC encoding, wraps in a command frame, and waits for ACK.
 // Retransmits the same encoded frame on timeout or NACK up to MaxRetries.
-func (h *ChaseCombining) Send(ctx context.Context, data []byte) error {
+// Priority defaults to PriorityNormal if not specified.
+func (h *ChaseCombining) Send(ctx context.Context, data []byte, p ...Priority) error {
 	if ctx == nil {
 		return ErrNilContext
 	}
@@ -241,7 +251,13 @@ func (h *ChaseCombining) Send(ctx context.Context, data []byte) error {
 		return err
 	}
 
-	currentSeq, err := h.prepareSend(data)
+	// Extract priority with default
+	priority := PriorityNormal
+	if len(p) > 0 {
+		priority = p[0]
+	}
+
+	currentSeq, err := h.prepareSend(data, priority)
 	if err != nil {
 		return err
 	}
@@ -314,7 +330,7 @@ func (h *ChaseCombining) validateSendDependencies() error {
 	return nil
 }
 
-func (h *ChaseCombining) prepareSend(data []byte) (uint16, error) {
+func (h *ChaseCombining) prepareSend(data []byte, priority Priority) (uint16, error) {
 	h.mu.Lock()
 	if err := h.validateSendDependencies(); err != nil {
 		h.mu.Unlock()
@@ -338,6 +354,9 @@ func (h *ChaseCombining) prepareSend(data []byte) (uint16, error) {
 	}
 	f.Header.Sequence = h.txSequence
 	f.Header.Flags = frame.FlagRequiresAck
+	if priority != PriorityNormal {
+		f.Header.Flags |= frame.FlagPriority
+	}
 	if h.config.FECEnabled {
 		f.Header.Flags |= frame.FlagFECEnabled
 	}
@@ -600,20 +619,20 @@ func (h *ChaseCombining) waitForAck(ctx context.Context) (*frame.Frame, error) {
 	data, err := h.transport.Receive(frame.MaxFrameSize)
 	if err != nil {
 		errCtx := ctx.Err()
-		switch errCtx {
-		case context.DeadlineExceeded:
+		switch {
+		case errors.Is(errCtx, context.DeadlineExceeded):
 			return nil, ErrTimeout
-		case context.Canceled:
+		case errors.Is(errCtx, context.Canceled):
 			return nil, errCtx
 		default:
 		}
 		return nil, err
 	}
 	if errCtx := ctx.Err(); errCtx != nil {
-		switch errCtx {
-		case context.DeadlineExceeded:
+		switch {
+		case errors.Is(errCtx, context.DeadlineExceeded):
 			return nil, ErrTimeout
-		case context.Canceled:
+		case errors.Is(errCtx, context.Canceled):
 			return nil, errCtx
 		default:
 			return nil, errCtx

--- a/star-gateway/internal/harq/harq_test.go
+++ b/star-gateway/internal/harq/harq_test.go
@@ -301,11 +301,12 @@ func TestDecrementSequence(t *testing.T) {
 func TestSend_Success(t *testing.T) {
 	harq, mock := createTestHARQ(nil)
 	payload := []byte{0x01, 0x02, 0x03}
+	priority := PriorityNormal
 
 	// Queue ACK response with sequence 0
 	mock.QueueResponse(createAckFrame(0))
 
-	err := harq.Send(context.Background(), payload)
+	err := harq.Send(context.Background(), payload, priority)
 
 	if err != nil {
 		t.Errorf("Send() error = %v, want nil", err)

--- a/star-gateway/internal/service/motor_control.go
+++ b/star-gateway/internal/service/motor_control.go
@@ -64,7 +64,8 @@ func (s *MotorControlService) SetVelocity(ctx context.Context, req *starv1.SetVe
 	}
 
 	// 3. Send via HARQ (blocks until ACK or timeout/max retries)
-	if err := s.harqHandler.Send(ctx, payload); err != nil {
+	// Note: Using normal priority for standard velocity commands.
+	if err := s.harqHandler.Send(ctx, payload, harq.PriorityNormal); err != nil {
 		s.logger.Error("failed to send velocity command",
 			slog.String("request_id", req.Header.GetRequestId()),
 			slog.String("error", err.Error()))
@@ -109,7 +110,9 @@ func (s *MotorControlService) EmergencyStop(ctx context.Context, req *starv1.Eme
 		return nil, status.Errorf(codes.Internal, "failed to marshal estop command: %v", err)
 	}
 
-	if err := s.harqHandler.Send(ctx, payload); err != nil {
+	// Send via HARQ with emergency priority
+	// Note: Using high priority for emergency stop commands.
+	if err := s.harqHandler.Send(ctx, payload, harq.PriorityEmergency); err != nil {
 		s.logger.Error("failed to send emergency stop command",
 			slog.String("request_id", req.Header.GetRequestId()),
 			slog.String("reason", req.Reason),
@@ -286,7 +289,7 @@ func (s *MotorControlService) forwardVelocityCommand(ctx context.Context, cmd *s
 		return err
 	}
 
-	return s.harqHandler.Send(ctx, payload)
+	return s.harqHandler.Send(ctx, payload, harq.PriorityNormal)
 }
 
 // sendTelemetryLoop receives telemetry from Dispatcher and sends encoder feedback to client.


### PR DESCRIPTION
### Motivation

Introduces the ability to specify priority levels for HARQ transmissions, enabling differentiated handling for commands such as emergency stops and standard operations.

### Key Changes

- Adds a priority parameter to the HARQ send method, supporting emergency, high, and normal levels.
- Updates all internal usages to specify the appropriate priority, ensuring that critical commands (like emergency stop) are sent with higher urgency.
- Adjusts protocol handling to mark frames with a priority flag when required.
- Improves context error handling for more robust timeout and cancellation detection.

### Benefits

- Enables command prioritization, improving reliability for time-critical operations.
- Lays groundwork for future enhancements involving differentiated network handling or resource allocation based on priority.

Relates to feature request for prioritized control commands.


closes https://github.com/Locked-Inc/STAR/issues/139