### PR TITLE
Add TPU encoder pin configuration for rear wheels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -59,7 +59,7 @@ reviews:
         - REQUIRED: Update all call sites directly when refactoring
         - REQUIRED: Ensure main branch remains in working state after changes
 
-    - path: "star-rx72n-firmware/**/*.{c,h}"
+    - path: "{star-rx72n-firmware,e2-studio-star-rx72n-firmware}/**/*.{c,h}"
       instructions: |
         Review C firmware code with STRICT compliance checking:
         - Language standard: C23 ONLY (ignore any C11/C89-related warnings or comments)
@@ -695,6 +695,7 @@ reviews:
     # Include paths
     - "star-gateway/**"
     - "star-rx72n-firmware/**"
+    - "e2-studio-star-rx72n-firmware/**"
     - "lib/**"
     - "src/**"
     - "tests/**"

--- a/e2-studio-star-rx72n-firmware/libs/rx_hal/inc/rx_mpc.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_hal/inc/rx_mpc.h
@@ -961,6 +961,68 @@ typedef enum : uint8_t {
 [[nodiscard]] rx_err_t rx_mpc_set_mtu_encoder(rx_port_pin_t pin);
 
 /**
+ * @brief Configure pin for TPU encoder/phase counter input (TCLK)
+ *
+ * @details
+ * Configures a pin for TPU phase counting mode input, used with
+ * quadrature encoders on the rear wheels. Sets PSEL = k_psel_mtu_phase
+ * (0x03), which is the generic "timer phase counting input" function
+ * on the RX72N. The routing to TPU (vs MTU) depends on which timer
+ * module has phase counting mode enabled.
+ *
+ * This function exists as a separate API from rx_mpc_set_mtu_encoder()
+ * for documentation clarity, even though both write the same PSEL value.
+ *
+ * @par TPU Encoder Pins (STAR Project - Rear Wheels)
+ * | Pin Pair | TPU Input | Encoder |
+ * |----------|-----------|---------|
+ * | PC2/PA3 | TCLKA/TCLKB | Motor 2 (Rear Left) |
+ * | PC0/PB3 | TCLKC/TCLKD | Motor 3 (Rear Right) |
+ *
+ * @param[in] pin GPIO pin identifier for TPU encoder input
+ *                - Must be a pin that supports TCLK function
+ *                - Configure in pairs (A+B) for quadrature
+ *
+ * @return Error code indicating success or failure
+ * @retval k_rx_ok Pin successfully configured for TPU encoder input
+ * @retval k_rx_err_invalid_arg Invalid port or pin number
+ *
+ * @pre Pin must support TPU clock/phase function
+ * @pre PCLKB clock must be running
+ *
+ * @post PFS register contains PSEL = 0x03 (timer phase counting)
+ * @post Pin ready for quadrature encoder input via TPU
+ *
+ * @note Configure both Phase A and Phase B pins for proper operation
+ * @note Also requires TPU timer configuration in phase counting mode
+ *
+ * @par Example - Rear Wheel Encoder Setup
+ * @code{.c}
+ * rx_err_t err;
+ *
+ * // Motor 2 (Rear Left) - TPU1
+ * err = rx_mpc_set_tpu_encoder(k_rx_pc_2);  // PC2 = TCLKA (Phase A)
+ * if (err != k_rx_ok) return err;
+ * err = rx_mpc_set_tpu_encoder(k_rx_pa_3);  // PA3 = TCLKB (Phase B)
+ * if (err != k_rx_ok) return err;
+ *
+ * // Motor 3 (Rear Right) - TPU2
+ * err = rx_mpc_set_tpu_encoder(k_rx_pc_0);  // PC0 = TCLKC (Phase A)
+ * if (err != k_rx_ok) return err;
+ * err = rx_mpc_set_tpu_encoder(k_rx_pb_3);  // PB3 = TCLKD (Phase B)
+ * if (err != k_rx_ok) return err;
+ * @endcode
+ *
+ * @see rx_mpc_set_mtu_encoder() Front wheel encoder pin configuration
+ * @see rx_mpc_set_peripheral() Underlying implementation
+ * @see rx_encoder_tpu.h TPU encoder driver using phase counting
+ *
+ * @since Version 1.1.0
+ * @callgraph
+ */
+[[nodiscard]] rx_err_t rx_mpc_set_tpu_encoder(rx_port_pin_t pin);
+
+/**
  * @brief Configure pin for ADC analog input
  *
  * @details

--- a/e2-studio-star-rx72n-firmware/libs/rx_hal/src/rx_mpc.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_hal/src/rx_mpc.c
@@ -868,6 +868,38 @@ rx_err_t rx_mpc_set_mtu_encoder(const rx_port_pin_t pin)
 }
 
 /**
+ * @brief Configure pin for TPU encoder/phase counter input (TCLK)
+ *
+ * @details
+ * Convenience wrapper that configures a pin for TPU phase counting mode
+ * using PSEL = k_psel_mtu_phase (0x03). On the RX72N, PSEL 0x03 is the
+ * generic "timer phase counting input" function; routing to TPU (vs MTU)
+ * depends on which timer module has phase counting mode enabled.
+ *
+ * @param[in] pin GPIO pin identifier for TPU encoder input (e.g., PC2/PA3)
+ *
+ * @return Error code indicating success or failure
+ * @retval k_rx_ok Pin configured for TPU encoder input
+ * @retval k_rx_err_invalid_arg Invalid port or pin
+ *
+ * @note Configure both Phase A and Phase B pins for proper operation
+ *
+ * @see rx_mpc.h Full API documentation
+ * @see rx_encoder_tpu.h TPU encoder driver using phase counting
+ * @since Version 1.1.0
+ */
+rx_err_t rx_mpc_set_tpu_encoder(const rx_port_pin_t pin)
+{
+  /* TPU encoder (TCLK) pins use PSEL = 0x03 (same as MTU phase counting)
+   * Rear wheel encoder pins:
+   * - PC2/PA3: TCLKA/TCLKB (Motor 2, Rear Left)
+   * - PC0/PB3: TCLKC/TCLKD (Motor 3, Rear Right)
+   */
+  const rx_mpc_peripheral_config_t config = {.pin = pin, .psel = k_psel_mtu_phase};
+  return rx_mpc_set_peripheral(&config);
+}
+
+/**
  * @brief Configure pin for ADC analog input
  *
  * @details

--- a/e2-studio-star-rx72n-firmware/src/hardware_init.c
+++ b/e2-studio-star-rx72n-firmware/src/hardware_init.c
@@ -593,8 +593,7 @@ static rx_err_t gpio_init(void)
    * pin input, and the GTETRG logic reads the port pin state continuously.
    * No MPC config needed -- documented here for traceability. */
 
-  rx_log_info(s_tag, "54 pins: 4xI2C, 4xSPI, 4xMTU, 4xTPU, 8xGPTW, 4xADC, 1xUSB, "
-                     "8xSonar, 7xDRV_SPI, 4xGTETRG(doc), 6xLED(TBD)");
+  rx_log_info(s_tag, "GPIO pin muxing complete");
 
   return k_rx_ok;
 }

