### PR TITLE
Migrates protocol wire format to little-endian

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -186,6 +186,23 @@ jobs:
       - name: Run go vet
         run: go vet ./...
 
+      - name: Check for BigEndian usage (regression guard)
+        run: |
+          cd star-gateway
+          # Search production code (exclude tests and vendor)
+          if grep -r "binary\.BigEndian" \
+             --include="*.go" \
+             --exclude="*_test.go" \
+             --exclude-dir="vendor" \
+             .; then
+            echo "❌ ERROR: Found binary.BigEndian in production code!"
+            echo "All multi-byte fields must use binary.LittleEndian after endianness migration."
+            echo "See /workspaces/STAR/CLAUDE.md for protocol specification."
+            exit 1
+          fi
+          echo "✅ No BigEndian usage detected (expected after migration)"
+        working-directory: .
+
       - name: Check gofmt
         run: |
           unformatted=$(gofmt -l .)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help:
 	@echo "  make test-rx72n   - Run RX72N unit tests (regenerates protos first)"
 	@echo ""
 	@echo "Protocol Buffers:"
-	@echo "  make proto-gen    - Generate all proto code (Go, TypeScript, C/nanopb)"
+	@echo "  make proto-gen    - Generate all proto code and setup Go modules (Go, TS, C/nanopb)"
 	@echo ""
 	@echo "Persistent Container (optional):"
 	@echo "  make up           - Start a persistent background container named '$(CONTAINER_NAME)'"
@@ -90,6 +90,13 @@ proto-gen-go:
 	@echo "Generating protocol buffers (Go, TS, C, C++)..."
 	@buf generate star-proto/proto
 	@echo "✓ Code generated under star-proto/gen/"
+	@echo "Setting up Go module for generated code..."
+	@if [ ! -f star-proto/gen/go/go.mod ]; then \
+		cd star-proto/gen/go && go mod init github.com/Locked-Inc/star-proto/gen/go; \
+	fi
+	@cd star-proto/gen/go && go mod tidy
+	@go work sync
+	@echo "✓ Go workspace synchronized"
 
 # Placeholder for ROS2-specific generation (if distinct tooling is added)
 proto-gen-ros2:

--- a/star-gateway/HIL_SIMULATION.md
+++ b/star-gateway/HIL_SIMULATION.md
@@ -214,7 +214,7 @@ The Virtual RX72N handles control frames at the transport layer, before any prot
 
 ### PING/PONG Heartbeat
 
-- **Receives:** `FrameTypePing` (0x00) with 4-byte big-endian counter payload
+- **Receives:** `FrameTypePing` (0x00) with 4-byte little-endian counter payload
 - **Responds:** `FrameTypePong` (0x01) echoing the same 4-byte counter
 - Simulated latency (`SIM_LATENCY_MS`) is applied before responding
 

