### PR TITLE
Add OSHWA terminology mapping notes to hardware_config.h SPI tables

### DIFF
--- a/e2-studio-star-rx72n-firmware/src/inc/hardware_config.h
+++ b/e2-studio-star-rx72n-firmware/src/inc/hardware_config.h
@@ -148,6 +148,10 @@ typedef enum : uint8_t {
  * hardware conflict with GPTW motor PWM outputs. Moved to SCI7 (P90/91/92)
  * to resolve the pin function conflict. See Issue #288.
  *
+ * **Pin Naming Convention:** Hardware signal names (SMOSI7/SMISO7) are from
+ * the RX72N datasheet. This project uses COPI/CIPO terminology per OSHWA
+ * inclusive naming standards.
+ *
  * | Signal | Pin | Pkg Pin | Function | SCI Channel |
  * |--------|-----|---------|----------|-------------|
  * | DRV_SCLK | P91 | 129 | SCK7 | SCI7 |
@@ -202,6 +206,10 @@ typedef enum : uint8_t {
  *
  * @details
  * RSPI2 channel A pins on PORTD. All pins use MPC alternate function "A".
+ *
+ * **Pin Naming Convention:** Hardware signal names (MOSIC/MISOC) are from
+ * the RX72N datasheet. This project uses COPI/CIPO terminology per OSHWA
+ * inclusive naming standards.
  *
  * | Signal | Pin | Pkg Pin | Function |
  * |--------|-----|---------|----------|


### PR DESCRIPTION
Resolves #312

## Summary

Adds clarification notes to SPI pin tables explaining that hardware signal names come from the RX72N datasheet, while the project uses COPI/CIPO terminology per OSHWA standards.

## Changes

- Added note before DRV SPI table (SCI7 pins)  
- Added note before HOST SPI table (RSPI2 pins)

## Testing

✅ Build successful with zero warnings