### PR TITLE
fix: register required buses in bus manager during initialization

### DIFF
--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/google/protobuf/duration.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/google/protobuf/duration.pb.h
@@ -104,8 +104,8 @@ extern "C" {
 #define google_protobuf_Duration_FIELDLIST(X, a)                                                   \
   X(a, STATIC, SINGULAR, INT64, seconds, 1)                                                        \
   X(a, STATIC, SINGULAR, INT32, nanos, 2)
-#define google_protobuf_Duration_CALLBACKnullptr
-#define google_protobuf_Duration_DEFAULT nullptr
+#define google_protobuf_Duration_CALLBACK nullptr
+#define google_protobuf_Duration_DEFAULT  nullptr
 
 extern const pb_msgdesc_t google_protobuf_Duration_msg;
 

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/google/protobuf/timestamp.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/google/protobuf/timestamp.pb.h
@@ -134,8 +134,8 @@ extern "C" {
 #define google_protobuf_Timestamp_FIELDLIST(X, a)                                                  \
   X(a, STATIC, SINGULAR, INT64, seconds, 1)                                                        \
   X(a, STATIC, SINGULAR, INT32, nanos, 2)
-#define google_protobuf_Timestamp_CALLBACKnullptr
-#define google_protobuf_Timestamp_DEFAULT nullptr
+#define google_protobuf_Timestamp_CALLBACK nullptr
+#define google_protobuf_Timestamp_DEFAULT  nullptr
 
 extern const pb_msgdesc_t google_protobuf_Timestamp_msg;
 

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/battery_management.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/battery_management.pb.h
@@ -729,23 +729,23 @@ extern "C" {
 
 /* Struct field encoding specification for nanopb */
 #define star_v1_GetBatteryStateRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetBatteryStateRequest_CALLBACK       nullptr
-#define star_v1_GetBatteryStateRequest_DEFAULT        nullptr
+#define star_v1_GetBatteryStateRequest_CALLBACK        nullptr
+#define star_v1_GetBatteryStateRequest_DEFAULT         nullptr
 #define star_v1_GetBatteryStateRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetBatteryStateResponse_FIELDLIST(X, a)                                            \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, state, 2)
-#define star_v1_GetBatteryStateResponse_CALLBACK      nullptr
-#define star_v1_GetBatteryStateResponse_DEFAULT       nullptr
+#define star_v1_GetBatteryStateResponse_CALLBACK       nullptr
+#define star_v1_GetBatteryStateResponse_DEFAULT        nullptr
 #define star_v1_GetBatteryStateResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetBatteryStateResponse_state_MSGTYPE  star_v1_BatteryState
 
 #define star_v1_StreamBatteryStateRequest_FIELDLIST(X, a)                                          \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, INT32, rate_hz, 2)
-#define star_v1_StreamBatteryStateRequest_CALLBACK      nullptr
-#define star_v1_StreamBatteryStateRequest_DEFAULT       nullptr
+#define star_v1_StreamBatteryStateRequest_CALLBACK       nullptr
+#define star_v1_StreamBatteryStateRequest_DEFAULT        nullptr
 #define star_v1_StreamBatteryStateRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_BatteryState_FIELDLIST(X, a)                                                       \
@@ -755,8 +755,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, soc, 4)                                                          \
   X(a, STATIC, OPTIONAL, MESSAGE, status, 5)                                                       \
   X(a, STATIC, SINGULAR, INT64, timestamp_us, 6)
-#define star_v1_BatteryState_CALLBACK            nullptr
-#define star_v1_BatteryState_DEFAULT             nullptr
+#define star_v1_BatteryState_CALLBACK             nullptr
+#define star_v1_BatteryState_DEFAULT              nullptr
 #define star_v1_BatteryState_cells_MSGTYPE        star_v1_CellData
 #define star_v1_BatteryState_temperatures_MSGTYPE star_v1_TemperatureData
 #define star_v1_BatteryState_current_MSGTYPE      star_v1_CurrentData
@@ -771,7 +771,7 @@ extern "C" {
   X(a, STATIC, SINGULAR, UINT32, max_cell_mv, 5)                                                   \
   X(a, STATIC, SINGULAR, UINT32, delta_mv, 6)
 #define star_v1_CellData_CALLBACK pb_default_field_callback
-#define star_v1_CellData_DEFAULT nullptr
+#define star_v1_CellData_DEFAULT  nullptr
 
 #define star_v1_TemperatureData_FIELDLIST(X, a)                                                    \
   X(a, CALLBACK, REPEATED, INT32, temp_deci_celsius, 1)                                            \
@@ -780,15 +780,15 @@ extern "C" {
   X(a, STATIC, SINGULAR, INT32, min_temp_deci_celsius, 4)                                          \
   X(a, STATIC, SINGULAR, INT32, max_temp_deci_celsius, 5)
 #define star_v1_TemperatureData_CALLBACK pb_default_field_callback
-#define star_v1_TemperatureData_DEFAULT nullptr
+#define star_v1_TemperatureData_DEFAULT  nullptr
 
 #define star_v1_CurrentData_FIELDLIST(X, a)                                                        \
   X(a, STATIC, SINGULAR, INT32, current_ma, 1)                                                     \
   X(a, STATIC, SINGULAR, INT32, avg_current_ma, 2)                                                 \
   X(a, STATIC, SINGULAR, UINT32, voltage_mv, 3)                                                    \
   X(a, STATIC, SINGULAR, INT32, power_mw, 4)
-#define star_v1_CurrentData_CALLBACKnullptr
-#define star_v1_CurrentData_DEFAULT nullptr
+#define star_v1_CurrentData_CALLBACK nullptr
+#define star_v1_CurrentData_DEFAULT  nullptr
 
 #define star_v1_StateOfChargeData_FIELDLIST(X, a)                                                  \
   X(a, STATIC, SINGULAR, UINT32, remaining_capacity_mah, 1)                                        \
@@ -797,8 +797,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, INT32, relative_soc_percent, 4)                                           \
   X(a, STATIC, SINGULAR, INT32, absolute_soc_percent, 5)                                           \
   X(a, STATIC, SINGULAR, UINT32, cycle_count, 6)
-#define star_v1_StateOfChargeData_CALLBACKnullptr
-#define star_v1_StateOfChargeData_DEFAULT nullptr
+#define star_v1_StateOfChargeData_CALLBACK nullptr
+#define star_v1_StateOfChargeData_DEFAULT  nullptr
 
 #define star_v1_BatteryStatus_FIELDLIST(X, a)                                                      \
   X(a, STATIC, SINGULAR, UINT32, battery_status_register, 1)                                       \
@@ -812,8 +812,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, BOOL, fault_active, 9)                                                    \
   X(a, STATIC, OPTIONAL, MESSAGE, safety_faults, 10)                                               \
   X(a, STATIC, SINGULAR, UENUM, state, 11)
-#define star_v1_BatteryStatus_CALLBACK             nullptr
-#define star_v1_BatteryStatus_DEFAULT              nullptr
+#define star_v1_BatteryStatus_CALLBACK              nullptr
+#define star_v1_BatteryStatus_DEFAULT               nullptr
 #define star_v1_BatteryStatus_safety_faults_MSGTYPE star_v1_SafetyFaults
 
 #define star_v1_SafetyFaults_FIELDLIST(X, a)                                                       \
@@ -825,8 +825,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, BOOL, overtemp_discharge, 6)                                              \
   X(a, STATIC, SINGULAR, BOOL, undertemp_charge, 7)                                                \
   X(a, STATIC, SINGULAR, BOOL, undertemp_discharge, 8)
-#define star_v1_SafetyFaults_CALLBACKnullptr
-#define star_v1_SafetyFaults_DEFAULT nullptr
+#define star_v1_SafetyFaults_CALLBACK nullptr
+#define star_v1_SafetyFaults_DEFAULT  nullptr
 
 #define star_v1_ProtectionThresholds_FIELDLIST(X, a)                                               \
   X(a, STATIC, SINGULAR, UINT32, overvoltage_mv, 1)                                                \
@@ -835,100 +835,100 @@ extern "C" {
   X(a, STATIC, SINGULAR, UINT32, overdischarge_ma, 4)                                              \
   X(a, STATIC, SINGULAR, INT32, overtemp_deci_celsius, 5)                                          \
   X(a, STATIC, SINGULAR, INT32, undertemp_deci_celsius, 6)
-#define star_v1_ProtectionThresholds_CALLBACKnullptr
-#define star_v1_ProtectionThresholds_DEFAULT nullptr
+#define star_v1_ProtectionThresholds_CALLBACK nullptr
+#define star_v1_ProtectionThresholds_DEFAULT  nullptr
 
 #define star_v1_GetProtectionThresholdsRequest_FIELDLIST(X, a)                                     \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetProtectionThresholdsRequest_CALLBACK      nullptr
-#define star_v1_GetProtectionThresholdsRequest_DEFAULT       nullptr
+#define star_v1_GetProtectionThresholdsRequest_CALLBACK       nullptr
+#define star_v1_GetProtectionThresholdsRequest_DEFAULT        nullptr
 #define star_v1_GetProtectionThresholdsRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_GetProtectionThresholdsResponse_FIELDLIST(X, a)                                    \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, thresholds, 2)
-#define star_v1_GetProtectionThresholdsResponse_CALLBACK          nullptr
-#define star_v1_GetProtectionThresholdsResponse_DEFAULT           nullptr
+#define star_v1_GetProtectionThresholdsResponse_CALLBACK           nullptr
+#define star_v1_GetProtectionThresholdsResponse_DEFAULT            nullptr
 #define star_v1_GetProtectionThresholdsResponse_header_MSGTYPE     star_v1_ResponseHeader
 #define star_v1_GetProtectionThresholdsResponse_thresholds_MSGTYPE star_v1_ProtectionThresholds
 
 #define star_v1_SetProtectionThresholdsRequest_FIELDLIST(X, a)                                     \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, thresholds, 2)
-#define star_v1_SetProtectionThresholdsRequest_CALLBACK          nullptr
-#define star_v1_SetProtectionThresholdsRequest_DEFAULT           nullptr
+#define star_v1_SetProtectionThresholdsRequest_CALLBACK           nullptr
+#define star_v1_SetProtectionThresholdsRequest_DEFAULT            nullptr
 #define star_v1_SetProtectionThresholdsRequest_header_MSGTYPE     star_v1_RequestHeader
 #define star_v1_SetProtectionThresholdsRequest_thresholds_MSGTYPE star_v1_ProtectionThresholds
 
 #define star_v1_SetProtectionThresholdsResponse_FIELDLIST(X, a)                                    \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SetProtectionThresholdsResponse_CALLBACK      nullptr
-#define star_v1_SetProtectionThresholdsResponse_DEFAULT       nullptr
+#define star_v1_SetProtectionThresholdsResponse_CALLBACK       nullptr
+#define star_v1_SetProtectionThresholdsResponse_DEFAULT        nullptr
 #define star_v1_SetProtectionThresholdsResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_EnableCellBalancingRequest_FIELDLIST(X, a)                                         \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, UINT32, cell_mask, 2)
-#define star_v1_EnableCellBalancingRequest_CALLBACK      nullptr
-#define star_v1_EnableCellBalancingRequest_DEFAULT       nullptr
+#define star_v1_EnableCellBalancingRequest_CALLBACK       nullptr
+#define star_v1_EnableCellBalancingRequest_DEFAULT        nullptr
 #define star_v1_EnableCellBalancingRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_EnableCellBalancingResponse_FIELDLIST(X, a)                                        \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_EnableCellBalancingResponse_CALLBACK      nullptr
-#define star_v1_EnableCellBalancingResponse_DEFAULT       nullptr
+#define star_v1_EnableCellBalancingResponse_CALLBACK       nullptr
+#define star_v1_EnableCellBalancingResponse_DEFAULT        nullptr
 #define star_v1_EnableCellBalancingResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_DisableCellBalancingRequest_FIELDLIST(X, a)                                        \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_DisableCellBalancingRequest_CALLBACK      nullptr
-#define star_v1_DisableCellBalancingRequest_DEFAULT       nullptr
+#define star_v1_DisableCellBalancingRequest_CALLBACK       nullptr
+#define star_v1_DisableCellBalancingRequest_DEFAULT        nullptr
 #define star_v1_DisableCellBalancingRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_DisableCellBalancingResponse_FIELDLIST(X, a)                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_DisableCellBalancingResponse_CALLBACK      nullptr
-#define star_v1_DisableCellBalancingResponse_DEFAULT       nullptr
+#define star_v1_DisableCellBalancingResponse_CALLBACK       nullptr
+#define star_v1_DisableCellBalancingResponse_DEFAULT        nullptr
 #define star_v1_DisableCellBalancingResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_GetBalancingStatusRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetBalancingStatusRequest_CALLBACK       nullptr
-#define star_v1_GetBalancingStatusRequest_DEFAULT        nullptr
+#define star_v1_GetBalancingStatusRequest_CALLBACK        nullptr
+#define star_v1_GetBalancingStatusRequest_DEFAULT         nullptr
 #define star_v1_GetBalancingStatusRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetBalancingStatusResponse_FIELDLIST(X, a)                                         \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, UINT32, active_cell_mask, 2)
-#define star_v1_GetBalancingStatusResponse_CALLBACK      nullptr
-#define star_v1_GetBalancingStatusResponse_DEFAULT       nullptr
+#define star_v1_GetBalancingStatusResponse_CALLBACK       nullptr
+#define star_v1_GetBalancingStatusResponse_DEFAULT        nullptr
 #define star_v1_GetBalancingStatusResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_ControlFetsRequest_FIELDLIST(X, a)                                                 \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, enable_charge_fet, 2)                                               \
   X(a, STATIC, SINGULAR, BOOL, enable_discharge_fet, 3)
-#define star_v1_ControlFetsRequest_CALLBACK      nullptr
-#define star_v1_ControlFetsRequest_DEFAULT       nullptr
+#define star_v1_ControlFetsRequest_CALLBACK       nullptr
+#define star_v1_ControlFetsRequest_DEFAULT        nullptr
 #define star_v1_ControlFetsRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_ControlFetsResponse_FIELDLIST(X, a)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, charge_fet_enabled, 2)                                              \
   X(a, STATIC, SINGULAR, BOOL, discharge_fet_enabled, 3)
-#define star_v1_ControlFetsResponse_CALLBACK      nullptr
-#define star_v1_ControlFetsResponse_DEFAULT       nullptr
+#define star_v1_ControlFetsResponse_CALLBACK       nullptr
+#define star_v1_ControlFetsResponse_DEFAULT        nullptr
 #define star_v1_ControlFetsResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_GetDeviceInfoRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetDeviceInfoRequest_CALLBACK       nullptr
-#define star_v1_GetDeviceInfoRequest_DEFAULT        nullptr
+#define star_v1_GetDeviceInfoRequest_CALLBACK        nullptr
+#define star_v1_GetDeviceInfoRequest_DEFAULT         nullptr
 #define star_v1_GetDeviceInfoRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetDeviceInfoResponse_FIELDLIST(X, a)                                              \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, device_info, 2)
-#define star_v1_GetDeviceInfoResponse_CALLBACK           nullptr
-#define star_v1_GetDeviceInfoResponse_DEFAULT            nullptr
+#define star_v1_GetDeviceInfoResponse_CALLBACK            nullptr
+#define star_v1_GetDeviceInfoResponse_DEFAULT             nullptr
 #define star_v1_GetDeviceInfoResponse_header_MSGTYPE      star_v1_ResponseHeader
 #define star_v1_GetDeviceInfoResponse_device_info_MSGTYPE star_v1_BmsDeviceInfo
 
@@ -941,18 +941,18 @@ extern "C" {
   X(a, CALLBACK, SINGULAR, STRING, device_name, 6)                                                 \
   X(a, CALLBACK, SINGULAR, STRING, chemistry, 7)
 #define star_v1_BmsDeviceInfo_CALLBACK pb_default_field_callback
-#define star_v1_BmsDeviceInfo_DEFAULT nullptr
+#define star_v1_BmsDeviceInfo_DEFAULT  nullptr
 
 #define star_v1_ResetDeviceRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_ResetDeviceRequest_CALLBACK       nullptr
-#define star_v1_ResetDeviceRequest_DEFAULT        nullptr
+#define star_v1_ResetDeviceRequest_CALLBACK        nullptr
+#define star_v1_ResetDeviceRequest_DEFAULT         nullptr
 #define star_v1_ResetDeviceRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_ResetDeviceResponse_FIELDLIST(X, a)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, reset_initiated, 2)
-#define star_v1_ResetDeviceResponse_CALLBACK      nullptr
-#define star_v1_ResetDeviceResponse_DEFAULT       nullptr
+#define star_v1_ResetDeviceResponse_CALLBACK       nullptr
+#define star_v1_ResetDeviceResponse_DEFAULT        nullptr
 #define star_v1_ResetDeviceResponse_header_MSGTYPE star_v1_ResponseHeader
 
 extern const pb_msgdesc_t star_v1_GetBatteryStateRequest_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/common.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/common.pb.h
@@ -207,8 +207,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, client_timestamp, 2)                                             \
   X(a, STATIC, SINGULAR, STRING, client_version, 3)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, timeout, 4)
-#define star_v1_RequestHeader_CALLBACK                nullptr
-#define star_v1_RequestHeader_DEFAULT                 nullptr
+#define star_v1_RequestHeader_CALLBACK                 nullptr
+#define star_v1_RequestHeader_DEFAULT                  nullptr
 #define star_v1_RequestHeader_client_timestamp_MSGTYPE google_protobuf_Timestamp
 #define star_v1_RequestHeader_timeout_MSGTYPE          google_protobuf_Duration
 
@@ -218,38 +218,38 @@ extern "C" {
   X(a, STATIC, SINGULAR, UENUM, status, 3)                                                         \
   X(a, STATIC, SINGULAR, STRING, error_message, 4)                                                 \
   X(a, STATIC, SINGULAR, INT64, latency_us, 5)
-#define star_v1_ResponseHeader_CALLBACK                nullptr
-#define star_v1_ResponseHeader_DEFAULT                 nullptr
+#define star_v1_ResponseHeader_CALLBACK                 nullptr
+#define star_v1_ResponseHeader_DEFAULT                  nullptr
 #define star_v1_ResponseHeader_server_timestamp_MSGTYPE google_protobuf_Timestamp
 
 #define star_v1_Vector3_FIELDLIST(X, a)                                                            \
   X(a, STATIC, SINGULAR, DOUBLE, x, 1)                                                             \
   X(a, STATIC, SINGULAR, DOUBLE, y, 2)                                                             \
   X(a, STATIC, SINGULAR, DOUBLE, z, 3)
-#define star_v1_Vector3_CALLBACKnullptr
-#define star_v1_Vector3_DEFAULT nullptr
+#define star_v1_Vector3_CALLBACK nullptr
+#define star_v1_Vector3_DEFAULT  nullptr
 
 #define star_v1_Quaternion_FIELDLIST(X, a)                                                         \
   X(a, STATIC, SINGULAR, DOUBLE, w, 1)                                                             \
   X(a, STATIC, SINGULAR, DOUBLE, x, 2)                                                             \
   X(a, STATIC, SINGULAR, DOUBLE, y, 3)                                                             \
   X(a, STATIC, SINGULAR, DOUBLE, z, 4)
-#define star_v1_Quaternion_CALLBACKnullptr
-#define star_v1_Quaternion_DEFAULT nullptr
+#define star_v1_Quaternion_CALLBACK nullptr
+#define star_v1_Quaternion_DEFAULT  nullptr
 
 #define star_v1_SE2Pose_FIELDLIST(X, a)                                                            \
   X(a, STATIC, SINGULAR, DOUBLE, x_m, 1)                                                           \
   X(a, STATIC, SINGULAR, DOUBLE, y_m, 2)                                                           \
   X(a, STATIC, SINGULAR, DOUBLE, angle_rad, 3)
-#define star_v1_SE2Pose_CALLBACKnullptr
-#define star_v1_SE2Pose_DEFAULT nullptr
+#define star_v1_SE2Pose_CALLBACK nullptr
+#define star_v1_SE2Pose_DEFAULT  nullptr
 
 #define star_v1_SE2Velocity_FIELDLIST(X, a)                                                        \
   X(a, STATIC, SINGULAR, DOUBLE, vx_mps, 1)                                                        \
   X(a, STATIC, SINGULAR, DOUBLE, vy_mps, 2)                                                        \
   X(a, STATIC, SINGULAR, DOUBLE, omega_rad_per_s, 3)
-#define star_v1_SE2Velocity_CALLBACKnullptr
-#define star_v1_SE2Velocity_DEFAULT nullptr
+#define star_v1_SE2Velocity_CALLBACK nullptr
+#define star_v1_SE2Velocity_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_RequestHeader_msg;
 extern const pb_msgdesc_t star_v1_ResponseHeader_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.h
@@ -696,15 +696,15 @@ extern "C" {
 
 /* Struct field encoding specification for nanopb */
 #define star_v1_GetConfigurationRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetConfigurationRequest_CALLBACK       nullptr
-#define star_v1_GetConfigurationRequest_DEFAULT        nullptr
+#define star_v1_GetConfigurationRequest_CALLBACK        nullptr
+#define star_v1_GetConfigurationRequest_DEFAULT         nullptr
 #define star_v1_GetConfigurationRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetConfigurationResponse_FIELDLIST(X, a)                                           \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)
-#define star_v1_GetConfigurationResponse_CALLBACK             nullptr
-#define star_v1_GetConfigurationResponse_DEFAULT              nullptr
+#define star_v1_GetConfigurationResponse_CALLBACK              nullptr
+#define star_v1_GetConfigurationResponse_DEFAULT               nullptr
 #define star_v1_GetConfigurationResponse_header_MSGTYPE        star_v1_ResponseHeader
 #define star_v1_GetConfigurationResponse_configuration_MSGTYPE star_v1_SystemConfiguration
 
@@ -712,77 +712,77 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)                                                \
   X(a, STATIC, SINGULAR, BOOL, persist_to_nvs, 3)
-#define star_v1_SetConfigurationRequest_CALLBACK             nullptr
-#define star_v1_SetConfigurationRequest_DEFAULT              nullptr
+#define star_v1_SetConfigurationRequest_CALLBACK              nullptr
+#define star_v1_SetConfigurationRequest_DEFAULT               nullptr
 #define star_v1_SetConfigurationRequest_header_MSGTYPE        star_v1_RequestHeader
 #define star_v1_SetConfigurationRequest_configuration_MSGTYPE star_v1_SystemConfiguration
 
 #define star_v1_SetConfigurationResponse_FIELDLIST(X, a)                                           \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, validation_result, 2)
-#define star_v1_SetConfigurationResponse_CALLBACK                 nullptr
-#define star_v1_SetConfigurationResponse_DEFAULT                  nullptr
+#define star_v1_SetConfigurationResponse_CALLBACK                  nullptr
+#define star_v1_SetConfigurationResponse_DEFAULT                   nullptr
 #define star_v1_SetConfigurationResponse_header_MSGTYPE            star_v1_ResponseHeader
 #define star_v1_SetConfigurationResponse_validation_result_MSGTYPE star_v1_ConfigValidationResult
 
 #define star_v1_ResetToDefaultsRequest_FIELDLIST(X, a)                                             \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, persist_to_nvs, 2)
-#define star_v1_ResetToDefaultsRequest_CALLBACK      nullptr
-#define star_v1_ResetToDefaultsRequest_DEFAULT       nullptr
+#define star_v1_ResetToDefaultsRequest_CALLBACK       nullptr
+#define star_v1_ResetToDefaultsRequest_DEFAULT        nullptr
 #define star_v1_ResetToDefaultsRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_ResetToDefaultsResponse_FIELDLIST(X, a)                                            \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)
-#define star_v1_ResetToDefaultsResponse_CALLBACK             nullptr
-#define star_v1_ResetToDefaultsResponse_DEFAULT              nullptr
+#define star_v1_ResetToDefaultsResponse_CALLBACK              nullptr
+#define star_v1_ResetToDefaultsResponse_DEFAULT               nullptr
 #define star_v1_ResetToDefaultsResponse_header_MSGTYPE        star_v1_ResponseHeader
 #define star_v1_ResetToDefaultsResponse_configuration_MSGTYPE star_v1_SystemConfiguration
 
 #define star_v1_ValidateConfigurationRequest_FIELDLIST(X, a)                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)
-#define star_v1_ValidateConfigurationRequest_CALLBACK             nullptr
-#define star_v1_ValidateConfigurationRequest_DEFAULT              nullptr
+#define star_v1_ValidateConfigurationRequest_CALLBACK              nullptr
+#define star_v1_ValidateConfigurationRequest_DEFAULT               nullptr
 #define star_v1_ValidateConfigurationRequest_header_MSGTYPE        star_v1_RequestHeader
 #define star_v1_ValidateConfigurationRequest_configuration_MSGTYPE star_v1_SystemConfiguration
 
 #define star_v1_ValidateConfigurationResponse_FIELDLIST(X, a)                                      \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, validation_result, 2)
-#define star_v1_ValidateConfigurationResponse_CALLBACK      nullptr
-#define star_v1_ValidateConfigurationResponse_DEFAULT       nullptr
+#define star_v1_ValidateConfigurationResponse_CALLBACK       nullptr
+#define star_v1_ValidateConfigurationResponse_DEFAULT        nullptr
 #define star_v1_ValidateConfigurationResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_ValidateConfigurationResponse_validation_result_MSGTYPE                            \
   star_v1_ConfigValidationResult
 
 #define star_v1_SaveConfigurationRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SaveConfigurationRequest_CALLBACK       nullptr
-#define star_v1_SaveConfigurationRequest_DEFAULT        nullptr
+#define star_v1_SaveConfigurationRequest_CALLBACK        nullptr
+#define star_v1_SaveConfigurationRequest_DEFAULT         nullptr
 #define star_v1_SaveConfigurationRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_SaveConfigurationResponse_FIELDLIST(X, a)                                          \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, saved, 2)                                                           \
   X(a, STATIC, SINGULAR, UINT32, config_crc, 3)
-#define star_v1_SaveConfigurationResponse_CALLBACK      nullptr
-#define star_v1_SaveConfigurationResponse_DEFAULT       nullptr
+#define star_v1_SaveConfigurationResponse_CALLBACK       nullptr
+#define star_v1_SaveConfigurationResponse_DEFAULT        nullptr
 #define star_v1_SaveConfigurationResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_GetMotorPidConfigRequest_FIELDLIST(X, a)                                           \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, INT32, motor_id, 2)
-#define star_v1_GetMotorPidConfigRequest_CALLBACK      nullptr
-#define star_v1_GetMotorPidConfigRequest_DEFAULT       nullptr
+#define star_v1_GetMotorPidConfigRequest_CALLBACK       nullptr
+#define star_v1_GetMotorPidConfigRequest_DEFAULT        nullptr
 #define star_v1_GetMotorPidConfigRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_GetMotorPidConfigResponse_FIELDLIST(X, a)                                          \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, INT32, motor_id, 2)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 3)
-#define star_v1_GetMotorPidConfigResponse_CALLBACK          nullptr
-#define star_v1_GetMotorPidConfigResponse_DEFAULT           nullptr
+#define star_v1_GetMotorPidConfigResponse_CALLBACK           nullptr
+#define star_v1_GetMotorPidConfigResponse_DEFAULT            nullptr
 #define star_v1_GetMotorPidConfigResponse_header_MSGTYPE     star_v1_ResponseHeader
 #define star_v1_GetMotorPidConfigResponse_pid_config_MSGTYPE star_v1_PidConfig
 
@@ -791,16 +791,16 @@ extern "C" {
   X(a, STATIC, SINGULAR, INT32, motor_id, 2)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 3)                                                   \
   X(a, STATIC, SINGULAR, BOOL, persist_to_nvs, 4)
-#define star_v1_SetMotorPidConfigRequest_CALLBACK          nullptr
-#define star_v1_SetMotorPidConfigRequest_DEFAULT           nullptr
+#define star_v1_SetMotorPidConfigRequest_CALLBACK           nullptr
+#define star_v1_SetMotorPidConfigRequest_DEFAULT            nullptr
 #define star_v1_SetMotorPidConfigRequest_header_MSGTYPE     star_v1_RequestHeader
 #define star_v1_SetMotorPidConfigRequest_pid_config_MSGTYPE star_v1_PidConfig
 
 #define star_v1_SetMotorPidConfigResponse_FIELDLIST(X, a)                                          \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, validation_result, 2)
-#define star_v1_SetMotorPidConfigResponse_CALLBACK                 nullptr
-#define star_v1_SetMotorPidConfigResponse_DEFAULT                  nullptr
+#define star_v1_SetMotorPidConfigResponse_CALLBACK                  nullptr
+#define star_v1_SetMotorPidConfigResponse_DEFAULT                   nullptr
 #define star_v1_SetMotorPidConfigResponse_header_MSGTYPE            star_v1_ResponseHeader
 #define star_v1_SetMotorPidConfigResponse_validation_result_MSGTYPE star_v1_ConfigValidationResult
 
@@ -809,21 +809,21 @@ extern "C" {
   X(a, STATIC, SINGULAR, UINT32, max_retries, 2)                                                   \
   X(a, STATIC, SINGULAR, UINT32, ack_timeout_ms, 3)                                                \
   X(a, STATIC, SINGULAR, UINT32, max_backoff_ms, 4)
-#define star_v1_RetransmitConfig_CALLBACKnullptr
-#define star_v1_RetransmitConfig_DEFAULT nullptr
+#define star_v1_RetransmitConfig_CALLBACK nullptr
+#define star_v1_RetransmitConfig_DEFAULT  nullptr
 
 #define star_v1_SetRetransmitConfigRequest_FIELDLIST(X, a)                                         \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, retransmit_config, 2)
-#define star_v1_SetRetransmitConfigRequest_CALLBACK                 nullptr
-#define star_v1_SetRetransmitConfigRequest_DEFAULT                  nullptr
+#define star_v1_SetRetransmitConfigRequest_CALLBACK                  nullptr
+#define star_v1_SetRetransmitConfigRequest_DEFAULT                   nullptr
 #define star_v1_SetRetransmitConfigRequest_header_MSGTYPE            star_v1_RequestHeader
 #define star_v1_SetRetransmitConfigRequest_retransmit_config_MSGTYPE star_v1_RetransmitConfig
 
 #define star_v1_SetRetransmitConfigResponse_FIELDLIST(X, a)                                        \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SetRetransmitConfigResponse_CALLBACK      nullptr
-#define star_v1_SetRetransmitConfigResponse_DEFAULT       nullptr
+#define star_v1_SetRetransmitConfigResponse_CALLBACK       nullptr
+#define star_v1_SetRetransmitConfigResponse_DEFAULT        nullptr
 #define star_v1_SetRetransmitConfigResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_SystemConfiguration_FIELDLIST(X, a)                                                \
@@ -835,8 +835,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, timing_config, 6)                                                \
   X(a, STATIC, SINGULAR, UINT32, config_version, 7)                                                \
   X(a, STATIC, SINGULAR, UINT32, config_crc, 8)
-#define star_v1_SystemConfiguration_CALLBACK                       nullptr
-#define star_v1_SystemConfiguration_DEFAULT                        nullptr
+#define star_v1_SystemConfiguration_CALLBACK                        nullptr
+#define star_v1_SystemConfiguration_DEFAULT                         nullptr
 #define star_v1_SystemConfiguration_motor_configs_MSGTYPE           star_v1_MotorPidConfiguration
 #define star_v1_SystemConfiguration_current_calibration_MSGTYPE     star_v1_CurrentSensorCalibration
 #define star_v1_SystemConfiguration_temperature_calibration_MSGTYPE star_v1_TemperatureCalibration
@@ -847,48 +847,48 @@ extern "C" {
 #define star_v1_MotorPidConfiguration_FIELDLIST(X, a)                                              \
   X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 2)
-#define star_v1_MotorPidConfiguration_CALLBACK          nullptr
-#define star_v1_MotorPidConfiguration_DEFAULT           nullptr
+#define star_v1_MotorPidConfiguration_CALLBACK           nullptr
+#define star_v1_MotorPidConfiguration_DEFAULT            nullptr
 #define star_v1_MotorPidConfiguration_pid_config_MSGTYPE star_v1_PidConfig
 
 #define star_v1_CurrentSensorCalibration_FIELDLIST(X, a)                                           \
   X(a, CALLBACK, REPEATED, DOUBLE, offset_ma, 1)                                                   \
   X(a, CALLBACK, REPEATED, DOUBLE, scale_factor, 2)
 #define star_v1_CurrentSensorCalibration_CALLBACK pb_default_field_callback
-#define star_v1_CurrentSensorCalibration_DEFAULT nullptr
+#define star_v1_CurrentSensorCalibration_DEFAULT  nullptr
 
 #define star_v1_TemperatureCalibration_FIELDLIST(X, a)                                             \
   X(a, STATIC, SINGULAR, DOUBLE, offset_celsius, 1)
-#define star_v1_TemperatureCalibration_CALLBACKnullptr
-#define star_v1_TemperatureCalibration_DEFAULT nullptr
+#define star_v1_TemperatureCalibration_CALLBACK nullptr
+#define star_v1_TemperatureCalibration_DEFAULT  nullptr
 
 #define star_v1_SafetyThresholds_FIELDLIST(X, a)                                                   \
   X(a, STATIC, SINGULAR, UINT32, overcurrent_threshold_ma, 1)                                      \
   X(a, STATIC, SINGULAR, INT32, thermal_shutdown_deci_celsius, 2)                                  \
   X(a, STATIC, SINGULAR, UINT32, cell_imbalance_threshold_mv, 3)
-#define star_v1_SafetyThresholds_CALLBACKnullptr
-#define star_v1_SafetyThresholds_DEFAULT nullptr
+#define star_v1_SafetyThresholds_CALLBACK nullptr
+#define star_v1_SafetyThresholds_DEFAULT  nullptr
 
 #define star_v1_EncoderConfiguration_FIELDLIST(X, a)                                               \
   X(a, STATIC, SINGULAR, UINT32, edges_per_revolution, 1)                                          \
   X(a, STATIC, SINGULAR, DOUBLE, wheel_diameter_m, 2)                                              \
   X(a, STATIC, SINGULAR, DOUBLE, gear_ratio, 3)
-#define star_v1_EncoderConfiguration_CALLBACKnullptr
-#define star_v1_EncoderConfiguration_DEFAULT nullptr
+#define star_v1_EncoderConfiguration_CALLBACK nullptr
+#define star_v1_EncoderConfiguration_DEFAULT  nullptr
 
 #define star_v1_TimingConfiguration_FIELDLIST(X, a)                                                \
   X(a, STATIC, SINGULAR, UINT32, motor_control_period_ms, 1)                                       \
   X(a, STATIC, SINGULAR, UINT32, telemetry_period_ms, 2)                                           \
   X(a, STATIC, SINGULAR, UINT32, communication_timeout_ms, 3)                                      \
   X(a, STATIC, SINGULAR, UINT32, bms_poll_period_ms, 4)
-#define star_v1_TimingConfiguration_CALLBACKnullptr
-#define star_v1_TimingConfiguration_DEFAULT nullptr
+#define star_v1_TimingConfiguration_CALLBACK nullptr
+#define star_v1_TimingConfiguration_DEFAULT  nullptr
 
 #define star_v1_ConfigValidationResult_FIELDLIST(X, a)                                             \
   X(a, STATIC, SINGULAR, UENUM, status, 1)                                                         \
   X(a, STATIC, REPEATED, MESSAGE, errors, 2)
-#define star_v1_ConfigValidationResult_CALLBACK      nullptr
-#define star_v1_ConfigValidationResult_DEFAULT       nullptr
+#define star_v1_ConfigValidationResult_CALLBACK       nullptr
+#define star_v1_ConfigValidationResult_DEFAULT        nullptr
 #define star_v1_ConfigValidationResult_errors_MSGTYPE star_v1_ConfigValidationError
 
 #define star_v1_ConfigValidationError_FIELDLIST(X, a)                                              \
@@ -897,8 +897,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, STRING, message, 3)                                                       \
   X(a, STATIC, SINGULAR, STRING, actual_value, 4)                                                  \
   X(a, STATIC, SINGULAR, STRING, expected_constraint, 5)
-#define star_v1_ConfigValidationError_CALLBACKnullptr
-#define star_v1_ConfigValidationError_DEFAULT nullptr
+#define star_v1_ConfigValidationError_CALLBACK nullptr
+#define star_v1_ConfigValidationError_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_GetConfigurationRequest_msg;
 extern const pb_msgdesc_t star_v1_GetConfigurationResponse_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/controller.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/controller.pb.h
@@ -49,8 +49,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, FLOAT, angular_vel, 2)                                                    \
   X(a, STATIC, SINGULAR, INT64, timestamp, 3)                                                      \
   X(a, STATIC, SINGULAR, BOOL, debug, 4)