--- a/star-gateway/TRANSPORT_ARCHITECTURE.md
+++ b/star-gateway/TRANSPORT_ARCHITECTURE.md
@@ -90,7 +90,7 @@ The STAR Gateway implements intelligent transport switching between USB CDC (pri
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | SYNC word | `0x55AA` | Both sides agree; standard framing marker |
-| Header byte order | Big-endian (network byte order) | RFC 1700 convention; both sides agree |
+| Header byte order | Little-endian | Consistent with CRC-32; both sides agree |
 | CRC-32 byte order | **Little-endian** (IEEE 802.3 LSB-first) | Industry standard; firmware was correct, Go fixed in Phase 1 |
 | Canonical TYPE values | `0x00/0x01/0x10-0x13/0xFE/0xFF` | Designed for full protocol; firmware aligned in Phase 2 |
 | HARQ type | Chase Combining (Type I) | Implemented end-to-end; Type II is aspirational |
@@ -106,13 +106,13 @@ All frames use the same wire format regardless of transport:
 ```text
 ┌──────┬──────┬──────┬──────┬───────┬─────────┬─────────┐
 │ SYNC │ SEQ  │ LEN  │ TYPE │ FLAGS │ PAYLOAD │ CRC-32  │
-│ (BE) │ (BE) │ (BE) │      │       │         │  (LE)   │
+│ (LE) │ (LE) │ (LE) │      │       │         │  (LE)   │
 ├──────┼──────┼──────┼──────┼───────┼─────────┼─────────┤
 │ 2B   │ 2B   │ 2B   │ 1B   │ 1B    │ 0-1024B │ 4B      │
 └──────┴──────┴──────┴──────┴───────┴─────────┴─────────┘
 ```
 
-**Header Fields (big-endian):**
+**Header Fields (little-endian):**
 - **SYNC**: Magic number `0x55AA` for frame synchronization
 - **SEQ**: Sequence number (0-65535, wraps around)
 - **LEN**: Payload length in bytes
@@ -147,7 +147,7 @@ const (
 
 **PING Frame:**
 - **TYPE**: `0x00`
-- **PAYLOAD**: 4-byte counter (big-endian uint32)
+- **PAYLOAD**: 4-byte counter (little-endian uint32)
 - **Purpose**: Explicit idle-link probe when no frames for >1s
 
 **PONG Frame:**

--- a/star-gateway/cmd/virtual_rx72n/control_frames_test.go
+++ b/star-gateway/cmd/virtual_rx72n/control_frames_test.go
@@ -23,7 +23,7 @@ const (
 func newTestPingFrame(t *testing.T, counter uint32, seq uint16) *frame.Frame {
 	t.Helper()
 	payload := make([]byte, PingPayloadSize)
-	binary.BigEndian.PutUint32(payload, counter)
+	binary.LittleEndian.PutUint32(payload, counter)
 	f, err := frame.NewFrame(frame.FrameTypePing, payload)
 	if err != nil {
 		t.Fatalf("failed to create PING frame: %v", err)
@@ -40,7 +40,7 @@ func newTestResetFrame(t *testing.T, seq uint16, sessionID ...uint32) *frame.Fra
 	var payload []byte
 	if len(sessionID) > 0 {
 		payload = make([]byte, sessionIDPayloadSize)
-		binary.BigEndian.PutUint32(payload, sessionID[0])
+		binary.LittleEndian.PutUint32(payload, sessionID[0])
 	} else {
 		payload = []byte{}
 	}
@@ -85,7 +85,7 @@ func TestHandleFrame_PingPong(t *testing.T) {
 				t.Fatalf("PONG payload size = %d, want %d", len(pong.Payload), PingPayloadSize)
 			}
 
-			gotCounter := binary.BigEndian.Uint32(pong.Payload)
+			gotCounter := binary.LittleEndian.Uint32(pong.Payload)
 			if gotCounter != tc.wantPongCounter {
 				t.Errorf("PONG counter = %d, want %d", gotCounter, tc.wantPongCounter)
 			}
@@ -151,7 +151,7 @@ func TestHandleFrame_ResetResetAck(t *testing.T) {
 	if len(resetAck.Payload) != sessionIDPayloadSize {
 		t.Fatalf("RESET_ACK payload len = %d, want %d", len(resetAck.Payload), sessionIDPayloadSize)
 	}
-	gotSessionID := binary.BigEndian.Uint32(resetAck.Payload)
+	gotSessionID := binary.LittleEndian.Uint32(resetAck.Payload)
 	if gotSessionID != testSessionID {
 		t.Errorf("RESET_ACK session ID = %d, want %d", gotSessionID, testSessionID)
 	}
@@ -219,7 +219,7 @@ func TestHandleFrame_ResetSessionIDEcho(t *testing.T) {
 				t.Fatalf("RESET_ACK payload len = %d, want %d", len(resetAck.Payload), sessionIDPayloadSize)
 			}
 
-			gotID := binary.BigEndian.Uint32(resetAck.Payload)
+			gotID := binary.LittleEndian.Uint32(resetAck.Payload)
 			if gotID != tc.sessionID {
 				t.Errorf("RESET_ACK session ID = %d, want %d", gotID, tc.sessionID)
 			}
@@ -301,7 +301,7 @@ func TestHandleFrame_PingWithAckFlag(t *testing.T) {
 		t.Errorf("PONG sequence = %d, want 0", resp.frames[1].Header.Sequence)
 	}
 
-	gotCounter := binary.BigEndian.Uint32(resp.frames[1].Payload)
+	gotCounter := binary.LittleEndian.Uint32(resp.frames[1].Payload)
 	if gotCounter != testPingCounter {
 		t.Errorf("PONG counter = %d, want %d", gotCounter, testPingCounter)
 	}

--- a/star-gateway/cmd/virtual_rx72n/main.go
+++ b/star-gateway/cmd/virtual_rx72n/main.go
@@ -51,7 +51,7 @@ const (
 	// readDeadlineTimeout is the timeout for socket read operations.
 	readDeadlineTimeout = 1 * time.Second
 
-	// PingPayloadSize is the expected payload size for PING frames (4-byte big-endian counter).
+	// PingPayloadSize is the expected payload size for PING frames (4-byte little-endian counter).
 	PingPayloadSize = 4
 
 	// DefaultSimLatencyMs is the default simulated processing latency in milliseconds.
@@ -348,12 +348,12 @@ func handlePing(decoded *frame.Frame, session *simulatorSession, latency time.Du
 		time.Sleep(latency)
 	}
 
-	counter := binary.BigEndian.Uint32(decoded.Payload)
+	counter := binary.LittleEndian.Uint32(decoded.Payload)
 	log.Printf("PING received (counter=%d), sending PONG", counter)
 
 	// Echo the same 4-byte counter in PONG
 	pongPayload := make([]byte, PingPayloadSize)
-	binary.BigEndian.PutUint32(pongPayload, counter)
+	binary.LittleEndian.PutUint32(pongPayload, counter)
 
 	pongFrame := &frame.Frame{
 		Header: frame.Header{
@@ -373,7 +373,7 @@ func handlePing(decoded *frame.Frame, session *simulatorSession, latency time.Du
 const sessionIDPayloadSize = 4
 
 // handleReset responds to a RESET frame with RESET_ACK and resets session state.
-// If the RESET frame carries a session ID (4-byte big-endian payload), it is echoed
+// If the RESET frame carries a session ID (4-byte little-endian payload), it is echoed
 // back in the RESET_ACK payload for the gateway to match the handshake.
 // RESET_ACK is built with the current sequence, then session state is reset.
 // Applies simulated latency before generating the response.
@@ -391,10 +391,10 @@ func handleReset(decoded *frame.Frame, session *simulatorSession, latency time.D
 		log.Printf("RESET received (no session ID), sending RESET_ACK")
 		resetAckPayload = []byte{}
 	} else if len(decoded.Payload) == sessionIDPayloadSize {
-		sessionID := binary.BigEndian.Uint32(decoded.Payload[:sessionIDPayloadSize])
+		sessionID := binary.LittleEndian.Uint32(decoded.Payload[:sessionIDPayloadSize])
 		log.Printf("RESET received (session=%d), sending RESET_ACK", sessionID)
 		resetAckPayload = make([]byte, sessionIDPayloadSize)
-		binary.BigEndian.PutUint32(resetAckPayload, sessionID)
+		binary.LittleEndian.PutUint32(resetAckPayload, sessionID)
 	} else {
 		log.Printf("RESET payload length protocol error: got %d, expected 0 or %d; dropping frame", len(decoded.Payload), sessionIDPayloadSize)
 		return frameResponse{frames: existing}

--- a/star-gateway/internal/frame/decoder.go
+++ b/star-gateway/internal/frame/decoder.go
@@ -25,7 +25,7 @@ func NewDecoder() *DefaultDecoder {
 
 // Decode parses wire format bytes into a Frame.
 //
-// Wire format (header fields in big-endian, CRC-32 in little-endian per IEEE 802.3):
+// Wire format (all fields in little-endian per IEEE 802.3):
 //
 //	[SYNC (2B)][SEQ (2B)][LEN (2B)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B)]
 //
@@ -38,19 +38,19 @@ func (d *DefaultDecoder) Decode(data []byte) (*Frame, error) {
 
 	offset := 0
 
-	// Parse and verify SYNC word (big-endian)
-	sync := binary.BigEndian.Uint16(data[offset:])
+	// Parse and verify SYNC word (little-endian)
+	sync := binary.LittleEndian.Uint16(data[offset:])
 	if sync != SyncWord {
 		return nil, ErrInvalidSync
 	}
 	offset += SyncSize
 
-	// Parse SEQ (big-endian)
-	seq := binary.BigEndian.Uint16(data[offset:])
+	// Parse SEQ (little-endian)
+	seq := binary.LittleEndian.Uint16(data[offset:])
 	offset += SeqSize
 
-	// Parse LEN (big-endian)
-	payloadLen := binary.BigEndian.Uint16(data[offset:])
+	// Parse LEN (little-endian)
+	payloadLen := binary.LittleEndian.Uint16(data[offset:])
 	offset += LenSize
 
 	// Validate payload length

--- a/star-gateway/internal/frame/decoder_test.go
+++ b/star-gateway/internal/frame/decoder_test.go
@@ -93,7 +93,7 @@ func TestDecoder_Decode(t *testing.T) {
 			input: func() []byte {
 				data := createEncodedFrame(t, FrameTypeCommand, 1, FlagNone, []byte{})
 				// Set length field to MaxPayloadSize + 1
-				binary.BigEndian.PutUint16(data[4:6], uint16(MaxPayloadSize+1))
+				binary.LittleEndian.PutUint16(data[4:6], uint16(MaxPayloadSize+1))
 				return data
 			}(),
 			expectError: ErrPayloadTooLarge,

--- a/star-gateway/internal/frame/encoder.go
+++ b/star-gateway/internal/frame/encoder.go
@@ -25,11 +25,15 @@ func NewEncoder() *DefaultEncoder {
 
 // Encode serializes a Frame into wire format bytes.
 //
-// Wire format (all fields in little-endian per IEEE 802.3):
+// Wire format:
 //
 //	[SYNC (2B)][SEQ (2B)][LEN (2B)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B)]
 //
-// CRC-32 is calculated over SYNC + Header + Payload.
+// Header fields (SYNC, SEQ, LEN, TYPE, FLAGS) are encoded in little-endian
+// by project choice for consistency across platforms.
+//
+// CRC-32 uses the IEEE 802.3 polynomial (0xEDB88320) with bit/byte ordering
+// as defined by the standard. The CRC is calculated over SYNC + Header + Payload.
 func (e *DefaultEncoder) Encode(frame *Frame) ([]byte, error) {
 	// Validate payload size
 	if len(frame.Payload) > MaxPayloadSize {

--- a/star-gateway/internal/frame/encoder.go
+++ b/star-gateway/internal/frame/encoder.go
@@ -25,7 +25,7 @@ func NewEncoder() *DefaultEncoder {
 
 // Encode serializes a Frame into wire format bytes.
 //
-// Wire format (header fields in big-endian, CRC-32 in little-endian per IEEE 802.3):
+// Wire format (all fields in little-endian per IEEE 802.3):
 //
 //	[SYNC (2B)][SEQ (2B)][LEN (2B)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B)]
 //
@@ -41,16 +41,16 @@ func (e *DefaultEncoder) Encode(frame *Frame) ([]byte, error) {
 	buf := make([]byte, frameSize)
 	offset := 0
 
-	// Write SYNC word (big-endian)
-	binary.BigEndian.PutUint16(buf[offset:], SyncWord)
+	// Write SYNC word (little-endian)
+	binary.LittleEndian.PutUint16(buf[offset:], SyncWord)
 	offset += SyncSize
 
-	// Write SEQ (big-endian)
-	binary.BigEndian.PutUint16(buf[offset:], frame.Header.Sequence)
+	// Write SEQ (little-endian)
+	binary.LittleEndian.PutUint16(buf[offset:], frame.Header.Sequence)
 	offset += SeqSize
 
-	// Write LEN (big-endian)
-	binary.BigEndian.PutUint16(buf[offset:], frame.Header.Length)
+	// Write LEN (little-endian)
+	binary.LittleEndian.PutUint16(buf[offset:], frame.Header.Length)
 	offset += LenSize
 
 	// Write TYPE (1 byte) - Explicit field

--- a/star-gateway/internal/frame/frame.go
+++ b/star-gateway/internal/frame/frame.go
@@ -1,8 +1,12 @@
 // Package frame defines the wire protocol frame structure for RPi5 <-> RX72N communication.
 //
-// Frame format (all fields little-endian per IEEE 802.3):
+// Frame format:
 //
-//	[SYNC (2B, LE)][SEQ (2B, LE)][LEN (2B, LE)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B, LE)]
+//	[SYNC (2B, LE)][SEQ (2B, LE)][LEN (2B, LE)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B)]
+//
+// All multi-byte header fields (SYNC, SEQ, LEN) are little-endian by project convention.
+// The CRC-32 uses the IEEE 802.3 polynomial and bit-ordering (CRC byte serialization
+// is independent of the project's multi-byte field endianness).
 //
 // STAR Project - Texas A&M University
 // January 2026

--- a/star-gateway/internal/frame/frame.go
+++ b/star-gateway/internal/frame/frame.go
@@ -1,8 +1,8 @@
 // Package frame defines the wire protocol frame structure for RPi5 <-> RX72N communication.
 //
-// Frame format (header fields big-endian, CRC-32 little-endian per IEEE 802.3):
+// Frame format (all fields little-endian per IEEE 802.3):
 //
-//	[SYNC (2B, BE)][SEQ (2B, BE)][LEN (2B, BE)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B, LE)]
+//	[SYNC (2B, LE)][SEQ (2B, LE)][LEN (2B, LE)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B, LE)]
 //
 // STAR Project - Texas A&M University
 // January 2026

--- a/star-gateway/internal/frame/frame.go
+++ b/star-gateway/internal/frame/frame.go
@@ -5,8 +5,8 @@
 //	[SYNC (2B, LE)][SEQ (2B, LE)][LEN (2B, LE)][TYPE (1B)][FLAGS (1B)][PAYLOAD (0-1KB)][CRC-32 (4B)]
 //
 // All multi-byte header fields (SYNC, SEQ, LEN) are little-endian by project convention.
-// The CRC-32 uses the IEEE 802.3 polynomial and bit-ordering (CRC byte serialization
-// is independent of the project's multi-byte field endianness).
+// The CRC-32 uses the IEEE 802.3 polynomial and bit-ordering; the resulting 32-bit
+// CRC value is serialized in little-endian to match the header field convention.
 //
 // STAR Project - Texas A&M University
 // January 2026

--- a/star-gateway/internal/frame/frame_test.go
+++ b/star-gateway/internal/frame/frame_test.go
@@ -80,8 +80,8 @@ func TestEncoderEncode(t *testing.T) {
 				t.Errorf("encoded size = %d, want %d", len(encoded), expectedSize)
 			}
 
-			// Verify SYNC word (big-endian)
-			sync := binary.BigEndian.Uint16(encoded[0:2])
+			// Verify SYNC word (little-endian)
+			sync := binary.LittleEndian.Uint16(encoded[0:2])
 			if sync != SyncWord {
 				t.Errorf("SYNC = 0x%04X, want 0x%04X", sync, SyncWord)
 			}
@@ -116,12 +116,12 @@ func TestEncoderByteOrder(t *testing.T) {
 			seq:     0x1234,
 			payload: []byte{0x01},
 			checks: []byteCheck{
-				{offset: 0, expected: 0x55, desc: "SYNC high"},
-				{offset: 1, expected: 0xAA, desc: "SYNC low"},
-				{offset: 2, expected: 0x12, desc: "SEQ high"},
-				{offset: 3, expected: 0x34, desc: "SEQ low"},
-				{offset: 4, expected: 0x00, desc: "LEN high"},
-				{offset: 5, expected: 0x01, desc: "LEN low"},
+				{offset: 0, expected: 0xAA, desc: "SYNC low"}, // Little-endian: low byte first
+				{offset: 1, expected: 0x55, desc: "SYNC high"},
+				{offset: 2, expected: 0x34, desc: "SEQ low"}, // Little-endian: 0x1234 = [0x34, 0x12]
+				{offset: 3, expected: 0x12, desc: "SEQ high"},
+				{offset: 4, expected: 0x01, desc: "LEN low"}, // Little-endian: 0x0001 = [0x01, 0x00]
+				{offset: 5, expected: 0x00, desc: "LEN high"},
 				{offset: 6, expected: 0x10, desc: "TYPE (Command)"},
 				{offset: 7, expected: 0x00, desc: "FLAGS"},
 			},
@@ -184,6 +184,7 @@ type crossVector struct {
 
 // crossCompatibilityVectors returns the canonical test vectors shared with C firmware.
 // Any change to these vectors MUST be mirrored in test_rx_frame.c.
+// All multi-byte fields (SYNC, SEQ, LEN) use little-endian byte order.
 func crossCompatibilityVectors() []crossVector {
 	return []crossVector{
 		{
@@ -193,12 +194,12 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagNone,
 			payload:   nil,
 			wire: []byte{
-				0x55, 0xAA, // SYNC
+				0xAA, 0x55, // SYNC (little-endian)
 				0x00, 0x00, // SEQ=0
 				0x00, 0x00, // LEN=0
 				0x00,                   // TYPE=PING
 				0x00,                   // FLAGS=none
-				0xEB, 0xAE, 0x3F, 0x9B, // CRC-32 LE = 0x9B3FAEEB
+				0x3D, 0xE2, 0x42, 0x2F, // CRC-32 LE = 0x2F42E23D
 			},
 		},
 		{
@@ -206,15 +207,15 @@ func crossCompatibilityVectors() []crossVector {
 			frameType: FrameTypePong,
 			seq:       0,
 			flags:     FlagNone,
-			payload:   []byte{0x00, 0x00, 0x00, 0x2A}, // counter=42 big-endian
+			payload:   []byte{0x00, 0x00, 0x00, 0x2A}, // counter=42 (payload bytes unchanged)
 			wire: []byte{
-				0x55, 0xAA, // SYNC
+				0xAA, 0x55, // SYNC (little-endian)
 				0x00, 0x00, // SEQ=0
-				0x00, 0x04, // LEN=4
+				0x04, 0x00, // LEN=4 (little-endian)
 				0x01,                   // TYPE=PONG
 				0x00,                   // FLAGS=none
 				0x00, 0x00, 0x00, 0x2A, // PAYLOAD
-				0xDF, 0x37, 0x77, 0x28, // CRC-32 LE = 0x287737DF
+				0xF9, 0xFF, 0x50, 0x74, // CRC-32 LE = 0x7450FFF9
 			},
 		},
 		{
@@ -224,13 +225,13 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagRequiresAck,
 			payload:   []byte{0x54, 0x45, 0x53, 0x54}, // "TEST"
 			wire: []byte{
-				0x55, 0xAA, // SYNC
-				0x00, 0x01, // SEQ=1
-				0x00, 0x04, // LEN=4
+				0xAA, 0x55, // SYNC (little-endian)
+				0x01, 0x00, // SEQ=1 (little-endian)
+				0x04, 0x00, // LEN=4 (little-endian)
 				0x10,                   // TYPE=COMMAND
 				0x01,                   // FLAGS=REQUIRES_ACK
 				0x54, 0x45, 0x53, 0x54, // PAYLOAD="TEST"
-				0x60, 0x5E, 0xF3, 0xDE, // CRC-32 LE = 0xDEF35E60
+				0x3B, 0xE9, 0x6D, 0x7A, // CRC-32 LE = 0x7A6DE93B
 			},
 		},
 		{
@@ -240,13 +241,13 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagNone,
 			payload:   []byte{0x4F, 0x4B}, // "OK"
 			wire: []byte{
-				0x55, 0xAA, // SYNC
-				0x00, 0x01, // SEQ=1
-				0x00, 0x02, // LEN=2
+				0xAA, 0x55, // SYNC (little-endian)
+				0x01, 0x00, // SEQ=1 (little-endian)
+				0x02, 0x00, // LEN=2 (little-endian)
 				0x11,       // TYPE=RESPONSE
 				0x00,       // FLAGS=none
 				0x4F, 0x4B, // PAYLOAD="OK"
-				0xF4, 0x8E, 0xC0, 0x6F, // CRC-32 LE = 0x6FC08EF4
+				0xEA, 0xAC, 0x1D, 0x9A, // CRC-32 LE = 0x9A1DACEA
 			},
 		},
 		{
@@ -256,12 +257,12 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagNone,
 			payload:   nil,
 			wire: []byte{
-				0x55, 0xAA, // SYNC
-				0x00, 0x01, // SEQ=1
+				0xAA, 0x55, // SYNC (little-endian)
+				0x01, 0x00, // SEQ=1 (little-endian)
 				0x00, 0x00, // LEN=0
 				0x12,                   // TYPE=ACK
 				0x00,                   // FLAGS=none
-				0x88, 0xF7, 0xAB, 0xDE, // CRC-32 LE = 0xDEABF788
+				0x4B, 0x41, 0xEA, 0x9C, // CRC-32 LE = 0x9CEA414B
 			},
 		},
 		{
@@ -271,12 +272,12 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagNone,
 			payload:   nil,
 			wire: []byte{
-				0x55, 0xAA, // SYNC
-				0x00, 0x01, // SEQ=1
+				0xAA, 0x55, // SYNC (little-endian)
+				0x01, 0x00, // SEQ=1 (little-endian)
 				0x00, 0x00, // LEN=0
 				0x13,                   // TYPE=NACK
 				0x00,                   // FLAGS=none
-				0xC9, 0xC6, 0xB0, 0xC7, // CRC-32 LE = 0xC7B0C6C9
+				0x0A, 0x70, 0xF1, 0x85, // CRC-32 LE = 0x85F1700A
 			},
 		},
 		{
@@ -286,12 +287,12 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagNone,
 			payload:   nil,
 			wire: []byte{
-				0x55, 0xAA, // SYNC
+				0xAA, 0x55, // SYNC (little-endian)
 				0x00, 0x00, // SEQ=0
 				0x00, 0x00, // LEN=0
 				0xFF,                   // TYPE=RESET
 				0x00,                   // FLAGS=none
-				0x99, 0x53, 0x1B, 0x08, // CRC-32 LE = 0x081B5399
+				0x4F, 0x1F, 0x66, 0xBC, // CRC-32 LE = 0xBC661F4F
 			},
 		},
 		{
@@ -301,12 +302,12 @@ func crossCompatibilityVectors() []crossVector {
 			flags:     FlagNone,
 			payload:   nil,
 			wire: []byte{
-				0x55, 0xAA, // SYNC
+				0xAA, 0x55, // SYNC (little-endian)
 				0x00, 0x00, // SEQ=0
 				0x00, 0x00, // LEN=0
 				0xFE,                   // TYPE=RESET_ACK
 				0x00,                   // FLAGS=none
-				0xD8, 0x62, 0x00, 0x11, // CRC-32 LE = 0x110062D8
+				0x0E, 0x2E, 0x7D, 0xA5, // CRC-32 LE = 0xA57D2E0E
 			},
 		},
 	}

--- a/star-gateway/internal/frame/frame_test.go
+++ b/star-gateway/internal/frame/frame_test.go
@@ -207,15 +207,15 @@ func crossCompatibilityVectors() []crossVector {
 			frameType: FrameTypePong,
 			seq:       0,
 			flags:     FlagNone,
-			payload:   []byte{0x00, 0x00, 0x00, 0x2A}, // counter=42 (payload bytes unchanged)
+			payload:   []byte{0x2A, 0x00, 0x00, 0x00}, // counter=42 (little-endian)
 			wire: []byte{
 				0xAA, 0x55, // SYNC (little-endian)
 				0x00, 0x00, // SEQ=0
 				0x04, 0x00, // LEN=4 (little-endian)
 				0x01,                   // TYPE=PONG
 				0x00,                   // FLAGS=none
-				0x00, 0x00, 0x00, 0x2A, // PAYLOAD
-				0xF9, 0xFF, 0x50, 0x74, // CRC-32 LE = 0x7450FFF9
+				0x2A, 0x00, 0x00, 0x00, // PAYLOAD (little-endian)
+				0x75, 0x79, 0x64, 0x60, // CRC-32 LE = 0x60647975
 			},
 		},
 		{

--- a/star-gateway/internal/frame/stream_decoder.go
+++ b/star-gateway/internal/frame/stream_decoder.go
@@ -70,7 +70,7 @@ func (d *StreamDecoder) Decode() (*Frame, error) {
 			return nil, err
 		}
 
-		syncCandidate := binary.BigEndian.Uint16(peekBuf)
+		syncCandidate := binary.LittleEndian.Uint16(peekBuf)
 		if syncCandidate != SyncWord {
 			// Discard 1 byte and retry
 			if _, err := d.r.Discard(1); err != nil {
@@ -95,8 +95,8 @@ func (d *StreamDecoder) Decode() (*Frame, error) {
 		}
 
 		// Parse Header
-		seq := binary.BigEndian.Uint16(headerBuf[seqOffset : seqOffset+2])
-		payloadLen := binary.BigEndian.Uint16(headerBuf[lenOffset : lenOffset+2])
+		seq := binary.LittleEndian.Uint16(headerBuf[seqOffset : seqOffset+2])
+		payloadLen := binary.LittleEndian.Uint16(headerBuf[lenOffset : lenOffset+2])
 		frameType := Type(headerBuf[typeOffset])
 		flags := Flags(headerBuf[flagsOffset])
 
@@ -118,7 +118,7 @@ func (d *StreamDecoder) Decode() (*Frame, error) {
 		totalRemaining := HeaderSize + int(payloadLen) + CRCSize
 
 		frameBuf := make([]byte, SyncSize+totalRemaining)
-		binary.BigEndian.PutUint16(frameBuf[0:], SyncWord) // Reconstruct SYNC
+		binary.LittleEndian.PutUint16(frameBuf[0:], SyncWord) // Reconstruct SYNC
 
 		// Read the rest
 		_, err = io.ReadFull(d.r, frameBuf[SyncSize:])

--- a/star-gateway/internal/frame/stream_decoder_test.go
+++ b/star-gateway/internal/frame/stream_decoder_test.go
@@ -15,15 +15,15 @@ func buildTestFrame(seq uint16, flags Flags, payload []byte) []byte {
 	offset := 0
 
 	// SYNC
-	binary.BigEndian.PutUint16(buf[offset:], SyncWord)
+	binary.LittleEndian.PutUint16(buf[offset:], SyncWord)
 	offset += 2
 
 	// SEQ
-	binary.BigEndian.PutUint16(buf[offset:], seq)
+	binary.LittleEndian.PutUint16(buf[offset:], seq)
 	offset += 2
 
 	// LEN
-	binary.BigEndian.PutUint16(buf[offset:], uint16(len(payload)))
+	binary.LittleEndian.PutUint16(buf[offset:], uint16(len(payload)))
 	offset += 2
 
 	// TYPE (Default to Command for testing)
@@ -183,7 +183,7 @@ func TestStreamDecoder_InvalidLength(t *testing.T) {
 	// Mutate LEN field: SYNC(2) + SEQ(2) = offset 4
 	const lenOffset = SyncSize + SeqSize
 	const invalidLength = MaxPayloadSize + 1
-	binary.BigEndian.PutUint16(frame1[lenOffset:], invalidLength)
+	binary.LittleEndian.PutUint16(frame1[lenOffset:], invalidLength)
 	// Note: CRC is now invalid, but decoder will reject on length check first
 
 	// Build a valid frame to follow

--- a/star-gateway/internal/manager/health_monitor.go
+++ b/star-gateway/internal/manager/health_monitor.go
@@ -168,7 +168,7 @@ func (hm *HealthMonitor) probeSPI(wrapper *TransportWrapper) bool {
 
 	// Create PING payload with test marker
 	payload := make([]byte, SPIProbePayloadSize)
-	binary.BigEndian.PutUint32(payload, SPIProbeTestMarker)
+	binary.LittleEndian.PutUint32(payload, SPIProbeTestMarker)
 
 	// Send PING
 	if err := wrapper.Transport.Send(ctx, payload); err != nil {
@@ -189,6 +189,6 @@ func (hm *HealthMonitor) probeSPI(wrapper *TransportWrapper) bool {
 		return false
 	}
 
-	receivedCounter := binary.BigEndian.Uint32(result.Payload)
+	receivedCounter := binary.LittleEndian.Uint32(result.Payload)
 	return receivedCounter == SPIProbeTestMarker
 }

--- a/star-gateway/internal/manager/health_monitor_test.go
+++ b/star-gateway/internal/manager/health_monitor_test.go
@@ -12,7 +12,8 @@ import (
 
 // Test timing constants to avoid magic numbers
 const (
-	testProbeCheckInterval = 100 * time.Millisecond
+	testProbeCheckInterval        = 100 * time.Millisecond
+	testWrongProbeMarker   uint32 = 0x12345678
 )
 
 // MockHARQ for testing
@@ -187,7 +188,7 @@ func TestProbeTransport_SPI_WrongPayloadValue(t *testing.T) {
 
 	// Return payload with wrong value (not SPIProbeTestMarker)
 	wrongPayload := make([]byte, SPIProbePayloadSize)
-	binary.LittleEndian.PutUint32(wrongPayload, 0x12345678) // Wrong marker
+	binary.LittleEndian.PutUint32(wrongPayload, testWrongProbeMarker) // Wrong marker
 
 	mockTransport := &MockTransportProbe{
 		receiveData: wrongPayload,

--- a/star-gateway/internal/manager/health_monitor_test.go
+++ b/star-gateway/internal/manager/health_monitor_test.go
@@ -102,7 +102,7 @@ func TestProbeTransport_SPI_Success(t *testing.T) {
 
 	// Create mock transport that returns valid PONG
 	pongPayload := make([]byte, SPIProbePayloadSize)
-	binary.BigEndian.PutUint32(pongPayload, SPIProbeTestMarker)
+	binary.LittleEndian.PutUint32(pongPayload, SPIProbeTestMarker)
 
 	mockTransport := &MockTransportProbe{
 		receiveData: pongPayload,
@@ -187,7 +187,7 @@ func TestProbeTransport_SPI_WrongPayloadValue(t *testing.T) {
 
 	// Return payload with wrong value (not SPIProbeTestMarker)
 	wrongPayload := make([]byte, SPIProbePayloadSize)
-	binary.BigEndian.PutUint32(wrongPayload, 0x12345678) // Wrong marker
+	binary.LittleEndian.PutUint32(wrongPayload, 0x12345678) // Wrong marker
 
 	mockTransport := &MockTransportProbe{
 		receiveData: wrongPayload,

--- a/star-gateway/internal/manager/heartbeat.go
+++ b/star-gateway/internal/manager/heartbeat.go
@@ -213,7 +213,7 @@ func (hm *HeartbeatManager) OnPongReceived(payload []byte) bool {
 	}
 
 	// Extract counter from PONG payload
-	receivedCounter := binary.BigEndian.Uint32(payload)
+	receivedCounter := binary.LittleEndian.Uint32(payload)
 
 	// Validate counter matches last sent PING
 	if receivedCounter != hm.lastPingSent {
@@ -350,7 +350,7 @@ func (hm *HeartbeatManager) check(ctx context.Context, tm *TransportManager) {
 //
 // PING Frame Format:
 //   - Type: FrameTypePing (0x00)
-//   - Payload: 4-byte counter (big-endian uint32)
+//   - Payload: 4-byte counter (little-endian uint32)
 //   - Expected Response: PONG frame with same counter (validated by OnPongReceived)
 //
 // The counter enables replay detection: the RX72N echoes the counter in PONG,
@@ -367,9 +367,9 @@ func (hm *HeartbeatManager) sendPing(ctx context.Context, tm *TransportManager) 
 	hm.pingCounter++
 	hm.mu.Unlock()
 
-	// Create PING payload (pingPayloadSize bytes, big-endian counter)
+	// Create PING payload (pingPayloadSize bytes, little-endian counter)
 	payload := make([]byte, pingPayloadSize)
-	binary.BigEndian.PutUint32(payload, counter)
+	binary.LittleEndian.PutUint32(payload, counter)
 
 	// Send PING via TransportManager with explicit frame type
 	// Note: We don't wait for PONG here - OnPongReceived() will be called

--- a/star-gateway/internal/manager/heartbeat_test.go
+++ b/star-gateway/internal/manager/heartbeat_test.go
@@ -360,7 +360,7 @@ func TestHeartbeatManager_PongValidation_MatchingCounter(t *testing.T) {
 
 	// Create matching PONG payload
 	payload := make([]byte, testPongPayloadLen)
-	binary.BigEndian.PutUint32(payload, testPongCounter)
+	binary.LittleEndian.PutUint32(payload, testPongCounter)
 
 	// Validate PONG
 	matched := hm.OnPongReceived(payload)
@@ -400,7 +400,7 @@ func TestHeartbeatManager_PongValidation_MismatchedCounter(t *testing.T) {
 
 	// Create PONG with wrong counter
 	payload := make([]byte, testPongPayloadLen)
-	binary.BigEndian.PutUint32(payload, testWrongCounter)
+	binary.LittleEndian.PutUint32(payload, testWrongCounter)
 
 	matched := hm.OnPongReceived(payload)
 	if matched {
@@ -554,7 +554,7 @@ func TestHeartbeatManager_ConsecutiveMissReset(t *testing.T) {
 
 	// Send valid PONG that matches
 	payload := make([]byte, testPongPayloadLen)
-	binary.BigEndian.PutUint32(payload, testPongCounter)
+	binary.LittleEndian.PutUint32(payload, testPongCounter)
 
 	matched := hm.OnPongReceived(payload)
 	if !matched {

--- a/star-gateway/internal/manager/manager.go
+++ b/star-gateway/internal/manager/manager.go
@@ -260,10 +260,10 @@ func (tm *TransportManager) performResetHandshake(ctx context.Context) error {
 		return fmt.Errorf("active transport does not support SendWithType")
 	}
 
-	// Increment session ID and encode as 4-byte big-endian payload
+	// Increment session ID and encode as 4-byte little-endian payload
 	newSessionID := tm.sessionState.IncrementSessionID()
 	resetPayload := make([]byte, SessionIDPayloadSize)
-	binary.BigEndian.PutUint32(resetPayload, newSessionID)
+	binary.LittleEndian.PutUint32(resetPayload, newSessionID)
 
 	// Activate barrier BEFORE sending RESET to ensure stale frames are rejected
 	tm.sessionState.ActivateBarrier(newSessionID)

--- a/star-gateway/internal/manager/manager_test.go
+++ b/star-gateway/internal/manager/manager_test.go
@@ -210,7 +210,7 @@ func TestTransportManager_SendReceive(t *testing.T) {
 		SendWithTypeFunc: func(ctx context.Context, data []byte, frameType frame.Type) error {
 			// Capture session ID from RESET payload
 			if frameType == frame.FrameTypeReset && len(data) >= SessionIDPayloadSize {
-				capturedSessionID.Store(binary.BigEndian.Uint32(data[:SessionIDPayloadSize]))
+				capturedSessionID.Store(binary.LittleEndian.Uint32(data[:SessionIDPayloadSize]))
 			}
 			return nil
 		},
@@ -220,7 +220,7 @@ func TestTransportManager_SendReceive(t *testing.T) {
 			if count == 1 {
 				sid := capturedSessionID.Load()
 				payload := make([]byte, SessionIDPayloadSize)
-				binary.BigEndian.PutUint32(payload, sid)
+				binary.LittleEndian.PutUint32(payload, sid)
 				return &harq.ReceiveResult{
 					Payload: payload,
 					Metadata: harq.FrameMetadata{
@@ -368,7 +368,7 @@ func newTestManagerWithMock(mock *testutil.MockHARQ) *TransportManager {
 // Helper to build a RESET_ACK payload with a given session ID.
 func makeResetAckPayload(sessionID uint32) []byte {
 	payload := make([]byte, SessionIDPayloadSize)
-	binary.BigEndian.PutUint32(payload, sessionID)
+	binary.LittleEndian.PutUint32(payload, sessionID)
 	return payload
 }
 
@@ -379,7 +379,7 @@ func TestPerformResetHandshake_StaleFramesDrained(t *testing.T) {
 	mock := &testutil.MockHARQ{
 		SendWithTypeFunc: func(ctx context.Context, data []byte, frameType frame.Type) error {
 			if frameType == frame.FrameTypeReset && len(data) >= SessionIDPayloadSize {
-				capturedSessionID.Store(binary.BigEndian.Uint32(data[:SessionIDPayloadSize]))
+				capturedSessionID.Store(binary.LittleEndian.Uint32(data[:SessionIDPayloadSize]))
 			}
 			return nil
 		},
@@ -445,7 +445,7 @@ func TestPerformResetHandshake_SessionIDMismatch(t *testing.T) {
 	mock := &testutil.MockHARQ{
 		SendWithTypeFunc: func(ctx context.Context, data []byte, frameType frame.Type) error {
 			if frameType == frame.FrameTypeReset && len(data) >= SessionIDPayloadSize {
-				capturedSessionID.Store(binary.BigEndian.Uint32(data[:SessionIDPayloadSize]))
+				capturedSessionID.Store(binary.LittleEndian.Uint32(data[:SessionIDPayloadSize]))
 			}
 			return nil
 		},
@@ -616,7 +616,7 @@ func TestPerformResetHandshake_TimeoutRetry(t *testing.T) {
 		SendWithTypeFunc: func(ctx context.Context, data []byte, frameType frame.Type) error {
 			sendCount.Add(1)
 			if frameType == frame.FrameTypeReset && len(data) >= SessionIDPayloadSize {
-				capturedSessionID.Store(binary.BigEndian.Uint32(data[:SessionIDPayloadSize]))
+				capturedSessionID.Store(binary.LittleEndian.Uint32(data[:SessionIDPayloadSize]))
 			}
 			return nil
 		},

--- a/star-gateway/internal/manager/session.go
+++ b/star-gateway/internal/manager/session.go
@@ -210,7 +210,7 @@ func (s *SessionState) IsBarrierActive() bool {
 // Returns true only if:
 //   - The barrier is currently active
 //   - The payload is exactly SessionIDPayloadSize (4) bytes
-//   - The big-endian decoded session ID matches the barrier's expected session ID
+//   - The little-endian decoded session ID matches the barrier's expected session ID
 //
 // Thread Safety: Uses mutex to ensure atomicity.
 func (s *SessionState) ValidateResetAck(payload []byte) bool {
@@ -228,7 +228,7 @@ func (s *SessionState) ValidateResetAck(payload []byte) bool {
 		return false
 	}
 
-	receivedID := binary.BigEndian.Uint32(payload[:SessionIDPayloadSize])
+	receivedID := binary.LittleEndian.Uint32(payload[:SessionIDPayloadSize])
 	if receivedID != s.resetBarrierSessionID {
 		log.Printf("WARN: RESET_ACK session ID mismatch (got=%d, expected=%d)",
 			receivedID, s.resetBarrierSessionID)

--- a/star-gateway/internal/manager/session_test.go
+++ b/star-gateway/internal/manager/session_test.go
@@ -88,7 +88,7 @@ func TestSessionState_ValidateResetAck_MatchingID(t *testing.T) {
 	ss.ActivateBarrier(sessionID)
 
 	payload := make([]byte, SessionIDPayloadSize)
-	binary.BigEndian.PutUint32(payload, sessionID)
+	binary.LittleEndian.PutUint32(payload, sessionID)
 
 	if !ss.ValidateResetAck(payload) {
 		t.Error("ValidateResetAck should accept matching session ID")
@@ -101,7 +101,7 @@ func TestSessionState_ValidateResetAck_MismatchID(t *testing.T) {
 	ss.ActivateBarrier(42)
 
 	payload := make([]byte, SessionIDPayloadSize)
-	binary.BigEndian.PutUint32(payload, 99) // Wrong session ID
+	binary.LittleEndian.PutUint32(payload, 99) // Wrong session ID
 
 	if ss.ValidateResetAck(payload) {
 		t.Error("ValidateResetAck should reject mismatched session ID")
@@ -129,7 +129,7 @@ func TestSessionState_ValidateResetAck_BarrierInactive(t *testing.T) {
 
 	// Barrier not active
 	payload := make([]byte, SessionIDPayloadSize)
-	binary.BigEndian.PutUint32(payload, 1)
+	binary.LittleEndian.PutUint32(payload, 1)
 
 	if ss.ValidateResetAck(payload) {
 		t.Error("ValidateResetAck should reject when barrier is inactive")
@@ -144,7 +144,7 @@ func TestSessionState_ValidateResetAck_LongerPayload(t *testing.T) {
 
 	// Payload longer than 4 bytes should still work (reads first 4)
 	payload := make([]byte, 8)
-	binary.BigEndian.PutUint32(payload, sessionID)
+	binary.LittleEndian.PutUint32(payload, sessionID)
 	payload[4] = 0xFF // Extra bytes
 
 	if !ss.ValidateResetAck(payload) {

--- a/star-proto/README.md
+++ b/star-proto/README.md
@@ -1,0 +1,99 @@
+# star-proto - Protocol Buffers for STAR Project
+
+This directory contains the Protocol Buffers definitions and generated code for the STAR distributed robotics platform.
+
+## Quick Start
+
+### Generate Protocol Buffers Code
+
+From the **workspace root** (`/workspaces/STAR`), run:
+
+```bash
+make proto-gen
+```
+
+This will:
+1. Generate code for all targets (Go, TypeScript, C/nanopb, C++)
+2. Initialize the Go module in `gen/go/` if needed
+3. Download Go dependencies with `go mod tidy`
+4. Synchronize the Go workspace
+
+### Manual Generation (if not using Makefile)
+
+```bash
+# From workspace root
+cd star-proto
+
+# Generate protobuf code
+buf generate proto/ --template buf.gen.yaml
+
+# Setup Go module (first time or after cleaning)
+cd gen/go
+go mod init github.com/Locked-Inc/star-proto/gen/go
+go mod tidy
+
+# Sync workspace
+cd /workspaces/STAR
+go work sync
+```
+
+## Directory Structure
+
+```
+star-proto/
+├── proto/              # Protocol Buffer definitions (.proto files)
+│   └── star/v1/        # STAR v1 API
+├── gen/                # Generated code (gitignored)
+│   ├── go/             # Go gRPC/protobuf code
+│   ├── typescript/     # TypeScript code for star-ui
+│   ├── nanopb/         # C code for star-rx72n-firmware
+│   └── cpp/            # C++ code for star-ros2
+├── nanopb/             # nanopb configuration files
+└── tests/              # Protocol buffer tests
+    └── go/             # Go test cases
+```
+
+## Linting and Formatting
+
+```bash
+# Lint proto files
+buf lint proto/
+
+# Format proto files
+buf format --diff proto/
+buf format --write proto/
+```
+
+## After Fresh Clone
+
+When cloning the repository for the first time, you **must** run:
+
+```bash
+make proto-gen
+```
+
+This generates the code and sets up the Go module dependency chain required by `go.work`.
+
+## Troubleshooting
+
+### Error: "directory ./star-proto/gen/go does not contain a module"
+
+This means the Go module wasn't initialized after code generation. Run:
+
+```bash
+make proto-gen-go
+```
+
+### Buf command not found
+
+Install buf CLI:
+- macOS: `brew install bufbuild/buf/buf`
+- Linux: See https://buf.build/docs/installation
+
+In the dev container, buf is pre-installed.
+
+## References
+
+- [Protocol Buffers Language Guide](https://protobuf.dev/programming-guides/proto3/)
+- [Buf Documentation](https://buf.build/docs)
+- [gRPC Go Guide](https://grpc.io/docs/languages/go/quickstart/)


### PR DESCRIPTION
Standardizes the communication protocol by transitioning all multi-byte fields from big-endian to little-endian byte order. 

This change ensures architectural consistency across the transport layer, aligning the frame header fields and control payloads with the existing little-endian CRC-32 implementation. By consolidating on a single endianness, the protocol reduces complexity for both the gateway and the connected firmware.

### Key Changes
- Updates the frame encoder and decoder to process SYNC, SEQ, and LEN fields in little-endian format.
- Migrates payload-specific logic, including heartbeat counters and session IDs, to use little-endian encoding.
- Refreshes cross-compatibility test vectors and documentation to reflect the updated wire format.
- Implements a CI regression guard to detect and prevent the accidental use of big-endian encoding in production code.

**Note:** This is a breaking protocol change that requires a coordinated update with the corresponding RX72N firmware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CI regression guard to detect prohibited big-endian usages.

* **Bug Fixes**
  * Standardized the wire protocol to little-endian for headers and payloads, ensuring consistent parsing across transports.
  * Updated runtime handling of heartbeat and reset exchanges to use little-endian counters/session IDs.
  * Added payload-size validation to frame construction to prevent oversized frames.

* **Documentation**
  * Updated protocol and heartbeat docs to reflect little-endian byte order.
  * Added a README for the proto tooling and workflow.

* **Tests**
  * Updated test suites and vectors to validate little-endian encoding/decoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->