### PR TITLE
docs: update SPI initialization status from pending to complete

### DIFF
--- a/e2-studio-star-rx72n-firmware/src/hardware_init.c
+++ b/e2-studio-star-rx72n-firmware/src/hardware_init.c
@@ -93,11 +93,11 @@
  * | **GPIO init** | ~5 µs | [PENDING] Planned | Pin mode, pull-up/down, output levels |
  * | **Timer init** | ~10 µs | [COMPLETE] | CMT0 setup for ThreadX tick |
  * | **UART debug** | ~50 µs | [COMPLETE] | SCI9 baud rate, FIFO, interrupts |
- * | **SPI init** | ~20 µs | [PENDING] Planned | RSPI0/1 mode, clock, DMA config |
+ * | **SPI init** | ~20 µs | [COMPLETE] | RSPI2 peripheral mode, 8-bit, mode 0 |
  * | **I2C init** | ~15 µs | [PENDING] Planned | RIIC0 speed, addressing, interrupts |
  * | **ADC init** | ~100 µs | [PENDING] Planned | ADC0 calibration, channel config |
  * | **Postcondition check** | ~0.5 µs | [COMPLETE] | SCKCR3 stability verification |
- * | **Total (current)** | **~61 µs** | Timers + UART only | |
+ * | **Total (current)** | **~81 µs** | Timers + UART + SPI | |
  * | **Total (planned)** | **~201 µs** | All peripherals | |
  *
  * ## Memory Usage


### PR DESCRIPTION
## Summary

Updates `hardware_init.c` documentation to reflect that SPI initialization is fully implemented, removing the stale "[PENDING] Planned" status marker.

## Changes

- Changed SPI init status from "[PENDING] Planned" to "[COMPLETE]"
- Fixed peripheral reference from incorrect "RSPI0/1" to correct "RSPI2"
- Updated implementation notes to show actual config: "RSPI2 peripheral mode, 8-bit, mode 0"
- Updated "Total (current)" timing from 61 µs to 81 µs (now includes SPI init)

## Verification

The `spi_init()` function (line 1021) is fully implemented and called during `hardware_init()` (line 1384). It successfully initializes RSPI2 in peripheral mode for RPi5 host communication.

## Impact

- **Severity**: Documentation accuracy
- **Category**: Technical Debt Cleanup
- Removes misleading "[PENDING]" marker
- Corrects hardware peripheral reference (RSPI2, not RSPI0/1)
- Accurate timing information for boot sequence

Fixes #315