-#define star_v1_ControllerState_CALLBACKnullptr
-#define star_v1_ControllerState_DEFAULT nullptr
+#define star_v1_ControllerState_CALLBACK nullptr
+#define star_v1_ControllerState_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_ControllerState_msg;
 

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/firmware_update.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/firmware_update.pb.h
@@ -666,7 +666,7 @@ extern "C" {
   X(a, CALLBACK, SINGULAR, STRING, expected_version, 3)                                            \
   X(a, STATIC, SINGULAR, UINT32, expected_crc32, 4)
 #define star_v1_BeginUpdateRequest_CALLBACK       pb_default_field_callback
-#define star_v1_BeginUpdateRequest_DEFAULT       nullptr
+#define star_v1_BeginUpdateRequest_DEFAULT        nullptr
 #define star_v1_BeginUpdateRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_BeginUpdateResponse_FIELDLIST(X, a)                                                \
@@ -676,15 +676,15 @@ extern "C" {
   X(a, CALLBACK, SINGULAR, STRING, session_id, 4)                                                  \
   X(a, STATIC, OPTIONAL, MESSAGE, error, 5)
 #define star_v1_BeginUpdateResponse_CALLBACK       pb_default_field_callback
-#define star_v1_BeginUpdateResponse_DEFAULT       nullptr
+#define star_v1_BeginUpdateResponse_DEFAULT        nullptr
 #define star_v1_BeginUpdateResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_BeginUpdateResponse_error_MSGTYPE  star_v1_FirmwareUpdateError
 
 #define star_v1_WriteChunkRequest_FIELDLIST(X, a)                                                  \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, chunk, 2)
-#define star_v1_WriteChunkRequest_CALLBACK      nullptr
-#define star_v1_WriteChunkRequest_DEFAULT       nullptr
+#define star_v1_WriteChunkRequest_CALLBACK       nullptr
+#define star_v1_WriteChunkRequest_DEFAULT        nullptr
 #define star_v1_WriteChunkRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_WriteChunkRequest_chunk_MSGTYPE  star_v1_FirmwareChunk
 
@@ -692,8 +692,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, success, 2)                                                         \
   X(a, STATIC, OPTIONAL, MESSAGE, progress, 3)
-#define star_v1_WriteChunkResponse_CALLBACK        nullptr
-#define star_v1_WriteChunkResponse_DEFAULT         nullptr
+#define star_v1_WriteChunkResponse_CALLBACK         nullptr
+#define star_v1_WriteChunkResponse_DEFAULT          nullptr
 #define star_v1_WriteChunkResponse_header_MSGTYPE   star_v1_ResponseHeader
 #define star_v1_WriteChunkResponse_progress_MSGTYPE star_v1_FirmwareUpdateProgress
 
@@ -703,22 +703,22 @@ extern "C" {
   X(a, STATIC, SINGULAR, UINT32, offset, 3)                                                        \
   X(a, STATIC, SINGULAR, UINT32, chunk_crc32, 4)
 #define star_v1_FirmwareChunk_CALLBACK pb_default_field_callback
-#define star_v1_FirmwareChunk_DEFAULT nullptr
+#define star_v1_FirmwareChunk_DEFAULT  nullptr
 
 #define star_v1_StreamChunksResponse_FIELDLIST(X, a)                                               \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, UINT32, chunks_received, 2)                                               \
   X(a, STATIC, OPTIONAL, MESSAGE, progress, 3)                                                     \
   X(a, STATIC, OPTIONAL, MESSAGE, error, 4)
-#define star_v1_StreamChunksResponse_CALLBACK        nullptr
-#define star_v1_StreamChunksResponse_DEFAULT         nullptr
+#define star_v1_StreamChunksResponse_CALLBACK         nullptr
+#define star_v1_StreamChunksResponse_DEFAULT          nullptr
 #define star_v1_StreamChunksResponse_header_MSGTYPE   star_v1_ResponseHeader
 #define star_v1_StreamChunksResponse_progress_MSGTYPE star_v1_FirmwareUpdateProgress
 #define star_v1_StreamChunksResponse_error_MSGTYPE    star_v1_FirmwareUpdateError
 
 #define star_v1_FinalizeUpdateRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_FinalizeUpdateRequest_CALLBACK       nullptr
-#define star_v1_FinalizeUpdateRequest_DEFAULT        nullptr
+#define star_v1_FinalizeUpdateRequest_CALLBACK        nullptr
+#define star_v1_FinalizeUpdateRequest_DEFAULT         nullptr
 #define star_v1_FinalizeUpdateRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_FinalizeUpdateResponse_FIELDLIST(X, a)                                             \
@@ -726,8 +726,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, BOOL, validated, 2)                                                       \
   X(a, STATIC, SINGULAR, BOOL, ready_to_reboot, 3)                                                 \
   X(a, STATIC, OPTIONAL, MESSAGE, error, 4)
-#define star_v1_FinalizeUpdateResponse_CALLBACK      nullptr
-#define star_v1_FinalizeUpdateResponse_DEFAULT       nullptr
+#define star_v1_FinalizeUpdateResponse_CALLBACK       nullptr
+#define star_v1_FinalizeUpdateResponse_DEFAULT        nullptr
 #define star_v1_FinalizeUpdateResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_FinalizeUpdateResponse_error_MSGTYPE  star_v1_FirmwareUpdateError
 
@@ -735,34 +735,34 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, CALLBACK, SINGULAR, STRING, reason, 2)
 #define star_v1_AbortUpdateRequest_CALLBACK       pb_default_field_callback
