### PR TITLE
feat(harq): add priority flag to HARQ send method and update usage

### DIFF
--- a/star-gateway/internal/dispatcher/dispatcher_test.go
+++ b/star-gateway/internal/dispatcher/dispatcher_test.go
@@ -24,9 +24,10 @@ const (
 )
 
 // MockHARQ is a mock implementation of the harq.HARQ interface for testing.
+// Note: Kept local to avoid import cycle with testutil (which imports dispatcher for MockDispatcher).
 type MockHARQ struct {
 	ReceiveFunc  func(ctx context.Context) ([]byte, error)
-	SendFunc     func(ctx context.Context, data []byte) error
+	SendFunc     func(ctx context.Context, data []byte, p ...harq.Priority) error
 	GetStateFunc func() harq.State
 	GetTxSeqFunc func() uint16
 	GetRxSeqFunc func() uint16
@@ -35,10 +36,10 @@ type MockHARQ struct {
 	LastSentData []byte
 }
 
-func (m *MockHARQ) Send(ctx context.Context, data []byte) error {
+func (m *MockHARQ) Send(ctx context.Context, data []byte, p ...harq.Priority) error {
 	m.LastSentData = data
 	if m.SendFunc != nil {
-		return m.SendFunc(ctx, data)
+		return m.SendFunc(ctx, data, p...)
 	}
 	return nil
 }

--- a/star-gateway/internal/harq/harq.go
+++ b/star-gateway/internal/harq/harq.go
@@ -1,7 +1,7 @@
 // Package harq implements Hybrid Automatic Repeat reQuest (HARQ) protocol
 // for reliable frame delivery over the SPI transport.
 //
-// The HARQ mechanism uses Chase Combining (Type I) with the following properties:
+// The HARQ mechanism use`s Chase Combining (Type I) with the following properties:
 //   - 16-bit sequence numbers with wraparound
 //   - ACK/NACK response frames
 //   - Configurable retry count and timeout

--- a/star-gateway/internal/harq/harq.go
+++ b/star-gateway/internal/harq/harq.go
@@ -81,13 +81,22 @@ func (s State) String() string {
 	}
 }
 
+// Priority represents the priority level of a HARQ transmission.
+type Priority uint8
+
+const (
+	PriorityEmergency Priority = 0
+	PriorityHigh      Priority = 1
+	PriorityNormal    Priority = 2
+)
+
 // HARQ defines the interface for the HARQ protocol handler.
 type HARQ interface {
 	// Send transmits data with HARQ reliability.
 	// Applies FEC encoding before transmission.
 	// Handles retransmission on timeout or NACK.
 	// Returns an error if max retries exceeded.
-	Send(ctx context.Context, data []byte) error
+	Send(ctx context.Context, data []byte, p ...Priority) error
 
 	// Receive waits for data with HARQ handling.
 	// Applies FEC decoding and soft bit combining on retransmissions.
@@ -233,7 +242,8 @@ func NewChaseCombining(
 // Send transmits data with HARQ reliability.
 // Applies FEC encoding, wraps in a command frame, and waits for ACK.
 // Retransmits the same encoded frame on timeout or NACK up to MaxRetries.
-func (h *ChaseCombining) Send(ctx context.Context, data []byte) error {
+// Priority defaults to PriorityNormal if not specified.
+func (h *ChaseCombining) Send(ctx context.Context, data []byte, p ...Priority) error {
 	if ctx == nil {
 		return ErrNilContext
 	}
@@ -241,7 +251,13 @@ func (h *ChaseCombining) Send(ctx context.Context, data []byte) error {
 		return err
 	}
 
-	currentSeq, err := h.prepareSend(data)
+	// Extract priority with default
+	priority := PriorityNormal
+	if len(p) > 0 {
+		priority = p[0]
+	}
+
+	currentSeq, err := h.prepareSend(data, priority)
 	if err != nil {
 		return err
 	}
@@ -314,7 +330,7 @@ func (h *ChaseCombining) validateSendDependencies() error {
 	return nil
 }
 
-func (h *ChaseCombining) prepareSend(data []byte) (uint16, error) {
+func (h *ChaseCombining) prepareSend(data []byte, priority Priority) (uint16, error) {
 	h.mu.Lock()
 	if err := h.validateSendDependencies(); err != nil {
 		h.mu.Unlock()
@@ -338,6 +354,9 @@ func (h *ChaseCombining) prepareSend(data []byte) (uint16, error) {
 	}
 	f.Header.Sequence = h.txSequence
 	f.Header.Flags = frame.FlagRequiresAck
+	if priority != PriorityNormal {
+		f.Header.Flags |= frame.FlagPriority
+	}
 	if h.config.FECEnabled {
 		f.Header.Flags |= frame.FlagFECEnabled
 	}
@@ -600,20 +619,20 @@ func (h *ChaseCombining) waitForAck(ctx context.Context) (*frame.Frame, error) {
 	data, err := h.transport.Receive(frame.MaxFrameSize)
 	if err != nil {
 		errCtx := ctx.Err()
-		switch errCtx {
-		case context.DeadlineExceeded:
+		switch {
+		case errors.Is(errCtx, context.DeadlineExceeded):
 			return nil, ErrTimeout
-		case context.Canceled:
+		case errors.Is(errCtx, context.Canceled):
 			return nil, errCtx
 		default:
 		}
 		return nil, err
 	}
 	if errCtx := ctx.Err(); errCtx != nil {
-		switch errCtx {
-		case context.DeadlineExceeded:
+		switch {
+		case errors.Is(errCtx, context.DeadlineExceeded):
 			return nil, ErrTimeout
-		case context.Canceled:
+		case errors.Is(errCtx, context.Canceled):
 			return nil, errCtx
 		default:
 			return nil, errCtx

--- a/star-gateway/internal/harq/harq.go
+++ b/star-gateway/internal/harq/harq.go
@@ -90,6 +90,13 @@ const (
 	PriorityNormal    Priority = 2
 )
 
+// Protocol wire format values for priority levels
+const (
+	PriorityValueEmergency uint8 = 0
+	PriorityValueHigh      uint8 = 1
+	PriorityValueNormal    uint8 = 2
+)
+
 // HARQ defines the interface for the HARQ protocol handler.
 type HARQ interface {
 	// Send transmits data with HARQ reliability.

--- a/star-gateway/internal/harq/harq_test.go
+++ b/star-gateway/internal/harq/harq_test.go
@@ -301,11 +301,12 @@ func TestDecrementSequence(t *testing.T) {
 func TestSend_Success(t *testing.T) {
 	harq, mock := createTestHARQ(nil)
 	payload := []byte{0x01, 0x02, 0x03}
+	priority := PriorityNormal
 
 	// Queue ACK response with sequence 0
 	mock.QueueResponse(createAckFrame(0))
 
-	err := harq.Send(context.Background(), payload)
+	err := harq.Send(context.Background(), payload, priority)
 
 	if err != nil {
 		t.Errorf("Send() error = %v, want nil", err)

--- a/star-gateway/internal/harq/harq_test.go
+++ b/star-gateway/internal/harq/harq_test.go
@@ -1180,9 +1180,9 @@ func TestPriorityConstants(t *testing.T) {
 		priority Priority
 		expected uint8
 	}{
-		{"Emergency", PriorityEmergency, 0},
-		{"High", PriorityHigh, 1},
-		{"Normal", PriorityNormal, 2},
+		{"Emergency", PriorityEmergency, PriorityValueEmergency},
+		{"High", PriorityHigh, PriorityValueHigh},
+		{"Normal", PriorityNormal, PriorityValueNormal},
 	}
 
 	for _, tc := range tests {

--- a/star-gateway/internal/harq/harq_test.go
+++ b/star-gateway/internal/harq/harq_test.go
@@ -1214,26 +1214,19 @@ func TestSend_PriorityEmergencyPreservedOnRetransmit(t *testing.T) {
 	go func() {
 		ticker := time.NewTicker(testPollInterval)
 		defer ticker.Stop()
+		defer close(retransmitDetected)
 
 		timeout := time.After(testWaitTimeout)
-		channelClosed := false
 
 		for {
 			select {
 			case <-ticker.C:
 				sentData := mock.GetSentData()
 				if len(sentData) >= 2 {
-					if !channelClosed {
-						close(retransmitDetected)
-						channelClosed = true
-					}
 					mock.QueueResponse(createAckFrame(0))
 					return
 				}
 			case <-timeout:
-				if !channelClosed {
-					close(retransmitDetected)
-				}
 				t.Errorf("timeout waiting for retransmission after %v", testWaitTimeout)
 				return
 			}

--- a/star-gateway/internal/harq/harq_test.go
+++ b/star-gateway/internal/harq/harq_test.go
@@ -1169,3 +1169,211 @@ func TestChaseCombining_FEC_NilFECDecoder(t *testing.T) {
 		t.Errorf("Receive() error = %v, want ErrFECDecoderNil", err)
 	}
 }
+
+// ============================================================================
+// Priority Flag Tests
+// ============================================================================
+
+func TestPriorityConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		priority Priority
+		expected uint8
+	}{
+		{"Emergency", PriorityEmergency, 0},
+		{"High", PriorityHigh, 1},
+		{"Normal", PriorityNormal, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if uint8(tc.priority) != tc.expected {
+				t.Errorf("Priority value = %d, want %d", uint8(tc.priority), tc.expected)
+			}
+		})
+	}
+}
+
+func TestSend_PriorityEmergencyPreservedOnRetransmit(t *testing.T) {
+	const (
+		testMaxRetries   = 3
+		testTimeout      = 5 * time.Millisecond
+		testPollInterval = 1 * time.Millisecond
+		testWaitTimeout  = 100 * time.Millisecond
+	)
+
+	config := &Config{
+		MaxRetries: testMaxRetries,
+		Timeout:    testTimeout,
+	}
+	harq, mock := createTestHARQ(config)
+	payload := []byte{0x01, 0x02, 0x03}
+
+	// Use channel-based synchronization to deterministically trigger ACK after retransmit
+	retransmitDetected := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(testPollInterval)
+		defer ticker.Stop()
+
+		timeout := time.After(testWaitTimeout)
+		channelClosed := false
+
+		for {
+			select {
+			case <-ticker.C:
+				sentData := mock.GetSentData()
+				if len(sentData) >= 2 {
+					if !channelClosed {
+						close(retransmitDetected)
+						channelClosed = true
+					}
+					mock.QueueResponse(createAckFrame(0))
+					return
+				}
+			case <-timeout:
+				if !channelClosed {
+					close(retransmitDetected)
+				}
+				t.Errorf("timeout waiting for retransmission after %v", testWaitTimeout)
+				return
+			}
+		}
+	}()
+
+	// Send with PriorityEmergency
+	err := harq.Send(context.Background(), payload, PriorityEmergency)
+
+	if err != nil {
+		t.Errorf("Send() error = %v, want nil", err)
+	}
+
+	// Wait for retransmit detection to complete
+	<-retransmitDetected
+
+	// Verify priority flag is set on both original and retransmitted frames
+	sentData := mock.GetSentData()
+	if len(sentData) < 2 {
+		t.Fatalf("expected at least 2 sent frames, got %d", len(sentData))
+	}
+
+	decoder := frame.NewDecoder()
+	for i, data := range sentData {
+		f, err := decoder.Decode(data)
+		if err != nil {
+			t.Fatalf("failed to decode frame %d: %v", i, err)
+		}
+
+		if f.Header.Flags&frame.FlagPriority == 0 {
+			t.Errorf("Frame %d should have FlagPriority set for PriorityEmergency", i)
+		}
+	}
+}
+
+func TestSend_PriorityHighWithFEC(t *testing.T) {
+	config := &Config{
+		MaxRetries: 3,
+		Timeout:    50 * time.Millisecond,
+		FECEnabled: true,
+	}
+	mock := NewMockTransport()
+	encoder := frame.NewEncoder()
+	decoder := frame.NewDecoder()
+	fecEncoder := &MockFECEncoder{}
+	fecDecoder := &MockFECDecoder{}
+	harq := NewChaseCombining(config, mock, encoder, decoder, fecEncoder, fecDecoder)
+
+	mock.QueueResponse(createAckFrame(0))
+
+	payload := []byte("high-priority-message")
+	err := harq.Send(context.Background(), payload, PriorityHigh)
+
+	if err != nil {
+		t.Errorf("Send() error = %v, want nil", err)
+	}
+
+	sentData := mock.GetSentData()
+	if len(sentData) == 0 {
+		t.Fatal("expected at least 1 sent frame, got 0")
+	}
+
+	// Decode and verify priority flag is set along with FEC flag
+	f, err := decoder.Decode(sentData[0])
+	if err != nil {
+		t.Fatalf("failed to decode frame: %v", err)
+	}
+
+	hasPriorityFlag := f.Header.Flags&frame.FlagPriority != 0
+	hasFECFlag := f.Header.Flags&frame.FlagFECEnabled != 0
+
+	if !hasPriorityFlag {
+		t.Error("PriorityHigh should set FlagPriority")
+	}
+	if !hasFECFlag {
+		t.Error("FEC enabled should set FlagFECEnabled")
+	}
+}
+
+func TestSend_VariadicPriorityHandling(t *testing.T) {
+	tests := []struct {
+		name            string
+		priority        []Priority
+		expectedFlagSet bool
+		description     string
+	}{
+		{
+			name:            "no_priority_arg",
+			priority:        []Priority{},
+			expectedFlagSet: false,
+			description:     "Should default to PriorityNormal and not set flag",
+		},
+		{
+			name:            "single_priority_normal",
+			priority:        []Priority{PriorityNormal},
+			expectedFlagSet: false,
+			description:     "PriorityNormal should not set flag",
+		},
+		{
+			name:            "single_priority_high",
+			priority:        []Priority{PriorityHigh},
+			expectedFlagSet: true,
+			description:     "PriorityHigh should set flag",
+		},
+		{
+			name:            "single_priority_emergency",
+			priority:        []Priority{PriorityEmergency},
+			expectedFlagSet: true,
+			description:     "PriorityEmergency should set flag",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			harq, mock := createTestHARQ(nil)
+			mock.QueueResponse(createAckFrame(0))
+
+			payload := []byte{0xFF}
+			var err error
+			if len(tc.priority) == 0 {
+				err = harq.Send(context.Background(), payload)
+			} else {
+				err = harq.Send(context.Background(), payload, tc.priority[0])
+			}
+
+			if err != nil {
+				t.Errorf("Send() error = %v, want nil", err)
+			}
+
+			sentData := mock.GetSentData()
+			decoder := frame.NewDecoder()
+			f, err := decoder.Decode(sentData[0])
+			if err != nil {
+				t.Fatalf("failed to decode frame: %v", err)
+			}
+
+			flagSet := f.Header.Flags&frame.FlagPriority != 0
+			if flagSet != tc.expectedFlagSet {
+				t.Errorf("%s: FlagPriority=%v, want=%v", tc.description, flagSet, tc.expectedFlagSet)
+			}
+		})
+	}
+}

--- a/star-gateway/internal/service/battery_test.go
+++ b/star-gateway/internal/service/battery_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Locked-Inc/STAR/star-gateway/internal/dispatcher"
+	"github.com/Locked-Inc/STAR/star-gateway/internal/harq"
 	"github.com/Locked-Inc/STAR/star-gateway/internal/testutil"
 	starv1 "github.com/Locked-Inc/star-proto/gen/go/star/v1"
 	"google.golang.org/grpc"
@@ -247,7 +248,7 @@ func TestGetBatteryState_NilRequest(t *testing.T) {
 
 func TestGetBatteryState_HarqFailure(t *testing.T) {
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(_ context.Context, _ []byte) error {
+		SendFunc: func(_ context.Context, _ []byte, _ ...harq.Priority) error {
 			return status.Error(codes.Unavailable, "harq send failure")
 		},
 	}

--- a/star-gateway/internal/service/configuration_test.go
+++ b/star-gateway/internal/service/configuration_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/Locked-Inc/STAR/star-gateway/internal/harq"
 	"github.com/Locked-Inc/STAR/star-gateway/internal/testutil"
 	starv1 "github.com/Locked-Inc/star-proto/gen/go/star/v1"
 	"google.golang.org/grpc/codes"
@@ -128,7 +129,7 @@ func TestGetConfiguration_Success(t *testing.T) {
 
 func TestGetConfiguration_HarqFailure(t *testing.T) {
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(_ context.Context, _ []byte) error {
+		SendFunc: func(_ context.Context, _ []byte, _ ...harq.Priority) error {
 			return status.Error(codes.Unavailable, "harq send failure")
 		},
 	}
@@ -549,7 +550,7 @@ func TestResetToDefaults_Success(t *testing.T) {
 
 func TestResetToDefaults_HarqFailure(t *testing.T) {
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(_ context.Context, _ []byte) error {
+		SendFunc: func(_ context.Context, _ []byte, _ ...harq.Priority) error {
 			return status.Error(codes.Unavailable, "harq send failure")
 		},
 	}
@@ -640,7 +641,7 @@ func TestSaveConfiguration_Success(t *testing.T) {
 
 func TestSaveConfiguration_HarqFailure(t *testing.T) {
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(_ context.Context, _ []byte) error {
+		SendFunc: func(_ context.Context, _ []byte, _ ...harq.Priority) error {
 			return status.Error(codes.Unavailable, "harq send failure")
 		},
 	}
@@ -850,7 +851,7 @@ func TestSetMotorPidConfig_RuntimeUpdate(t *testing.T) {
 		t.Fatalf("failed to marshal save response: %v", err)
 	}
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(_ context.Context, data []byte) error {
+		SendFunc: func(_ context.Context, data []byte, _ ...harq.Priority) error {
 			sentPayloads = append(sentPayloads, data)
 			return nil
 		},

--- a/star-gateway/internal/service/motor_control.go
+++ b/star-gateway/internal/service/motor_control.go
@@ -64,7 +64,8 @@ func (s *MotorControlService) SetVelocity(ctx context.Context, req *starv1.SetVe
 	}
 
 	// 3. Send via HARQ (blocks until ACK or timeout/max retries)
-	if err := s.harqHandler.Send(ctx, payload); err != nil {
+	// Note: Using normal priority for standard velocity commands.
+	if err := s.harqHandler.Send(ctx, payload, harq.PriorityNormal); err != nil {
 		s.logger.Error("failed to send velocity command",
 			slog.String("request_id", req.Header.GetRequestId()),
 			slog.String("error", err.Error()))
@@ -109,7 +110,9 @@ func (s *MotorControlService) EmergencyStop(ctx context.Context, req *starv1.Eme
 		return nil, status.Errorf(codes.Internal, "failed to marshal estop command: %v", err)
 	}
 
-	if err := s.harqHandler.Send(ctx, payload); err != nil {
+	// Send via HARQ with emergency priority
+	// Note: Using high priority for emergency stop commands.
+	if err := s.harqHandler.Send(ctx, payload, harq.PriorityEmergency); err != nil {
 		s.logger.Error("failed to send emergency stop command",
 			slog.String("request_id", req.Header.GetRequestId()),
 			slog.String("reason", req.Reason),
@@ -286,7 +289,7 @@ func (s *MotorControlService) forwardVelocityCommand(ctx context.Context, cmd *s
 		return err
 	}
 
-	return s.harqHandler.Send(ctx, payload)
+	return s.harqHandler.Send(ctx, payload, harq.PriorityNormal)
 }
 
 // sendTelemetryLoop receives telemetry from Dispatcher and sends encoder feedback to client.

--- a/star-gateway/internal/service/motor_control_test.go
+++ b/star-gateway/internal/service/motor_control_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Locked-Inc/STAR/star-gateway/internal/dispatcher"
+	"github.com/Locked-Inc/STAR/star-gateway/internal/harq"
 	"github.com/Locked-Inc/STAR/star-gateway/internal/testutil"
 	starv1 "github.com/Locked-Inc/star-proto/gen/go/star/v1"
 	"google.golang.org/grpc"
@@ -67,7 +68,7 @@ func TestSetVelocity(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			mockHARQ := &testutil.MockHARQ{
-				SendFunc: func(ctx context.Context, data []byte) error {
+				SendFunc: func(ctx context.Context, data []byte, _ ...harq.Priority) error {
 					return tc.mockSendErr
 				},
 			}
@@ -416,7 +417,7 @@ func TestControlStream_BasicFlow(t *testing.T) {
 	var mu sync.Mutex
 
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(ctx context.Context, data []byte) error {
+		SendFunc: func(ctx context.Context, data []byte, _ ...harq.Priority) error {
 			mu.Lock()
 			sendCalls++
 			mu.Unlock()
@@ -506,7 +507,7 @@ func TestControlStream_HarqSendError(t *testing.T) {
 
 	// Mock HARQ that fails to send
 	mockHARQ := &testutil.MockHARQ{
-		SendFunc: func(ctx context.Context, data []byte) error {
+		SendFunc: func(ctx context.Context, data []byte, _ ...harq.Priority) error {
 			return errors.New("send failed")
 		},
 		ReceiveFunc: func(ctx context.Context) ([]byte, error) {

--- a/star-gateway/internal/testutil/mocks.go
+++ b/star-gateway/internal/testutil/mocks.go
@@ -9,27 +9,37 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/Locked-Inc/STAR/star-gateway/internal/dispatcher"
 	"github.com/Locked-Inc/STAR/star-gateway/internal/harq"
 	starv1 "github.com/Locked-Inc/star-proto/gen/go/star/v1"
 )
 
+const (
+	// DefaultHARQTimeout is the default timeout for mock HARQ receive operations.
+	DefaultHARQTimeout = 50 * time.Millisecond
+)
+
 // MockHARQ is a mock implementation of the harq.HARQ interface.
 type MockHARQ struct {
-	SendFunc        func(ctx context.Context, data []byte) error
+	SendFunc        func(ctx context.Context, data []byte, p ...harq.Priority) error
 	ReceiveFunc     func(ctx context.Context) ([]byte, error)
 	GetStateFunc    func() harq.State
 	GetTxSeqFunc    func() uint16
 	GetRxSeqFunc    func() uint16
 	ResetFunc       func()
 	LastSentPayload []byte
+
+	// ReceiveChan is an optional channel for simulating HARQ receive operations.
+	// If set, Receive will pull from this channel instead of calling ReceiveFunc.
+	ReceiveChan chan []byte
 }
 
-func (m *MockHARQ) Send(ctx context.Context, data []byte) error {
+func (m *MockHARQ) Send(ctx context.Context, data []byte, p ...harq.Priority) error {
 	m.LastSentPayload = data
 	if m.SendFunc != nil {
-		return m.SendFunc(ctx, data)
+		return m.SendFunc(ctx, data, p...)
 	}
 	return nil
 }
@@ -37,6 +47,16 @@ func (m *MockHARQ) Send(ctx context.Context, data []byte) error {
 func (m *MockHARQ) Receive(ctx context.Context) ([]byte, error) {
 	if m.ReceiveFunc != nil {
 		return m.ReceiveFunc(ctx)
+	}
+	if m.ReceiveChan != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case data := <-m.ReceiveChan:
+			return data, nil
+		case <-time.After(DefaultHARQTimeout):
+			return nil, harq.ErrTimeout
+		}
 	}
 	return nil, errors.New("receive not implemented")
 }


### PR DESCRIPTION
Resolves https://github.com/Locked-Inc/STAR/issues/176

## Summary

This PR re-introduces the changes for priority-based message transmission in the HARQ layer.

### New Features
* Introduced priority-based message transmission (Emergency, High, Normal) and defaulting behavior.
* Emergency stop and velocity commands now send with appropriate priorities.
* Test utilities enhanced with mock receive channel and default timeout for HARQ simulation.

### Bug Fixes
* Improved error handling for context timeouts and cancellations across send/ack flows.

### Tests
* Updated tests and mocks to support optional priority parameters in send calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added priority-based HARQ transmissions (Emergency, High, Normal) for prioritized messaging.

* **Improvements**
  * Priority now propagates through the transmission pipeline and affects frame/header flags and retransmit behavior.
  * Improved use of context deadline/cancellation checks.

* **Tests**
  * Updated tests and mocks to accept optional priority parameters; HARQ mock gained receive-channel support and a default timeout constant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->