### PR TITLE
feat(link/spi): enable FEC by default; avoid encoding empty control frames

### DIFF
--- a/star-gateway/internal/link/spi.go
+++ b/star-gateway/internal/link/spi.go
@@ -129,8 +129,7 @@ var (
 // SPILinkConfig holds configuration parameters for SPILink.
 type SPILinkConfig struct {
 	// EnableFEC enables Forward Error Correction (Viterbi K=7, Rate 1/2).
-	// Phase 1: false (disabled)
-	// Phase 2: true (enabled)
+	// Default: Enable FEC by default to improve reliability on noisy SPI links.
 	EnableFEC bool
 
 	// MaxRetries overrides the default maximum retries (default: 3).
@@ -143,7 +142,7 @@ type SPILinkConfig struct {
 // DefaultSPILinkConfig returns the default configuration for SPILink.
 func DefaultSPILinkConfig() *SPILinkConfig {
 	return &SPILinkConfig{
-		EnableFEC:  false, // Phase 1: Disabled
+		EnableFEC:  true, // Enabled by default
 		MaxRetries: maxRetries,
 		ACKTimeout: ackTimeout,
 	}
@@ -336,7 +335,9 @@ func (s *SPILink) sendWithRetry(ctx context.Context, data []byte, seq uint16, fr
 	payload := data
 	flags := frame.FlagRequiresAck
 
-	if s.config.EnableFEC {
+	// Only apply FEC encoding for non-empty payloads. Control frames (empty)
+	// must not be passed to the convolutional encoder (it rejects empty data).
+	if s.config.EnableFEC && len(data) > 0 {
 		encoded, err := s.fecEncoder.Encode(data)
 		if err != nil {
 			return fmt.Errorf("FEC encode failed: %w", err)

--- a/star-gateway/internal/link/spi_test.go
+++ b/star-gateway/internal/link/spi_test.go
@@ -1386,6 +1386,14 @@ func TestSPILink_SendWithType_FrameTypes(t *testing.T) {
 				t.Errorf("Frame type = %v, want %v", f.Type, tc.frameType)
 			}
 
+			// For zero-length payloads the encoder must NOT set FlagFECEnabled.
+			// This enforces the "zero-length-skip" contract introduced around sendWithRetry.
+			if len(tc.payload) == 0 {
+				if (f.Header.Flags & frame.FlagFECEnabled) != 0 {
+					t.Fatalf("%s: zero-length payload must NOT set FlagFECEnabled", tc.name)
+				}
+			}
+
 			// If FEC is enabled the wire payload will be FEC-encoded; decode before comparing.
 			if (f.Header.Flags & frame.FlagFECEnabled) != 0 {
 				dec := fec.NewViterbiDecoder()

--- a/star-gateway/internal/link/spi_test.go
+++ b/star-gateway/internal/link/spi_test.go
@@ -126,8 +126,8 @@ func TestNewSPILink_Valid(t *testing.T) {
 		t.Error("Decoder not initialized")
 	}
 
-	if link.config.EnableFEC {
-		t.Error("FEC should be disabled by default")
+	if !link.config.EnableFEC {
+		t.Error("FEC should be enabled by default")
 	}
 }
 
@@ -1084,8 +1084,8 @@ func TestSPILink_ReceiveContextCanceled(t *testing.T) {
 func TestDefaultSPILinkConfig(t *testing.T) {
 	config := DefaultSPILinkConfig()
 
-	if config.EnableFEC {
-		t.Error("Expected FEC disabled by default")
+	if !config.EnableFEC {
+		t.Error("Expected FEC enabled by default")
 	}
 
 	if config.MaxRetries != maxRetries {
@@ -1385,8 +1385,21 @@ func TestSPILink_SendWithType_FrameTypes(t *testing.T) {
 			if f.Type != tc.frameType {
 				t.Errorf("Frame type = %v, want %v", f.Type, tc.frameType)
 			}
-			if string(f.Payload) != string(tc.payload) {
-				t.Errorf("Payload = %q, want %q", f.Payload, tc.payload)
+
+			// If FEC is enabled the wire payload will be FEC-encoded; decode before comparing.
+			if (f.Header.Flags & frame.FlagFECEnabled) != 0 {
+				dec := fec.NewViterbiDecoder()
+				decoded, err := dec.DecodeHard(f.Payload, len(tc.payload))
+				if err != nil {
+					t.Fatalf("FEC decode failed: %v", err)
+				}
+				if string(decoded) != string(tc.payload) {
+					t.Errorf("Decoded payload = %q, want %q", decoded, tc.payload)
+				}
+			} else {
+				if string(f.Payload) != string(tc.payload) {
+					t.Errorf("Payload = %q, want %q", f.Payload, tc.payload)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Summary:
- Enable Forward Error Correction (Viterbi, K=7, rate 1/2) by default for the SPI HARQ path.
- Skip FEC encoding for zero-length (control) payloads to prevent encoder errors.

Files changed:
- internal/link/spi.go            (default FEC on, skip-encoding fix)
- internal/link/spi_test.go       (tests updated to be FEC-aware)

Why:
- Implementation now matches TRANSPORT_ARCHITECTURE.md and HARQ.DefaultConfig.
- Prevents runtime FEC/encoder errors for empty control frames and makes tests robust.

Tests:
- All star-gateway unit tests pass locally.

Notes:
- Behaviour is backward-compatible; control frames remain unencoded.
- If you prefer the default to remain off, I can switch to an explicit config at creation time instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Forward Error Correction (FEC) is enabled by default for communications.
  * FEC encoding now skips frames with empty payloads (control frames), so only non-empty payloads are encoded.
  * Behavior and validation around FEC flags and payload decoding have been updated to reflect the new defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->