-#define star_v1_AbortUpdateRequest_DEFAULT       nullptr
+#define star_v1_AbortUpdateRequest_DEFAULT        nullptr
 #define star_v1_AbortUpdateRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_AbortUpdateResponse_FIELDLIST(X, a)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, aborted, 2)
-#define star_v1_AbortUpdateResponse_CALLBACK      nullptr
-#define star_v1_AbortUpdateResponse_DEFAULT       nullptr
+#define star_v1_AbortUpdateResponse_CALLBACK       nullptr
+#define star_v1_AbortUpdateResponse_DEFAULT        nullptr
 #define star_v1_AbortUpdateResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_GetUpdateProgressRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetUpdateProgressRequest_CALLBACK       nullptr
-#define star_v1_GetUpdateProgressRequest_DEFAULT        nullptr
+#define star_v1_GetUpdateProgressRequest_CALLBACK        nullptr
+#define star_v1_GetUpdateProgressRequest_DEFAULT         nullptr
 #define star_v1_GetUpdateProgressRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetUpdateProgressResponse_FIELDLIST(X, a)                                          \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, progress, 2)
-#define star_v1_GetUpdateProgressResponse_CALLBACK        nullptr
-#define star_v1_GetUpdateProgressResponse_DEFAULT         nullptr
+#define star_v1_GetUpdateProgressResponse_CALLBACK         nullptr
+#define star_v1_GetUpdateProgressResponse_DEFAULT          nullptr
 #define star_v1_GetUpdateProgressResponse_header_MSGTYPE   star_v1_ResponseHeader
 #define star_v1_GetUpdateProgressResponse_progress_MSGTYPE star_v1_FirmwareUpdateProgress
 
 #define star_v1_StreamUpdateProgressRequest_FIELDLIST(X, a)                                        \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, UINT32, update_interval_ms, 2)
