### PR TITLE
Update default transport mode to auto

### DIFF
--- a/star-gateway/cmd/star-gateway/main.go
+++ b/star-gateway/cmd/star-gateway/main.go
@@ -14,13 +14,12 @@ func main() {
 	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 
 	config := app.Config{}
-	config.TransportMode = manager.TransportMode(os.Getenv("TRANSPORT_MODE"))
-
-	// Check if the provided transport mode is valid otherwise set to default (ModeAuto)
-	if !config.TransportMode.IsValid() {
-		log.Printf("Invalid TRANSPORT_MODE %q, defaulting to %q", config.TransportMode, manager.ModeAuto)
-		config.TransportMode = manager.ModeAuto
+	// Get transport mode from environment variable, default to auto if not set or invalid
+	mode, err := manager.ParseTransportMode(os.Getenv("TRANSPORT_MODE"))
+	if err != nil {
+		log.Printf("Warning: %v. Defaulting to auto mode.", err)
 	}
+	config.TransportMode = mode
 
 	if val, ok := os.LookupEnv("STAR_SIMULATION_MODE"); ok {
 		var err error

--- a/star-gateway/cmd/star-gateway/main.go
+++ b/star-gateway/cmd/star-gateway/main.go
@@ -15,10 +15,11 @@ func main() {
 
 	config := app.Config{}
 	config.TransportMode = manager.TransportMode(os.Getenv("TRANSPORT_MODE"))
-	if config.TransportMode == "" {
-		// Note: We are keeping SPI-only mode as default, add --transport-mode flag for opt-in USB support:
-		// TODO: Change default to "auto" or "force-usb" once USB support is stable. And before testing on actual hardware.
-		config.TransportMode = manager.ModeForceSPI // Default: no changes
+
+	// Check if the provided transport mode is valid otherwise set to default (ModeAuto)
+	if !config.TransportMode.IsValid() {
+		log.Printf("Invalid TRANSPORT_MODE %q, defaulting to %q", config.TransportMode, manager.ModeAuto)
+		config.TransportMode = manager.ModeAuto
 	}
 
 	if val, ok := os.LookupEnv("STAR_SIMULATION_MODE"); ok {

--- a/star-gateway/internal/app/gateway.go
+++ b/star-gateway/internal/app/gateway.go
@@ -63,8 +63,8 @@ type Shutdownable interface {
 type Config struct {
 	SimulationMode bool
 	SocketPath     string
-	TransportMode  manager.TransportMode
 	// "auto", "prefer-usb", "force-usb", "force-spi"
+	TransportMode manager.TransportMode
 }
 
 // Run starts the gateway application.

--- a/star-gateway/internal/manager/manager_test.go
+++ b/star-gateway/internal/manager/manager_test.go
@@ -105,53 +105,65 @@ func TestTransportManager_ParseTransportMode(t *testing.T) {
 		name     string
 		input    string
 		wantMode TransportMode
+		wantErr  bool
 	}{
 		{
 			name:     "valid mode auto",
 			input:    "auto",
 			wantMode: ModeAuto,
+			wantErr:  false,
 		},
 		{
 			name:     "valid mode prefer-usb",
 			input:    "prefer-usb",
 			wantMode: ModePreferUSB,
+			wantErr:  false,
 		},
 		{
 			name:     "valid mode force-usb",
 			input:    "force-usb",
 			wantMode: ModeForceUSB,
+			wantErr:  false,
 		},
 		{
 			name:     "valid mode force-spi",
 			input:    "force-spi",
 			wantMode: ModeForceSPI,
+			wantErr:  false,
 		},
 		{
-			name:     "invalid mode defaults to auto",
+			name:     "invalid mode returns error",
 			input:    "invalid",
 			wantMode: ModeAuto,
+			wantErr:  true,
 		},
 		{
-			name:     "empty string defaults to auto",
+			name:     "empty string returns error",
 			input:    "",
 			wantMode: ModeAuto,
+			wantErr:  true,
 		},
 		{
 			name:     "case-insensitive mode",
 			input:    "PrEfEr-UsB",
 			wantMode: ModePreferUSB,
+			wantErr:  false,
 		},
 		{
-			name:     "numerical string defaults to auto",
+			name:     "numerical string returns error",
 			input:    "123",
 			wantMode: ModeAuto,
+			wantErr:  true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := ParseTransportMode(tt.input)
-			if got != tt.wantMode {
+			got, err := ParseTransportMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseTransportMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.wantMode {
 				t.Errorf("ParseTransportMode(%q) = %v, want %v", tt.input, got, tt.wantMode)
 			}
 		})

--- a/star-gateway/internal/manager/manager_test.go
+++ b/star-gateway/internal/manager/manager_test.go
@@ -45,6 +45,119 @@ func TestTransportManager_Lifecycle(t *testing.T) {
 	}
 }
 
+func TestTransportManager_CheckValidTransportMode(t *testing.T) {
+	tests := []struct {
+		name          string
+		transportmode TransportMode
+		wantValid     bool
+	}{
+		{
+			name:          "ModeAuto is valid",
+			transportmode: ModeAuto,
+			wantValid:     true,
+		},
+		{
+			name:          "ModePreferUSB is valid",
+			transportmode: ModePreferUSB,
+			wantValid:     true,
+		},
+		{
+			name:          "ModeForceUSB is valid",
+			transportmode: ModeForceUSB,
+			wantValid:     true,
+		},
+		{
+			name:          "ModeForceSPI is valid",
+			transportmode: ModeForceSPI,
+			wantValid:     true,
+		},
+		{
+			name:          "empty string defaults to auto",
+			transportmode: "",
+			wantValid:     false, // empty string is not valid, but should be handled by ParseTransportMode
+		},
+		{
+			name:          "invalid mode is not valid",
+			transportmode: "invalid",
+			wantValid:     false,
+		},
+		{
+
+			name:          "invalid numeral string",
+			transportmode: "123",
+			wantValid:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := DefaultConfig()
+			config.Mode = tt.transportmode
+			if got := config.Mode.IsValid(); got != tt.wantValid {
+				t.Errorf("IsValid() = %v, want %v", got, tt.wantValid)
+			}
+		})
+	}
+}
+
+func TestTransportManager_ParseTransportMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantMode TransportMode
+	}{
+		{
+			name:     "valid mode auto",
+			input:    "auto",
+			wantMode: ModeAuto,
+		},
+		{
+			name:     "valid mode prefer-usb",
+			input:    "prefer-usb",
+			wantMode: ModePreferUSB,
+		},
+		{
+			name:     "valid mode force-usb",
+			input:    "force-usb",
+			wantMode: ModeForceUSB,
+		},
+		{
+			name:     "valid mode force-spi",
+			input:    "force-spi",
+			wantMode: ModeForceSPI,
+		},
+		{
+			name:     "invalid mode defaults to auto",
+			input:    "invalid",
+			wantMode: ModeAuto,
+		},
+		{
+			name:     "empty string defaults to auto",
+			input:    "",
+			wantMode: ModeAuto,
+		},
+		{
+			name:     "case-insensitive mode",
+			input:    "PrEfEr-UsB",
+			wantMode: ModePreferUSB,
+		},
+		{
+			name:     "numerical string defaults to auto",
+			input:    "123",
+			wantMode: ModeAuto,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := ParseTransportMode(tt.input)
+			if got != tt.wantMode {
+				t.Errorf("ParseTransportMode(%q) = %v, want %v", tt.input, got, tt.wantMode)
+			}
+		})
+	}
+}
+
 func TestTransportManager_RegisterAndSelect(t *testing.T) {
 	config := DefaultConfig()
 	tm := NewTransportManager(config)

--- a/star-gateway/internal/manager/manager_test.go
+++ b/star-gateway/internal/manager/manager_test.go
@@ -72,7 +72,7 @@ func TestTransportManager_CheckValidTransportMode(t *testing.T) {
 			wantValid:     true,
 		},
 		{
-			name:          "empty string defaults to auto",
+			name:          "empty string is invalid for IsValid",
 			transportmode: "",
 			wantValid:     false, // empty string is not valid, but should be handled by ParseTransportMode
 		},
@@ -82,7 +82,6 @@ func TestTransportManager_CheckValidTransportMode(t *testing.T) {
 			wantValid:     false,
 		},
 		{
-
 			name:          "invalid numeral string",
 			transportmode: "123",
 			wantValid:     false,
@@ -91,9 +90,7 @@ func TestTransportManager_CheckValidTransportMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config := DefaultConfig()
-			config.Mode = tt.transportmode
-			if got := config.Mode.IsValid(); got != tt.wantValid {
+			if got := tt.transportmode.IsValid(); got != tt.wantValid {
 				t.Errorf("IsValid() = %v, want %v", got, tt.wantValid)
 			}
 		})
@@ -163,7 +160,7 @@ func TestTransportManager_ParseTransportMode(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseTransportMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 			}
-			if !tt.wantErr && got != tt.wantMode {
+			if got != tt.wantMode {
 				t.Errorf("ParseTransportMode(%q) = %v, want %v", tt.input, got, tt.wantMode)
 			}
 		})

--- a/star-gateway/internal/manager/types.go
+++ b/star-gateway/internal/manager/types.go
@@ -5,6 +5,8 @@
 package manager
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Locked-Inc/STAR/star-gateway/internal/frame"
@@ -27,6 +29,9 @@ const (
 	// ModeForceSPI only uses SPI transport. USB hot-plug is disabled in this mode.
 	ModeForceSPI TransportMode = "force-spi"
 )
+const (
+	InvalidTransportModeError = "invalid transport mode: %q"
+)
 
 // IsValid checks if the TransportMode is one of the defined constants.
 func (tm TransportMode) IsValid() bool {
@@ -36,6 +41,16 @@ func (tm TransportMode) IsValid() bool {
 	default:
 		return false
 	}
+}
+
+// ParseTransportMode converts a string to a TransportMode. Returns ModeAuto and an error if the input is invalid.
+func ParseTransportMode(s string) (TransportMode, error) {
+	// Normalize input to lowercase for case-insensitive matching
+	mode := TransportMode(strings.ToLower(s))
+	if !mode.IsValid() {
+		return ModeAuto, fmt.Errorf(InvalidTransportModeError, s)
+	}
+	return mode, nil
 }
 
 // State represents the internal state of the TransportManager.

--- a/star-gateway/internal/manager/types.go
+++ b/star-gateway/internal/manager/types.go
@@ -28,6 +28,16 @@ const (
 	ModeForceSPI TransportMode = "force-spi"
 )
 
+// IsValid checks if the TransportMode is one of the defined constants.
+func (tm TransportMode) IsValid() bool {
+	switch tm {
+	case ModeAuto, ModePreferUSB, ModeForceUSB, ModeForceSPI:
+		return true
+	default:
+		return false
+	}
+}
+
 // State represents the internal state of the TransportManager.
 type State uint8
 


### PR DESCRIPTION
Updates the default transport configuration to transition from forced SPI-only mode to automatic detection.

- **Sets the default behavior to auto-detection**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transport mode parsing and validation helpers to standardize and interpret mode inputs.

* **Bug Fixes**
  * Transport mode input is now validated; invalid or empty values log a warning and the system falls back to auto mode.

* **Tests**
  * Added tests covering transport mode parsing, validation, defaulting behavior, and case-insensitive inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->