--- a/e2-studio-star-rx72n-firmware/src/hardware_init.c
+++ b/e2-studio-star-rx72n-firmware/src/hardware_init.c
@@ -253,6 +253,12 @@ typedef enum : uint16_t {
   k_pin_enc1_pha   = k_rx_pa_1, /**< PA.1 - MTCLKC (encoder 1 phase A) */
   k_pin_enc1_phb   = k_rx_pc_5, /**< PC.5 - MTCLKD (encoder 1 phase B) */
 
+  /* TPU Encoder clock inputs (rear wheels) */
+  k_pin_enc2_pha   = k_rx_pc_2, /**< PC.2 - TCLKA (encoder 2 phase A) */
+  k_pin_enc2_phb   = k_rx_pa_3, /**< PA.3 - TCLKB (encoder 2 phase B) */
+  k_pin_enc3_pha   = k_rx_pc_0, /**< PC.0 - TCLKC (encoder 3 phase A) */
+  k_pin_enc3_phb   = k_rx_pb_3, /**< PB.3 - TCLKD (encoder 3 phase B) */
+
   /* GPTW PWM outputs (4 motors × 2 pins = PH + EN) */
   k_pin_motor0_ph  = k_rx_p2_3, /**< P2.3 - GTIOC0A (motor 0 phase) */
   k_pin_motor0_en  = k_rx_p1_7, /**< P1.7 - GTIOC0B (motor 0 enable) */
@@ -464,6 +470,19 @@ static rx_err_t gpio_init(void)
   err = rx_mpc_set_mtu_encoder((rx_port_pin_t)k_pin_enc1_phb); /* PC.5 = MTCLKD */
   RX_RETURN_ON_ERROR(err, s_tag, "MTCLKD pin config failed");
 
+  /* ---- TPU encoder clock inputs (rear wheels) ---- */
+  err = rx_mpc_set_tpu_encoder((rx_port_pin_t)k_pin_enc2_pha); /* PC.2 = TCLKA */
+  RX_RETURN_ON_ERROR(err, s_tag, "TCLKA pin config failed");
+
+  err = rx_mpc_set_tpu_encoder((rx_port_pin_t)k_pin_enc2_phb); /* PA.3 = TCLKB */
+  RX_RETURN_ON_ERROR(err, s_tag, "TCLKB pin config failed");
+
+  err = rx_mpc_set_tpu_encoder((rx_port_pin_t)k_pin_enc3_pha); /* PC.0 = TCLKC */
+  RX_RETURN_ON_ERROR(err, s_tag, "TCLKC pin config failed");
+
+  err = rx_mpc_set_tpu_encoder((rx_port_pin_t)k_pin_enc3_phb); /* PB.3 = TCLKD */
+  RX_RETURN_ON_ERROR(err, s_tag, "TCLKD pin config failed");
+
   /* ---- GPTW PWM outputs (4 motors × PH + EN = 8 pins) ---- */
   const rx_port_pin_t gptw_pins[] = {
     (rx_port_pin_t)k_pin_motor0_ph, (rx_port_pin_t)k_pin_motor0_en,
@@ -574,7 +593,7 @@ static rx_err_t gpio_init(void)
    * pin input, and the GTETRG logic reads the port pin state continuously.
    * No MPC config needed -- documented here for traceability. */
 
-  rx_log_info(s_tag, "50 pins: 4xI2C, 4xSPI, 4xMTU, 8xGPTW, 4xADC, 1xUSB, "
+  rx_log_info(s_tag, "54 pins: 4xI2C, 4xSPI, 4xMTU, 4xTPU, 8xGPTW, 4xADC, 1xUSB, "
                      "8xSonar, 7xDRV_SPI, 4xGTETRG(doc), 6xLED(TBD)");
 
   return k_rx_ok;


### PR DESCRIPTION
## Summary

- Add `rx_mpc_set_tpu_encoder()` MPC driver function for TPU phase counting pin configuration (PSEL=0x03)
- Configure 4 rear wheel encoder pins in `hardware_init.c`: PC2/TCLKA, PA3/TCLKB, PC0/TCLKC, PB3/TCLKD
- Completes the TPU encoder integration — `motor_control_task.c` already dispatches motors 2-3 to TPU1/TPU2, but pins were never routed

Closes #273

## Test plan

- [x] All 46 unit tests pass (`ctest --output-on-failure`)
- [ ] Verify rear wheel encoder reads return non-zero on hardware
- [ ] Confirm front wheel encoders (MTU) still work correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TPU-based encoder inputs, enabling configuration of two additional encoder channels (encoder 2 and encoder 3) to support rear-wheel encoder detection and motion tracking
  * Integrated encoder pin initialization into the hardware setup process with comprehensive error handling and diagnostic logging to ensure proper encoder functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->