-#define star_v1_StreamUpdateProgressRequest_CALLBACK      nullptr
-#define star_v1_StreamUpdateProgressRequest_DEFAULT       nullptr
+#define star_v1_StreamUpdateProgressRequest_CALLBACK       nullptr
+#define star_v1_StreamUpdateProgressRequest_DEFAULT        nullptr
 #define star_v1_StreamUpdateProgressRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_FirmwareUpdateProgress_FIELDLIST(X, a)                                             \
@@ -774,27 +774,27 @@ extern "C" {
   X(a, STATIC, SINGULAR, INT32, estimated_seconds_remaining, 6)                                    \
   X(a, STATIC, SINGULAR, UINT32, transfer_speed_bps, 7)                                            \
   X(a, STATIC, SINGULAR, UINT32, last_sequence, 8)
-#define star_v1_FirmwareUpdateProgress_CALLBACKnullptr
-#define star_v1_FirmwareUpdateProgress_DEFAULT nullptr
+#define star_v1_FirmwareUpdateProgress_CALLBACK nullptr
+#define star_v1_FirmwareUpdateProgress_DEFAULT  nullptr
 
 #define star_v1_RebootRequest_FIELDLIST(X, a)                                                      \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, UINT32, delay_ms, 2)
-#define star_v1_RebootRequest_CALLBACK      nullptr
-#define star_v1_RebootRequest_DEFAULT       nullptr
+#define star_v1_RebootRequest_CALLBACK       nullptr
+#define star_v1_RebootRequest_DEFAULT        nullptr
 #define star_v1_RebootRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_RebootResponse_FIELDLIST(X, a)                                                     \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, rebooting, 2)                                                       \
   X(a, STATIC, SINGULAR, UINT32, reboot_delay_ms, 3)
-#define star_v1_RebootResponse_CALLBACK      nullptr
-#define star_v1_RebootResponse_DEFAULT       nullptr
+#define star_v1_RebootResponse_CALLBACK       nullptr
+#define star_v1_RebootResponse_DEFAULT        nullptr
 #define star_v1_RebootResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_RollbackRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_RollbackRequest_CALLBACK       nullptr
-#define star_v1_RollbackRequest_DEFAULT        nullptr
+#define star_v1_RollbackRequest_CALLBACK        nullptr
+#define star_v1_RollbackRequest_DEFAULT         nullptr
 #define star_v1_RollbackRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_RollbackResponse_FIELDLIST(X, a)                                                   \
@@ -802,24 +802,24 @@ extern "C" {
   X(a, STATIC, SINGULAR, BOOL, rolling_back, 2)                                                    \
   X(a, CALLBACK, SINGULAR, STRING, previous_version, 3)
 #define star_v1_RollbackResponse_CALLBACK       pb_default_field_callback
-#define star_v1_RollbackResponse_DEFAULT       nullptr
+#define star_v1_RollbackResponse_DEFAULT        nullptr
 #define star_v1_RollbackResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_MarkValidRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_MarkValidRequest_CALLBACK       nullptr
-#define star_v1_MarkValidRequest_DEFAULT        nullptr
+#define star_v1_MarkValidRequest_CALLBACK        nullptr
+#define star_v1_MarkValidRequest_DEFAULT         nullptr
 #define star_v1_MarkValidRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_MarkValidResponse_FIELDLIST(X, a)                                                  \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, marked_valid, 2)
-#define star_v1_MarkValidResponse_CALLBACK      nullptr
-#define star_v1_MarkValidResponse_DEFAULT       nullptr
+#define star_v1_MarkValidResponse_CALLBACK       nullptr
+#define star_v1_MarkValidResponse_DEFAULT        nullptr
 #define star_v1_MarkValidResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_GetFirmwareInfoRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetFirmwareInfoRequest_CALLBACK       nullptr
-#define star_v1_GetFirmwareInfoRequest_DEFAULT        nullptr
+#define star_v1_GetFirmwareInfoRequest_CALLBACK        nullptr
+#define star_v1_GetFirmwareInfoRequest_DEFAULT         nullptr
 #define star_v1_GetFirmwareInfoRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetFirmwareInfoResponse_FIELDLIST(X, a)                                            \
@@ -828,8 +828,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, previous_firmware, 3)                                            \
   X(a, STATIC, SINGULAR, BOOL, is_ota_boot, 4)                                                     \
   X(a, STATIC, SINGULAR, BOOL, is_valid, 5)
-#define star_v1_GetFirmwareInfoResponse_CALLBACK                 nullptr
-#define star_v1_GetFirmwareInfoResponse_DEFAULT                  nullptr
+#define star_v1_GetFirmwareInfoResponse_CALLBACK                  nullptr
+#define star_v1_GetFirmwareInfoResponse_DEFAULT                   nullptr
 #define star_v1_GetFirmwareInfoResponse_header_MSGTYPE            star_v1_ResponseHeader
 #define star_v1_GetFirmwareInfoResponse_current_firmware_MSGTYPE  star_v1_FirmwareInfo
 #define star_v1_GetFirmwareInfoResponse_previous_firmware_MSGTYPE star_v1_FirmwareInfo
@@ -843,7 +843,7 @@ extern "C" {
   X(a, CALLBACK, SINGULAR, STRING, idf_version, 6)                                                 \
   X(a, CALLBACK, SINGULAR, STRING, chip_target, 7)
 #define star_v1_FirmwareInfo_CALLBACK pb_default_field_callback
-#define star_v1_FirmwareInfo_DEFAULT nullptr
+#define star_v1_FirmwareInfo_DEFAULT  nullptr
 
 #define star_v1_FirmwareUpdateError_FIELDLIST(X, a)                                                \
   X(a, STATIC, SINGULAR, UENUM, code, 1)                                                           \
@@ -852,7 +852,7 @@ extern "C" {
   X(a, STATIC, SINGULAR, UINT32, error_at_sequence, 4)                                             \
   X(a, STATIC, SINGULAR, UINT32, error_at_offset, 5)
 #define star_v1_FirmwareUpdateError_CALLBACK pb_default_field_callback
-#define star_v1_FirmwareUpdateError_DEFAULT nullptr
+#define star_v1_FirmwareUpdateError_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_BeginUpdateRequest_msg;
 extern const pb_msgdesc_t star_v1_BeginUpdateResponse_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.h
@@ -179,8 +179,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, system_status, 2)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, battery_state, 3)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, telemetry, 4)
-#define star_v1_ForwardTelemetryRequest_CALLBACK             nullptr
-#define star_v1_ForwardTelemetryRequest_DEFAULT              nullptr
+#define star_v1_ForwardTelemetryRequest_CALLBACK              nullptr
+#define star_v1_ForwardTelemetryRequest_DEFAULT               nullptr
 #define star_v1_ForwardTelemetryRequest_header_MSGTYPE        star_v1_RequestHeader
 #define star_v1_ForwardTelemetryRequest_system_status_MSGTYPE star_v1_SystemStatus
 #define star_v1_ForwardTelemetryRequest_battery_state_MSGTYPE star_v1_BatteryState
