### PR TITLE
docs: add OSHWA terminology mapping to SCI SPI pin table

### DIFF
--- a/e2-studio-star-rx72n-firmware/libs/rx_hal/inc/rx_sci_spi.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_hal/inc/rx_sci_spi.h
@@ -17,11 +17,16 @@
  * idle) which is generally tolerated by SPI peripherals.
  *
  * @par Example Hardware Pin Mapping (STAR Project - SCI7)
- * | SCI7 Pin | RX72N Pin | Signal     | Direction |
- * |----------|-----------|------------|-----------|
- * | SCK7     | P91       | SPI Clock  | Output    |
- * | SMOSI7   | P90       | COPI       | Output    |
- * | SMISO7   | P92       | CIPO       | Input     |
+ *
+ * **Pin Naming Convention:** Hardware signal names (SMOSI7/SMISO7) are from
+ * the RX72N datasheet. This project uses COPI/CIPO terminology per OSHWA
+ * inclusive naming standards.
+ *
+ * | SCI7 Pin (Hardware) | RX72N Pin | Project Name | Direction |
+ * |---------------------|-----------|--------------|-----------|
+ * | SCK7                | P91       | SPI Clock    | Output    |
+ * | SMOSI7              | P90       | COPI         | Output    |
+ * | SMISO7              | P92       | CIPO         | Input     |
  *
  * @par Baud Rate Calculation (Sync Mode)
  * bit_rate = PCLKB / (4 * (BRR + 1)) for CKS=0


### PR DESCRIPTION
## Summary

Adds explicit naming convention note to `rx_sci_spi.h` to clarify the relationship between RX72N hardware signal names and STAR project terminology.

## Changes

- Added "Pin Naming Convention" paragraph before hardware pin mapping table
- Updated table header to distinguish "Hardware" vs "Project Name" columns
- Makes it clear that SMOSI7/SMISO7 are RX72N datasheet names
- Explains that COPI/CIPO are project's inclusive OSHWA terminology

## Impact

- **Severity**: Documentation clarity
- **Category**: Code Documentation
- Eliminates confusion about mixed SMOSI/SMISO vs COPI/CIPO usage
- Consistent with hardware_config.h, rx_mpc.h, and rx72n_rspi_regs.h naming notes

## Testing

- [x] Documentation is self-explanatory
- [x] Follows same pattern as other files (hw_config.h, rx_mpc.h, rx72n_rspi_regs.h)
- [x] No functional code changes

Fixes #318