### PR TITLE
fix: align 1-Wire reset timing constants with protocol specification

### DIFF
--- a/e2-studio-star-rx72n-firmware/libs/rx_bus/inc/rx_bus_onewire.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_bus/inc/rx_bus_onewire.h
@@ -259,6 +259,12 @@ typedef enum : uint16_t {
                                          @note Device presence pulse is 60-240 µs; this wait covers
                                                the remaining recovery window regardless of pulse width */
 
+  k_onewire_reset_slot_total_us = 960, /**< Total reset slot duration in microseconds.
+                                            Sum of reset pulse, presence wait, and presence tail:
+                                            k_onewire_reset_pulse_us + k_onewire_presence_wait_us +
+                                            k_onewire_presence_tail_us = 480 + 70 + 410 = 960 µs.
+                                            @par Value: 960 µs (per Dallas/Maxim 1-Wire spec) */
+
   /* Write bit timing */
   k_onewire_write_1_low_us = 10, /**< Write-1 LOW pulse duration.
                                       Short pulse for logic 1.

--- a/e2-studio-star-rx72n-firmware/libs/rx_bus/inc/rx_bus_onewire.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_bus/inc/rx_bus_onewire.h
@@ -203,10 +203,12 @@ extern "C" {
  *
  * @par Timing Diagram Reference
  * ```
- * Reset/Presence:
- *   ___      ________
- *      |____|        |_______  <-- presence pulse from device
- *      |<480>|<70>|<240 max>|
+ * Reset/Presence (960 µs total slot):
+ *   ___      ______________________________
+ *      |____|        |_______             |
+ *      |<480>|<70>|<--- 410 remaining --->|
+ *                    Device presence pulse  ^
+ *                    lasts 60-240 µs       Slot complete
  *
  * Write 1:
  *   ___    __________
@@ -250,9 +252,12 @@ typedef enum : uint16_t {
                                         @par Value: 70 µs (within 60-75 µs window)
                                         @note Device pulls low 15-60 µs after reset release */
 
-  k_onewire_presence_timeout_us = 240, /**< Maximum presence pulse duration.
-                                            Presence pulse ends within this time.
-                                            @par Value: 240 µs (maximum per spec) */
+  k_onewire_presence_tail_us = 410, /**< Remaining presence window after sampling.
+                                         Wait after sampling to complete the full 960 µs reset slot.
+                                         @par Value: 410 µs (= 480 µs recovery − 70 µs pre-sample wait)
+                                         @note Total reset slot: 480 + 70 + 410 = 960 µs (per spec)
+                                         @note Device presence pulse is 60-240 µs; this wait covers
+                                               the remaining recovery window regardless of pulse width */
 
   /* Write bit timing */
   k_onewire_write_1_low_us = 10, /**< Write-1 LOW pulse duration.

--- a/e2-studio-star-rx72n-firmware/libs/rx_bus/src/rx_bus_onewire.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_bus/src/rx_bus_onewire.c
@@ -482,6 +482,7 @@ static void internal_reset_search_state(onewire_runtime_state_t* state)
  *
  * @see k_onewire_reset_pulse_us Reset pulse duration (480µs)
  * @see k_onewire_presence_wait_us Presence sample delay (70µs)
+ * @see k_onewire_presence_tail_us Remaining window after sample (410µs)
  */
 static rx_err_t
 internal_reset_pulse(rx_bus_config_t* bus_config, onewire_runtime_state_t* state, bool* presence)
@@ -508,7 +509,7 @@ internal_reset_pulse(rx_bus_config_t* bus_config, onewire_runtime_state_t* state
 
   *presence = !line_high;
 
-  internal_delay_us(k_onewire_presence_timeout_us);
+  internal_delay_us(k_onewire_presence_tail_us);
 
   return k_rx_ok;
 }

--- a/e2-studio-star-rx72n-firmware/libs/rx_bus/src/rx_bus_onewire.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_bus/src/rx_bus_onewire.c
@@ -28,7 +28,7 @@
  * |------------------|--------------------|----------|
  * | Reset pulse      | T_RSTL             | 480 µs   |
  * | Presence wait    | T_PDH              | 70 µs    |
- * | Presence timeout | T_RSTH             | 410 µs   |
+ * | Presence tail    | T_RSTH             | 410 µs   |
  * | Write-1 low      | T_LOW1             | 6 µs     |
  * | Write-1 high     | T_SLOT - T_LOW1    | 64 µs    |
  * | Write-0 low      | T_LOW0             | 60 µs    |

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_bus_onewire.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_bus_onewire.c
@@ -3089,7 +3089,7 @@ void test_rx_bus_onewire_timing_constants(void)
   TEST_ASSERT_GREATER_OR_EQUAL(480, k_onewire_reset_pulse_us);
   TEST_ASSERT_TRUE(k_onewire_presence_wait_us >= 60 && k_onewire_presence_wait_us <= 75);
   /* Remaining presence window: reset_pulse + presence_wait + presence_tail must equal 960 µs */
-  TEST_ASSERT_EQUAL(960, k_onewire_reset_pulse_us + k_onewire_presence_wait_us + k_onewire_presence_tail_us);
+  TEST_ASSERT_EQUAL(k_onewire_reset_slot_total_us, k_onewire_reset_pulse_us + k_onewire_presence_wait_us + k_onewire_presence_tail_us);
 
   /* Write-1 timing: LOW pulse 6-15µs */
   TEST_ASSERT_TRUE(k_onewire_write_1_low_us >= 6 && k_onewire_write_1_low_us <= 15);

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_bus_onewire.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_bus_onewire.c
@@ -3088,7 +3088,8 @@ void test_rx_bus_onewire_timing_constants(void)
   /* Reset timing */
   TEST_ASSERT_GREATER_OR_EQUAL(480, k_onewire_reset_pulse_us);
   TEST_ASSERT_TRUE(k_onewire_presence_wait_us >= 60 && k_onewire_presence_wait_us <= 75);
-  TEST_ASSERT_GREATER_OR_EQUAL(60, k_onewire_presence_timeout_us);
+  /* Remaining presence window: reset_pulse + presence_wait + presence_tail must equal 960 µs */
+  TEST_ASSERT_EQUAL(960, k_onewire_reset_pulse_us + k_onewire_presence_wait_us + k_onewire_presence_tail_us);
 
   /* Write-1 timing: LOW pulse 6-15µs */
   TEST_ASSERT_TRUE(k_onewire_write_1_low_us >= 6 && k_onewire_write_1_low_us <= 15);


### PR DESCRIPTION
## Summary

- Renames `k_onewire_presence_timeout_us` (240 µs) to `k_onewire_presence_tail_us` (410 µs) to correctly represent the controller's post-sample wait time rather than the device's presence pulse duration
- Corrects the enum value from 240 µs to 410 µs so the full reset slot is exactly 480 + 70 + 410 = 960 µs as required by the Dallas/Maxim 1-Wire specification
- Updates the timing diagram in `onewire_timing_us_t`, the `@see` cross-reference in `internal_reset_pulse()`, the call site in `rx_bus_onewire.c`, and the timing-constants test assertion

## Root Cause

The old constant (`k_onewire_presence_timeout_us = 240`) was named and commented as "maximum presence pulse duration" — describing the device's presence pulse width (60-240 µs per spec). However, the controller does not need to wait only as long as the device's pulse; it must wait out the remainder of the 480 µs recovery window to complete the full 960 µs reset slot. After the 70 µs pre-sample delay, 480 - 70 = 410 µs remain, not 240 µs. This caused an implementation/documentation mismatch and a 170 µs short reset slot (790 µs instead of 960 µs).

## Test plan

- [ ] `test_rx_bus_onewire_timing_constants` now asserts `k_onewire_reset_pulse_us + k_onewire_presence_wait_us + k_onewire_presence_tail_us == 960`, verifying the full slot constraint
- [ ] All other 1-Wire unit tests unchanged and unaffected
- [ ] No other callers of the old constant name exist in the codebase

Closes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined OneWire protocol timing: presence detection window recalibrated and reset-slot timing clarified to improve protocol compliance and reliability.

* **Tests**
  * Timing validations updated to verify the full reset-slot timing as a whole, ensuring end-to-end timing correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->