@@ -190,13 +190,13 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, cached, 2)                                                          \
   X(a, STATIC, SINGULAR, INT32, active_clients, 3)
-#define star_v1_ForwardTelemetryResponse_CALLBACK      nullptr
-#define star_v1_ForwardTelemetryResponse_DEFAULT       nullptr
+#define star_v1_ForwardTelemetryResponse_CALLBACK       nullptr
+#define star_v1_ForwardTelemetryResponse_DEFAULT        nullptr
 #define star_v1_ForwardTelemetryResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_GetTeleopCommandRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetTeleopCommandRequest_CALLBACK       nullptr
-#define star_v1_GetTeleopCommandRequest_DEFAULT        nullptr
+#define star_v1_GetTeleopCommandRequest_CALLBACK        nullptr
+#define star_v1_GetTeleopCommandRequest_DEFAULT         nullptr
 #define star_v1_GetTeleopCommandRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetTeleopCommandResponse_FIELDLIST(X, a)                                           \
@@ -204,8 +204,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, command, 2)                                                      \
   X(a, STATIC, SINGULAR, BOOL, command_available, 3)                                               \
   X(a, STATIC, SINGULAR, INT64, command_age_ms, 4)
-#define star_v1_GetTeleopCommandResponse_CALLBACK       nullptr
-#define star_v1_GetTeleopCommandResponse_DEFAULT        nullptr
+#define star_v1_GetTeleopCommandResponse_CALLBACK        nullptr
+#define star_v1_GetTeleopCommandResponse_DEFAULT         nullptr
 #define star_v1_GetTeleopCommandResponse_header_MSGTYPE  star_v1_ResponseHeader
 #define star_v1_GetTeleopCommandResponse_command_MSGTYPE star_v1_VelocityCommand
 
@@ -213,8 +213,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 2)                                                   \
   X(a, STATIC, SINGULAR, INT32, motor_id, 3)
-#define star_v1_SetPIDGainsRequest_CALLBACK          nullptr
-#define star_v1_SetPIDGainsRequest_DEFAULT           nullptr
+#define star_v1_SetPIDGainsRequest_CALLBACK           nullptr
+#define star_v1_SetPIDGainsRequest_DEFAULT            nullptr
 #define star_v1_SetPIDGainsRequest_header_MSGTYPE     star_v1_RequestHeader
 #define star_v1_SetPIDGainsRequest_pid_config_MSGTYPE star_v1_PidConfig
 
@@ -223,7 +223,7 @@ extern "C" {
   X(a, STATIC, SINGULAR, BOOL, success, 2)                                                         \
   X(a, CALLBACK, SINGULAR, STRING, message, 3)
 #define star_v1_SetPIDGainsResponse_CALLBACK       pb_default_field_callback
-#define star_v1_SetPIDGainsResponse_DEFAULT       nullptr
+#define star_v1_SetPIDGainsResponse_DEFAULT        nullptr
 #define star_v1_SetPIDGainsResponse_header_MSGTYPE star_v1_ResponseHeader
 
 extern const pb_msgdesc_t star_v1_ForwardTelemetryRequest_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.h
@@ -359,16 +359,16 @@ extern "C" {
 #define star_v1_SetVelocityRequest_FIELDLIST(X, a)                                                 \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, command, 2)
-#define star_v1_SetVelocityRequest_CALLBACK       nullptr
-#define star_v1_SetVelocityRequest_DEFAULT        nullptr
+#define star_v1_SetVelocityRequest_CALLBACK        nullptr
+#define star_v1_SetVelocityRequest_DEFAULT         nullptr
 #define star_v1_SetVelocityRequest_header_MSGTYPE  star_v1_RequestHeader
 #define star_v1_SetVelocityRequest_command_MSGTYPE star_v1_VelocityCommand
 
 #define star_v1_SetVelocityResponse_FIELDLIST(X, a)                                                \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, REPEATED, MESSAGE, motor_status, 2)
-#define star_v1_SetVelocityResponse_CALLBACK            nullptr
-#define star_v1_SetVelocityResponse_DEFAULT             nullptr
+#define star_v1_SetVelocityResponse_CALLBACK             nullptr
+#define star_v1_SetVelocityResponse_DEFAULT              nullptr
 #define star_v1_SetVelocityResponse_header_MSGTYPE       star_v1_ResponseHeader
 #define star_v1_SetVelocityResponse_motor_status_MSGTYPE star_v1_MotorStatus
 
@@ -379,47 +379,47 @@ extern "C" {
   X(a, STATIC, SINGULAR, INT64, timestamp_us, 4)                                                   \
   X(a, STATIC, SINGULAR, DOUBLE, back_left_velocity_mps, 5)                                        \
   X(a, STATIC, SINGULAR, DOUBLE, back_right_velocity_mps, 6)
-#define star_v1_VelocityCommand_CALLBACKnullptr
-#define star_v1_VelocityCommand_DEFAULT nullptr
+#define star_v1_VelocityCommand_CALLBACK nullptr
+#define star_v1_VelocityCommand_DEFAULT  nullptr
 
 #define star_v1_EmergencyStopRequest_FIELDLIST(X, a)                                               \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, STRING, reason, 2)
-#define star_v1_EmergencyStopRequest_CALLBACK      nullptr
-#define star_v1_EmergencyStopRequest_DEFAULT       nullptr
+#define star_v1_EmergencyStopRequest_CALLBACK       nullptr
+#define star_v1_EmergencyStopRequest_DEFAULT        nullptr
 #define star_v1_EmergencyStopRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_EmergencyStopResponse_FIELDLIST(X, a)                                              \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, BOOL, estop_engaged, 2)
-#define star_v1_EmergencyStopResponse_CALLBACK      nullptr
-#define star_v1_EmergencyStopResponse_DEFAULT       nullptr
+#define star_v1_EmergencyStopResponse_CALLBACK       nullptr
+#define star_v1_EmergencyStopResponse_DEFAULT        nullptr
 #define star_v1_EmergencyStopResponse_header_MSGTYPE star_v1_ResponseHeader
 
 #define star_v1_SetMotorPowerRequest_FIELDLIST(X, a)                                               \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, command, 2)
-#define star_v1_SetMotorPowerRequest_CALLBACK       nullptr
-#define star_v1_SetMotorPowerRequest_DEFAULT        nullptr
+#define star_v1_SetMotorPowerRequest_CALLBACK        nullptr
+#define star_v1_SetMotorPowerRequest_DEFAULT         nullptr
 #define star_v1_SetMotorPowerRequest_header_MSGTYPE  star_v1_RequestHeader
 #define star_v1_SetMotorPowerRequest_command_MSGTYPE star_v1_MotorPowerCommand
 
 #define star_v1_SetMotorPowerResponse_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SetMotorPowerResponse_CALLBACK       nullptr
-#define star_v1_SetMotorPowerResponse_DEFAULT        nullptr
+#define star_v1_SetMotorPowerResponse_CALLBACK        nullptr
+#define star_v1_SetMotorPowerResponse_DEFAULT         nullptr
 #define star_v1_SetMotorPowerResponse_header_MSGTYPE  star_v1_ResponseHeader
 
 #define star_v1_MotorPowerCommand_FIELDLIST(X, a)                                                  \
   X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
   X(a, STATIC, SINGULAR, DOUBLE, duty_cycle_percent, 2)
-#define star_v1_MotorPowerCommand_CALLBACKnullptr
-#define star_v1_MotorPowerCommand_DEFAULT nullptr
+#define star_v1_MotorPowerCommand_CALLBACK nullptr
+#define star_v1_MotorPowerCommand_DEFAULT  nullptr
 
 #define star_v1_StreamEncodersRequest_FIELDLIST(X, a)                                              \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, INT32, rate_hz, 2)
-#define star_v1_StreamEncodersRequest_CALLBACK      nullptr
-#define star_v1_StreamEncodersRequest_DEFAULT       nullptr
+#define star_v1_StreamEncodersRequest_CALLBACK       nullptr
+#define star_v1_StreamEncodersRequest_DEFAULT        nullptr
 #define star_v1_StreamEncodersRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_EncoderData_FIELDLIST(X, a)                                                        \
@@ -427,8 +427,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, INT64, ticks, 2)                                                          \
   X(a, STATIC, SINGULAR, DOUBLE, velocity_mps, 3)                                                  \
   X(a, STATIC, SINGULAR, INT64, timestamp_us, 4)
-#define star_v1_EncoderData_CALLBACKnullptr
-#define star_v1_EncoderData_DEFAULT nullptr
+#define star_v1_EncoderData_CALLBACK nullptr
+#define star_v1_EncoderData_DEFAULT  nullptr
 
 #define star_v1_MotorStatus_FIELDLIST(X, a)                                                        \
   X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
@@ -439,8 +439,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, DOUBLE, current_ma, 6)                                                    \
   X(a, STATIC, SINGULAR, UINT32, fault_flags, 7)                                                   \
   X(a, STATIC, SINGULAR, UENUM, state, 8)
-#define star_v1_MotorStatus_CALLBACKnullptr
-#define star_v1_MotorStatus_DEFAULT nullptr
+#define star_v1_MotorStatus_CALLBACK nullptr
+#define star_v1_MotorStatus_DEFAULT  nullptr
 
 #define star_v1_PidConfig_FIELDLIST(X, a)                                                          \
   X(a, STATIC, SINGULAR, DOUBLE, kp, 1)                                                            \
@@ -450,8 +450,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, DOUBLE, output_max_percent, 5)                                            \
   X(a, STATIC, SINGULAR, DOUBLE, integral_min, 6)                                                  \
   X(a, STATIC, SINGULAR, DOUBLE, integral_max, 7)
-#define star_v1_PidConfig_CALLBACKnullptr
-#define star_v1_PidConfig_DEFAULT nullptr
+#define star_v1_PidConfig_CALLBACK nullptr
+#define star_v1_PidConfig_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_SetVelocityRequest_msg;
 extern const pb_msgdesc_t star_v1_SetVelocityResponse_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
@@ -395,15 +395,15 @@ extern "C" {
 
 /* Struct field encoding specification for nanopb */
 #define star_v1_GetTelemetryRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetTelemetryRequest_CALLBACK       nullptr
-#define star_v1_GetTelemetryRequest_DEFAULT        nullptr
+#define star_v1_GetTelemetryRequest_CALLBACK        nullptr
+#define star_v1_GetTelemetryRequest_DEFAULT         nullptr
 #define star_v1_GetTelemetryRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetTelemetryResponse_FIELDLIST(X, a)                                               \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, telemetry, 2)
-#define star_v1_GetTelemetryResponse_CALLBACK         nullptr
-#define star_v1_GetTelemetryResponse_DEFAULT          nullptr
+#define star_v1_GetTelemetryResponse_CALLBACK          nullptr
+#define star_v1_GetTelemetryResponse_DEFAULT           nullptr
 #define star_v1_GetTelemetryResponse_header_MSGTYPE    star_v1_ResponseHeader
 #define star_v1_GetTelemetryResponse_telemetry_MSGTYPE star_v1_TelemetryData
 
@@ -411,20 +411,20 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, SINGULAR, INT32, rate_hz, 2)                                                        \
   X(a, STATIC, REPEATED, STRING, fields, 3)
-#define star_v1_StreamTelemetryRequest_CALLBACK      nullptr
-#define star_v1_StreamTelemetryRequest_DEFAULT       nullptr
+#define star_v1_StreamTelemetryRequest_CALLBACK       nullptr
+#define star_v1_StreamTelemetryRequest_DEFAULT        nullptr
 #define star_v1_StreamTelemetryRequest_header_MSGTYPE star_v1_RequestHeader
 
 #define star_v1_GetSystemStatusRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetSystemStatusRequest_CALLBACK       nullptr
-#define star_v1_GetSystemStatusRequest_DEFAULT        nullptr
+#define star_v1_GetSystemStatusRequest_CALLBACK        nullptr
+#define star_v1_GetSystemStatusRequest_DEFAULT         nullptr
 #define star_v1_GetSystemStatusRequest_header_MSGTYPE  star_v1_RequestHeader
 
 #define star_v1_GetSystemStatusResponse_FIELDLIST(X, a)                                            \
   X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
   X(a, STATIC, OPTIONAL, MESSAGE, status, 2)
-#define star_v1_GetSystemStatusResponse_CALLBACK      nullptr
-#define star_v1_GetSystemStatusResponse_DEFAULT       nullptr
+#define star_v1_GetSystemStatusResponse_CALLBACK       nullptr
+#define star_v1_GetSystemStatusResponse_DEFAULT        nullptr
 #define star_v1_GetSystemStatusResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetSystemStatusResponse_status_MSGTYPE star_v1_SystemStatus
 
@@ -447,8 +447,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, encoder_back_left, 17)                                           \
   X(a, STATIC, OPTIONAL, MESSAGE, encoder_back_right, 18)                                          \
   X(a, STATIC, SINGULAR, UINT32, frame_sequence, 19)
-#define star_v1_TelemetryData_CALLBACK                   nullptr
-#define star_v1_TelemetryData_DEFAULT                    nullptr
+#define star_v1_TelemetryData_CALLBACK                    nullptr
+#define star_v1_TelemetryData_DEFAULT                     nullptr
 #define star_v1_TelemetryData_imu_MSGTYPE                 star_v1_ImuData
 #define star_v1_TelemetryData_gps_MSGTYPE                 star_v1_GpsData
 #define star_v1_TelemetryData_timestamp_MSGTYPE           google_protobuf_Timestamp
@@ -467,8 +467,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, DOUBLE, gyro_x_rad_per_s, 7)                                              \
   X(a, STATIC, SINGULAR, DOUBLE, gyro_y_rad_per_s, 8)                                              \
   X(a, STATIC, SINGULAR, DOUBLE, gyro_z_rad_per_s, 9)
-#define star_v1_ImuData_CALLBACKnullptr
-#define star_v1_ImuData_DEFAULT nullptr
+#define star_v1_ImuData_CALLBACK nullptr
+#define star_v1_ImuData_DEFAULT  nullptr
 
 #define star_v1_GpsData_FIELDLIST(X, a)                                                            \
   X(a, STATIC, SINGULAR, DOUBLE, latitude_deg, 1)                                                  \
@@ -477,8 +477,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, DOUBLE, accuracy_m, 4)                                                    \
   X(a, STATIC, SINGULAR, INT32, satellites, 5)                                                     \
   X(a, STATIC, SINGULAR, UENUM, fix_type, 6)
-#define star_v1_GpsData_CALLBACKnullptr
-#define star_v1_GpsData_DEFAULT nullptr
+#define star_v1_GpsData_CALLBACK nullptr
+#define star_v1_GpsData_DEFAULT  nullptr
 
 #define star_v1_SystemStatus_FIELDLIST(X, a)                                                       \
   X(a, STATIC, SINGULAR, UENUM, connection_status, 1)                                              \
@@ -489,8 +489,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, STRING, firmware_version, 6)                                              \
   X(a, STATIC, SINGULAR, UINT64, uptime_s, 7)                                                      \
   X(a, STATIC, SINGULAR, UINT32, free_heap_bytes, 8)
-#define star_v1_SystemStatus_CALLBACKnullptr
-#define star_v1_SystemStatus_DEFAULT nullptr
+#define star_v1_SystemStatus_CALLBACK nullptr
+#define star_v1_SystemStatus_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_GetTelemetryRequest_msg;
 extern const pb_msgdesc_t star_v1_GetTelemetryResponse_msg;

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/wire.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/wire.pb.h
@@ -129,8 +129,8 @@ extern "C" {
   X(a, STATIC, ONEOF, MESSAGE, (payload, battery_status, payload.battery_status), 20)              \
   X(a, STATIC, ONEOF, MESSAGE, (payload, battery_state, payload.battery_state), 21)                \
   X(a, STATIC, ONEOF, MESSAGE, (payload, pid_config, payload.pid_config), 30)
-#define star_v1_WireMessage_CALLBACK                              nullptr
-#define star_v1_WireMessage_DEFAULT                               nullptr
+#define star_v1_WireMessage_CALLBACK                               nullptr
+#define star_v1_WireMessage_DEFAULT                                nullptr
 #define star_v1_WireMessage_payload_velocity_command_MSGTYPE       star_v1_VelocityCommand
 #define star_v1_WireMessage_payload_emergency_stop_command_MSGTYPE star_v1_EmergencyStopCommand
 #define star_v1_WireMessage_payload_motor_power_command_MSGTYPE    star_v1_MotorPowerCommand
@@ -144,8 +144,8 @@ extern "C" {
   X(a, STATIC, SINGULAR, STRING, reason, 1)                                                        \
   X(a, STATIC, SINGULAR, BOOL, engage_hardware_stop, 2)                                            \
   X(a, STATIC, SINGULAR, INT64, timestamp_us, 3)
-#define star_v1_EmergencyStopCommand_CALLBACKnullptr
-#define star_v1_EmergencyStopCommand_DEFAULT nullptr
+#define star_v1_EmergencyStopCommand_CALLBACK nullptr
+#define star_v1_EmergencyStopCommand_DEFAULT  nullptr
 
 extern const pb_msgdesc_t star_v1_WireMessage_msg;
 extern const pb_msgdesc_t star_v1_EmergencyStopCommand_msg;

--- a/e2-studio-star-rx72n-firmware/src/main.c
+++ b/e2-studio-star-rx72n-firmware/src/main.c
@@ -176,6 +176,7 @@
 #include "hardware.h"
 #include "hardware_init.h"
 #include "rx72n_system_regs.h"
+#include "rx_bq4050.h"
 #include "rx_bus_config.h"
 #include "rx_bus_manager.h"
 #include "rx_bus_types.h"
@@ -212,26 +213,192 @@ typedef enum : uint8_t {
 } main_ret_t;
 
 /* =============================================================================
+ * Hardware Configuration Constants
+ * =============================================================================
+ */
+
+/**
+ * @brief RIIC (I2C) channel number constants for RX72N
+ * @details
+ * RX72N has 3 RIIC channels (0-2). These constants are used with uint8_t
+ * parameters in bus configuration functions.
+ *
+ * @note hardware.h defines riic_channel_t as a struct wrapper, but bus
+ *       configuration functions use raw uint8_t for channel numbers.
+ *
+ * @see rx_bus_config_init_smbus() Uses uint8_t channel parameter
+ * @see rx_bus_config_init_i2c() Uses uint8_t channel parameter
+ */
+typedef enum : uint8_t {
+  k_riic_channel_0 = 0, /**< RIIC channel 0 */
+  k_riic_channel_1 = 1, /**< RIIC channel 1 (used for BQ4050 BMS) */
+  k_riic_channel_2 = 2, /**< RIIC channel 2 */
+} riic_channel_num_t;
+
+/**
+ * @brief Standard I2C bus frequencies for RIIC/SMBus configuration
+ * @details
+ * Standard I2C frequency constants for bus configuration.
+ * Values in Hz for clarity and type safety.
+ *
+ * @see rx_bus_config_init_smbus() Uses frequency_hz parameter
+ * @see rx_bus_config_init_i2c() Uses frequency_hz parameter
+ */
+typedef enum : uint32_t {
+  k_i2c_frequency_100khz = 100000, /**< Standard mode: 100 kHz (default) */
+  k_i2c_frequency_400khz = 400000, /**< Fast mode: 400 kHz */
+} i2c_frequency_t;
+
+/* =============================================================================
  * Static Bus Configurations
  * =============================================================================
  */
 
 /**
- * @brief Static bus configurations for system-wide communication
- * @details
- * Pre-allocated bus configurations registered with bus manager during
- * tx_application_define(). Static allocation follows NASA Rule 3.
+ * @var s_i2c0_config
+ * @brief SMBus configuration for BQ4050 battery management system
  *
- * | Bus Name | Type | Hardware | Purpose |
- * |----------|------|----------|---------|
- * | i2c0 | SMBus | RIIC1 | BQ4050 BMS communication |
- * | onewire0 | 1-Wire | P51 | DS18B20 temperature sensor |
- * | gpio | GPIO | Generic | Motor driver control pins |
- * | adc0 | ADC | S12AD0 | Motor current sensing |
+ * @details
+ * Configures RIIC1 channel as SMBus interface for BQ4050 fuel gauge IC.
+ * Uses P20 (SDA) and P21 (SCL) at 100 kHz with Packet Error Checking (PEC).
+ *
+ * **Hardware Configuration:**
+ * - Bus type: SMBus (I2C with PEC)
+ * - Channel: RIIC1
+ * - Device: BQ4050 @ 0x0B (7-bit address)
+ * - Pins: P20 (SDA), P21 (SCL)
+ * - Frequency: 100 kHz (standard mode)
+ * - Features: PEC enabled for error detection
+ *
+ * **Device Details:**
+ * The BQ4050 is a fully integrated battery management IC that provides:
+ * - State of charge (SoC) estimation
+ * - Cell voltage monitoring (up to 4 cells)
+ * - Current monitoring with coulomb counting
+ * - Temperature sensing
+ * - Safety protection (overcurrent, overvoltage, undertemperature)
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @note Registered with bus manager in tx_application_define() before task creation.
+ * @note SMBus protocol requires PEC for CRC-8 error checking on all transactions.
+ *
+ * @see rx_bus_config_init_smbus() Bus configuration function
+ * @see bms_monitor_task.c Task that uses this bus for battery monitoring
+ *
+ * @since Version 1.0.0
  */
 static rx_bus_config_t s_i2c0_config;
+
+/**
+ * @var s_onewire0_config
+ * @brief 1-Wire configuration for DS18B20 temperature sensor
+ *
+ * @details
+ * Configures GPIO P51 as 1-Wire interface for DS18B20 digital temperature sensor.
+ * Uses bit-banging protocol with precise timing requirements.
+ *
+ * **Hardware Configuration:**
+ * - Bus type: 1-Wire (Dallas/Maxim protocol)
+ * - Pin: P51 (bidirectional data line)
+ * - Pullup: 4.7 kΩ resistor required (external)
+ * - Protocol: Bit-banging with microsecond timing
+ *
+ * **Device Details:**
+ * The DS18B20 is a digital temperature sensor providing:
+ * - Temperature range: -55°C to +125°C
+ * - Accuracy: ±0.5°C (-10°C to +85°C)
+ * - Resolution: 9 to 12 bits (configurable)
+ * - Conversion time: 750 ms max (12-bit resolution)
+ * - Unique 64-bit serial number per device
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @note Registered with bus manager in tx_application_define() before task creation.
+ * @note Requires 4.7 kΩ pullup resistor on P51 (see schematic).
+ * @note 1-Wire protocol timing is critical - interrupts may cause timing violations.
+ *
+ * @see rx_bus_config_init_onewire() Bus configuration function
+ * @see temp_sensor_task.c Task that uses this bus for temperature monitoring
+ *
+ * @since Version 1.0.0
+ */
 static rx_bus_config_t s_onewire0_config;
+
+/**
+ * @var s_gpio_config
+ * @brief Generic GPIO bus configuration for motor driver control
+ *
+ * @details
+ * Configures a generic GPIO bus abstraction that provides access to all GPIO pins.
+ * The initial pin (P00) is required by the API but not significant - motor control
+ * task specifies actual pins (nFAULT, chip selects, etc.) at runtime.
+ *
+ * **Hardware Configuration:**
+ * - Bus type: GPIO (generic abstraction)
+ * - Initial pin: P00 (API requirement, not actually used)
+ * - Actual pins: Specified by motor_control_task at runtime
+ *
+ * **Usage Pattern:**
+ * Motor control task uses this generic GPIO bus to access:
+ * - DRV8243 nFAULT pins (fault detection)
+ * - DRV8243 chip select pins (SPI communication)
+ * - Motor enable/disable control pins
+ * - LED status indicators
+ *
+ * The pin validator ensures no physical pins are double-allocated.
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @note Registered with bus manager in tx_application_define() before task creation.
+ * @note This is a generic bus abstraction - one "gpio" bus serves all 4 motor drivers.
+ * @note Each driver operation specifies the actual pin to access.
+ *
+ * @see rx_bus_config_init_gpio() Bus configuration function
+ * @see motor_control_task.c Task that uses this bus for motor control
+ * @see rx_bus_gpio_write() Runtime GPIO write with pin specification
+ * @see rx_bus_gpio_read() Runtime GPIO read with pin specification
+ *
+ * @since Version 1.0.0
+ */
 static rx_bus_config_t s_gpio_config;
+
+/**
+ * @var s_adc0_config
+ * @brief ADC configuration for motor current sensing
+ *
+ * @details
+ * Configures ADC Unit 0 (S12AD0) as generic ADC bus for motor current monitoring.
+ * The initial channel (0) is required by the API but not significant - motor control
+ * task specifies actual channels (AN004-AN007) at runtime for each motor.
+ *
+ * **Hardware Configuration:**
+ * - Bus type: ADC (generic abstraction)
+ * - Unit: ADC Unit 0 (S12AD0)
+ * - Initial channel: 0 (API requirement, not actually used)
+ * - Resolution: 12-bit (0-4095 counts)
+ * - Actual channels: Specified by motor_control_task at runtime
+ *
+ * **Motor Current Sensing Channels:**
+ * | Motor | ADC Channel | Pin    | DRV8243 Output |
+ * |-------|-------------|--------|----------------|
+ * | Motor 0 | AN007 (ch 7) | P40.7  | IPROPI output  |
+ * | Motor 1 | AN006 (ch 6) | P40.6  | IPROPI output  |
+ * | Motor 2 | AN005 (ch 5) | P40.5  | IPROPI output  |
+ * | Motor 3 | AN004 (ch 4) | P40.4  | IPROPI output  |
+ *
+ * Each DRV8243 motor driver outputs an analog current signal (IPROPI) proportional
+ * to motor current: 500 µA per 1 A of motor current (500:1 ratio).
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @note Registered with bus manager in tx_application_define() before task creation.
+ * @note This is a generic bus abstraction - one "adc0" bus serves all 4 motor drivers.
+ * @note Each current reading specifies the actual ADC channel to sample.
+ * @note 12-bit resolution provides 1 mV per count with 3.3V reference.
+ *
+ * @see rx_bus_config_init_adc() Bus configuration function
+ * @see motor_control_task.c Task that uses this bus for current monitoring
+ * @see rx_bus_adc_read_voltage_mv() Runtime ADC read with channel specification
+ *
+ * @since Version 1.0.0
+ */
 static rx_bus_config_t s_adc0_config;
 
 /* =============================================================================
@@ -1387,13 +1554,13 @@ void tx_application_define(void* first_unused_memory)
 
     /* Register i2c0 (SMBus) - BQ4050 Battery Management System */
     err = rx_bus_config_init_smbus(&s_i2c0_config,
-                                   "i2c0",    /* name */
-                                   1,         /* channel = RIIC1 */
-                                   0x0B,      /* device_addr = BQ4050 */
-                                   k_rx_p2_0, /* sda_pin = P20 */
-                                   k_rx_p2_1, /* scl_pin = P21 */
-                                   100000,    /* frequency_hz = 100 kHz */
-                                   true);     /* use_pec = true */
+                                   "i2c0",                 /* name */
+                                   k_riic_channel_1,       /* channel = RIIC1 */
+                                   k_bq4050_i2c_addr,      /* device_addr = BQ4050 @ 0x0B */
+                                   k_rx_p2_0,              /* sda_pin = P20 */
+                                   k_rx_p2_1,              /* scl_pin = P21 */
+                                   k_i2c_frequency_100khz, /* frequency_hz = 100 kHz */
+                                   true);                  /* use_pec = true */
     RX_ASSERT(err == k_rx_ok, "i2c0 config init must succeed");
     err = rx_bus_manager_add_bus(&g_bus_manager, &s_i2c0_config);
     RX_ASSERT(err == k_rx_ok, "i2c0 registration must succeed");
@@ -1416,10 +1583,10 @@ void tx_application_define(void* first_unused_memory)
 
     /* Register adc0 - Motor Current Sensing (ADC Unit 0) */
     err = rx_bus_config_init_adc(&s_adc0_config,
-                                 "adc0", /* name */
-                                 0,      /* unit = ADC0 */
-                                 0,      /* channel = 0 (generic bus) */
-                                 12);    /* bits = 12-bit */
+                                 "adc0",                  /* name */
+                                 k_adc_unit_0,            /* unit = ADC0 (S12AD0) */
+                                 k_adc_channel_0,         /* channel = 0 (generic bus) */
+                                 k_adc_resolution_12bit); /* bits = 12-bit resolution */
     RX_ASSERT(err == k_rx_ok, "adc0 config init must succeed");
     err = rx_bus_manager_add_bus(&g_bus_manager, &s_adc0_config);
     RX_ASSERT(err == k_rx_ok, "adc0 registration must succeed");

--- a/e2-studio-star-rx72n-firmware/src/main.c
+++ b/e2-studio-star-rx72n-firmware/src/main.c
@@ -176,11 +176,14 @@
 #include "hardware.h"
 #include "hardware_init.h"
 #include "rx72n_system_regs.h"
+#include "rx_bus_config.h"
 #include "rx_bus_manager.h"
+#include "rx_bus_types.h"
 #include "rx_check.h"
 #include "rx_clock_power_init.h"
 #include "rx_err.h"
 #include "rx_infrastructure.h"
+#include "rx_port_utils.h"
 #include "tx_api.h"
 
 /* Multi-task architecture includes */
@@ -207,6 +210,29 @@
 typedef enum : uint8_t {
   k_main_ret_success = 0, /**< Successful completion (should never be reached) */
 } main_ret_t;
+
+/* =============================================================================
+ * Static Bus Configurations
+ * =============================================================================
+ */
+
+/**
+ * @brief Static bus configurations for system-wide communication
+ * @details
+ * Pre-allocated bus configurations registered with bus manager during
+ * tx_application_define(). Static allocation follows NASA Rule 3.
+ *
+ * | Bus Name | Type | Hardware | Purpose |
+ * |----------|------|----------|---------|
+ * | i2c0 | SMBus | RIIC1 | BQ4050 BMS communication |
+ * | onewire0 | 1-Wire | P51 | DS18B20 temperature sensor |
+ * | gpio | GPIO | Generic | Motor driver control pins |
+ * | adc0 | ADC | S12AD0 | Motor current sensing |
+ */
+static rx_bus_config_t s_i2c0_config;
+static rx_bus_config_t s_onewire0_config;
+static rx_bus_config_t s_gpio_config;
+static rx_bus_config_t s_adc0_config;
 
 /* =============================================================================
  * Startup Flag Check Helpers
@@ -1355,7 +1381,51 @@ void tx_application_define(void* first_unused_memory)
     RX_ASSERT(err == k_rx_ok, "rx_bus_manager_init must succeed");
   }
 
-  /* Step 1b: Initialize shared data module (mutexes, event flags) */
+  /* Step 1b: Register buses with manager (before tasks need them) */
+  {
+    extern rx_bus_manager_t g_bus_manager;
+
+    /* Register i2c0 (SMBus) - BQ4050 Battery Management System */
+    err = rx_bus_config_init_smbus(&s_i2c0_config,
+                                   "i2c0",    /* name */
+                                   1,         /* channel = RIIC1 */
+                                   0x0B,      /* device_addr = BQ4050 */
+                                   k_rx_p2_0, /* sda_pin = P20 */
+                                   k_rx_p2_1, /* scl_pin = P21 */
+                                   100000,    /* frequency_hz = 100 kHz */
+                                   true);     /* use_pec = true */
+    RX_ASSERT(err == k_rx_ok, "i2c0 config init must succeed");
+    err = rx_bus_manager_add_bus(&g_bus_manager, &s_i2c0_config);
+    RX_ASSERT(err == k_rx_ok, "i2c0 registration must succeed");
+
+    /* Register onewire0 - DS18B20 Temperature Sensor */
+    err = rx_bus_config_init_onewire(&s_onewire0_config,
+                                     "onewire0", /* name */
+                                     k_rx_p5_1); /* pin = P51 */
+    RX_ASSERT(err == k_rx_ok, "onewire0 config init must succeed");
+    err = rx_bus_manager_add_bus(&g_bus_manager, &s_onewire0_config);
+    RX_ASSERT(err == k_rx_ok, "onewire0 registration must succeed");
+
+    /* Register gpio - Generic GPIO Access (initial pin P00) */
+    err = rx_bus_config_init_gpio(&s_gpio_config,
+                                  "gpio",     /* name */
+                                  k_rx_p0_0); /* pin = P00 (generic bus) */
+    RX_ASSERT(err == k_rx_ok, "gpio config init must succeed");
+    err = rx_bus_manager_add_bus(&g_bus_manager, &s_gpio_config);
+    RX_ASSERT(err == k_rx_ok, "gpio registration must succeed");
+
+    /* Register adc0 - Motor Current Sensing (ADC Unit 0) */
+    err = rx_bus_config_init_adc(&s_adc0_config,
+                                 "adc0", /* name */
+                                 0,      /* unit = ADC0 */
+                                 0,      /* channel = 0 (generic bus) */
+                                 12);    /* bits = 12-bit */
+    RX_ASSERT(err == k_rx_ok, "adc0 config init must succeed");
+    err = rx_bus_manager_add_bus(&g_bus_manager, &s_adc0_config);
+    RX_ASSERT(err == k_rx_ok, "adc0 registration must succeed");
+  }
+
+  /* Step 1c: Initialize shared data module (mutexes, event flags) */
   err = shared_data_init();
   RX_ASSERT(err == k_rx_ok, "shared_data_init must succeed");
 

--- a/e2-studio-star-rx72n-firmware/src/shared/shared_data.c
+++ b/e2-studio-star-rx72n-firmware/src/shared/shared_data.c
@@ -1720,10 +1720,10 @@ void shared_data_trigger_estop_isr_safe(estop_reason_t reason)
  */
 rx_err_t shared_data_commit_isr_estop(void)
 {
-  UINT            tx_status;
-  UINT            saved_interrupt_state;
-  bool            pending = false;
-  estop_reason_t  reason  = k_estop_reason_none;
+  UINT           tx_status;
+  UINT           saved_interrupt_state;
+  bool           pending = false;
+  estop_reason_t reason  = k_estop_reason_none;
 
   /* Check initialization */
   if (!g_shared_data.initialized) {
@@ -1736,7 +1736,7 @@ rx_err_t shared_data_commit_isr_estop(void)
   /* Atomically read and clear the pending flag */
   pending = s_estop_pending_from_isr;
   if (pending) {
-    reason = s_pending_estop_reason;
+    reason                   = s_pending_estop_reason;
     s_estop_pending_from_isr = false; /* Clear flag while interrupts disabled */
   }
 

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -874,17 +874,17 @@ static void internal_init_transports(rx_comm_manager_config_t* config)
 
   /* Initialize USB communication layer */
   rx_usb_comm_config_t usb_cfg = {.session = &s_session_state, .time_iface = nullptr};
-  bool usb_ok                   = (rx_usb_comm_init(&s_usb_comm_handle, &usb_cfg) == k_rx_ok);
+  bool                 usb_ok  = (rx_usb_comm_init(&s_usb_comm_handle, &usb_cfg) == k_rx_ok);
   if (!usb_ok) {
     rx_log_error(s_tag, "USB comm init failed");
   }
 
   /* Initialize SPI communication layer (RSPI2, channel 0) */
   rx_spi_comm_config_t spi_cfg = {.session     = &s_session_state,
-                                   .channel     = k_spi_comm_default_channel,
-                                   .spi_mode    = k_spi_comm_default_mode,
-                                   .fec_enabled = false};
-  bool spi_ok                   = (rx_spi_comm_init(&s_spi_comm_handle, &spi_cfg) == k_rx_ok);
+                                  .channel     = k_spi_comm_default_channel,
+                                  .spi_mode    = k_spi_comm_default_mode,
+                                  .fec_enabled = false};
+  bool                 spi_ok  = (rx_spi_comm_init(&s_spi_comm_handle, &spi_cfg) == k_rx_ok);
   if (!spi_ok) {
     rx_log_error(s_tag, "SPI comm init failed");
   }


### PR DESCRIPTION
Resolves #291

## Problem

Bus manager was initialized but no application buses were registered, causing runtime failures when tasks attempted to access hardware:
- `bms_monitor_task` expects **"i2c0"** for BQ4050 battery management
- `temp_sensor_task` expects **"onewire0"** for DS18B20 temperature sensor  
- `motor_control_task` expects **"gpio"** and **"adc0"** for motor control

## Solution

Add bus registrations in `tx_application_define()` after bus manager init but before task creation:

| Bus Name | Type | Hardware | Purpose |
|----------|------|----------|---------|
| **i2c0** | SMBus | RIIC1, P20/P21 | BQ4050 BMS @ 0x0B, 100kHz |
| **onewire0** | 1-Wire | P51 | DS18B20 temperature sensor |
| **gpio** | GPIO | Generic | Motor driver control pins |
| **adc0** | ADC | S12AD0 | Motor current sensing (12-bit) |

### Implementation Details

- **Static allocation**: All bus configs use static storage (NASA Power of 10 Rule 3)
- **Error checking**: All operations validated with `RX_ASSERT`
- **Boot sequence**: Buses registered between bus manager init and shared_data_init

### Additional Fixes

Fixed pre-existing nanopb code generation issue:
- **Issue**: Macro definitions had `_CALLBACKnullptr` instead of `_CALLBACK nullptr` (missing space)
- **Impact**: Caused compilation errors in PB_BIND macro expansion
- **Fix**: Applied `sed` replacement to all affected nanopb generated headers

## Testing

✅ **Build**: Clean compilation with no errors/warnings
- Firmware size: 277,988 bytes total

✅ **Tests**: All 48 unit tests pass
- Execution time: 0.41 seconds
- 0 failures

✅ **Format**: All code formatted per project standards
- 15 files formatted

## Files Changed

### Core Implementation
- `e2-studio-star-rx72n-firmware/src/main.c`
  - Added includes: `rx_bus_config.h`, `rx_port_utils.h`
  - Added static bus config declarations
  - Added bus registration logic in `tx_application_define()`

### Formatting Updates
- `e2-studio-star-rx72n-firmware/src/shared/shared_data.c` - Alignment fixes
- `e2-studio-star-rx72n-firmware/src/tasks/comm_task.c` - Alignment fixes

### nanopb Fixes (11 files)
- `libs/rx_nanopb/inc/gen/google/protobuf/*.pb.h` (2 files)
- `libs/rx_nanopb/inc/gen/star/v1/*.pb.h` (9 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initialization and management of multiple communication buses (I2C, 1-Wire, GPIO, ADC) during system startup.

* **Improvements**
  * Enhanced USB and SPI transport error handling with detailed logging for initialization outcomes.
  * Optimized startup sequence to register bus configurations before task creation for improved system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->