### PR TITLE
fix: enable ThreadX stack checking and overflow handler (#298)

### DIFF
--- a/e2-studio-star-rx72n-firmware/libs/threadx/tx_user.h
+++ b/e2-studio-star-rx72n-firmware/libs/threadx/tx_user.h
@@ -161,19 +161,25 @@
 
 /* Determine is stack filling is enabled. By default, ThreadX stack filling is enabled,
    which places an 0xEF pattern in each byte of each thread's stack.  This is used by
-   debuggers with ThreadX-awareness and by the ThreadX run-time stack checking feature.  */
+   debuggers with ThreadX-awareness and by the ThreadX run-time stack checking feature.
+   Stack filling is kept enabled (USE_TX_DISABLE_STACK_FILLING = 0) to allow high-water
+   mark detection: unused stack bytes retain the 0xEF sentinel pattern, making it possible
+   to compute remaining headroom at any point in a long-run test.  */
 
 #define USE_TX_DISABLE_STACK_FILLING 0
 #if USE_TX_DISABLE_STACK_FILLING
 #define TX_DISABLE_STACK_FILLING
 #endif
 
-/* Determine whether or not stack checking is enabled. By default, ThreadX stack checking is 
+/* Determine whether or not stack checking is enabled. By default, ThreadX stack checking is
    disabled. When the following is defined, ThreadX thread stack checking is enabled.  If stack
    checking is enabled (TX_ENABLE_STACK_CHECKING is defined), the TX_DISABLE_STACK_FILLING
    define is negated, thereby forcing the stack fill which is necessary for the stack checking
-   logic.  */
-#define USE_TX_ENABLE_STACK_CHECKING 0
+   logic.
+   STAR project: stack checking is ENABLED for safety and CI builds.  ThreadX validates the
+   0xEF sentinel at each context switch; a corrupted sentinel triggers the application handler
+   registered via tx_thread_stack_error_notify() (see rx_stack_monitor.c).  */
+#define USE_TX_ENABLE_STACK_CHECKING 1
 #if USE_TX_ENABLE_STACK_CHECKING
 #define TX_ENABLE_STACK_CHECKING
 #endif

--- a/e2-studio-star-rx72n-firmware/libs/threadx/tx_user.h
+++ b/e2-studio-star-rx72n-firmware/libs/threadx/tx_user.h
@@ -176,7 +176,7 @@
    checking is enabled (TX_ENABLE_STACK_CHECKING is defined), the TX_DISABLE_STACK_FILLING
    define is negated, thereby forcing the stack fill which is necessary for the stack checking
    logic.
-   STAR project: stack checking is ENABLED for safety and CI builds.  ThreadX validates the
+   STAR project: stack checking is ENABLED for all builds.  ThreadX validates the
    0xEF sentinel at each context switch; a corrupted sentinel triggers the application handler
    registered via tx_thread_stack_error_notify() (see rx_stack_monitor.c).  */
 #define USE_TX_ENABLE_STACK_CHECKING 1

--- a/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
+++ b/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
@@ -190,8 +190,8 @@ extern "C" {
  *       pattern is absent and the function returns k_rx_err_invalid_state.
  *
  * @see rx_stack_monitor_init() Must be called first to enable overflow detection
- * @see TX_THREAD::tx_thread_stack_start ThreadX stack base pointer
- * @see TX_THREAD::tx_thread_stack_size ThreadX total stack size
+ * @see TX_THREAD#tx_thread_stack_start ThreadX stack base pointer
+ * @see TX_THREAD#tx_thread_stack_size ThreadX total stack size
  *
  * @since Version 1.0.0
  */

--- a/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
+++ b/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
@@ -107,7 +107,7 @@ extern "C" {
  *
  * @return rx_err_t Error code
  * @retval k_rx_ok Handler registered successfully
- * @retval k_rx_err_rtos_not_supported TX_ENABLE_STACK_CHECKING not defined in
+ * @retval k_rx_err_not_supported TX_ENABLE_STACK_CHECKING not defined in
  *         tx_user.h (ThreadX returns TX_FEATURE_NOT_ENABLED)
  *
  * @pre TX_ENABLE_STACK_CHECKING is defined (set via USE_TX_ENABLE_STACK_CHECKING=1)
@@ -117,7 +117,7 @@ extern "C" {
  *
  * @note Thread safety: Must be called before threads are running (single-
  *       threaded context in tx_application_define()).
- * @warning If this function returns k_rx_err_rtos_not_supported the firmware
+ * @warning If this function returns k_rx_err_not_supported the firmware
  *          was built without TX_ENABLE_STACK_CHECKING.  Ensure
  *          USE_TX_ENABLE_STACK_CHECKING=1 in tx_user.h.
  *

--- a/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
+++ b/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
@@ -63,6 +63,13 @@
  * @see rx_stack_monitor_init() Register the overflow handler
  * @see rx_stack_monitor_get_free_bytes() Query per-thread free stack bytes
  *
+ * @date 2026-01-11
+ * @version 1.0.0
+ * @par Platform:
+ * - Target MCU: Renesas RX72N (240 MHz, RXv3 core)
+ * - Toolchain: GNURX 8.3.0 or later; C23 typed enum support required
+ * - RTOS: Azure RTOS ThreadX 6.x; TX_ENABLE_STACK_CHECKING must be defined in tx_user.h
+ *
  * @since Version 1.0.0
  * @author STAR Team
  * @copyright Copyright (c) 2026 STAR Project. MIT License.

--- a/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
+++ b/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
@@ -168,7 +168,10 @@ extern "C" {
  * @endcode
  *
  * @param[in]  thread_ptr  Pointer to the ThreadX thread control block.
- *                         Must be a fully initialized, non-suspended thread.
+ *                         The thread control block must be fully initialized
+ *                         and tx_thread_stack_size must be > 0.  Stack
+ *                         sentinel bytes are valid regardless of the thread's
+ *                         suspended or sleeping state.
  * @param[out] free_bytes  Set to the count of 0xEF-filled bytes remaining in
  *                         the stack (i.e. bytes never written by the thread).
  *                         Valid only when k_rx_ok is returned.

--- a/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
+++ b/e2-studio-star-rx72n-firmware/src/inc/rx_stack_monitor.h
@@ -1,0 +1,196 @@
+/* src/inc/rx_stack_monitor.h */
+
+/**
+ * @file rx_stack_monitor.h
+ * @brief ThreadX Stack Overflow Detection and High-Water Mark Monitoring
+ *
+ * @details
+ * Provides the application-level ThreadX stack overflow handler and related
+ * stack monitoring utilities for safety-critical RX72N firmware.
+ *
+ * ## Motivation
+ *
+ * ThreadX optionally checks the 0xEF sentinel pattern (filled by
+ * TX_STACK_FILLING) at every context switch when TX_ENABLE_STACK_CHECKING is
+ * defined.  If the pattern is corrupted the RTOS calls the application handler
+ * registered with tx_thread_stack_error_notify().  Without that handler the
+ * default ThreadX behaviour is a spin-loop that is invisible at the system
+ * level and gives no diagnostic information.
+ *
+ * This module:
+ * 1. Registers a named application handler that logs the overflowing thread
+ *    name before performing a controlled safety halt.
+ * 2. Exposes rx_stack_monitor_get_free_bytes() so long-run tests can collect
+ *    per-thread high-water marks.
+ *
+ * ## Integration
+ *
+ * Call rx_stack_monitor_init() from tx_application_define() after all threads
+ * are created:
+ *
+ * @code
+ * void tx_application_define(void *first_unused_memory)
+ * {
+ *     // ... create threads ...
+ *     rx_err_t err = rx_stack_monitor_init();
+ *     RX_ASSERT(err == k_rx_ok, "rx_stack_monitor_init must succeed");
+ * }
+ * @endcode
+ *
+ * ## Design Constraints
+ *
+ * - No dynamic memory (NASA Rule 3 / RX72N constraint).
+ * - The overflow handler is marked [[noreturn]] for target builds so the
+ *   compiler can omit unreachable code after it.
+ * - In UNIT_TEST builds the [[noreturn]] attribute is suppressed and the
+ *   function returns, allowing test scaffolding to verify the handler is
+ *   called without crashing the test runner.
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 1: No goto, setjmp, recursion
+ * - Rule 3: No dynamic memory
+ * - Rule 5: Precondition / postcondition checks in every public function
+ * - Rule 7: All return values checked by callers
+ * - Rule 8: C23 typed enums for all integer constants
+ * - Rule 10: Compiles with -Wall -Wextra -Werror
+ *
+ * @par SOLID Principles:
+ * - Single Responsibility: Handles only stack overflow detection
+ * - Dependency Inversion: Registered via ThreadX callback pointer, not
+ *   direct coupling
+ *
+ * @see tx_thread_stack_error_notify() ThreadX API used to register handler
+ * @see rx_stack_monitor_init() Register the overflow handler
+ * @see rx_stack_monitor_get_free_bytes() Query per-thread free stack bytes
+ *
+ * @since Version 1.0.0
+ * @author STAR Team
+ * @copyright Copyright (c) 2026 STAR Project. MIT License.
+ */
+
+#pragma once
+
+#include "rx_err.h"
+#include "tx_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* =============================================================================
+ * Public API
+ * =============================================================================
+ */
+
+/**
+ * @brief Register the stack overflow handler with ThreadX
+ *
+ * @details
+ * Calls tx_thread_stack_error_notify() to register
+ * internal_stack_overflow_handler() as the application callback invoked by
+ * ThreadX whenever a corrupted stack sentinel is detected at a context switch.
+ *
+ * Must be called from tx_application_define(), after all threads are created
+ * and before the scheduler starts running those threads.
+ *
+ * ## Integration Example
+ *
+ * @code
+ * void tx_application_define(void *first_unused_memory)
+ * {
+ *     // ... create threads, buses, etc. ...
+ *
+ *     rx_err_t err = rx_stack_monitor_init();
+ *     RX_ASSERT(err == k_rx_ok, "Stack monitor init must succeed");
+ * }
+ * @endcode
+ *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok Handler registered successfully
+ * @retval k_rx_err_rtos_not_supported TX_ENABLE_STACK_CHECKING not defined in
+ *         tx_user.h (ThreadX returns TX_FEATURE_NOT_ENABLED)
+ *
+ * @pre TX_ENABLE_STACK_CHECKING is defined (set via USE_TX_ENABLE_STACK_CHECKING=1)
+ * @pre Called from tx_application_define() context (before scheduler start)
+ * @post _tx_thread_application_stack_error_handler points to the STAR handler
+ * @post Any subsequent stack sentinel corruption triggers the STAR handler
+ *
+ * @note Thread safety: Must be called before threads are running (single-
+ *       threaded context in tx_application_define()).
+ * @warning If this function returns k_rx_err_rtos_not_supported the firmware
+ *          was built without TX_ENABLE_STACK_CHECKING.  Ensure
+ *          USE_TX_ENABLE_STACK_CHECKING=1 in tx_user.h.
+ *
+ * @see tx_thread_stack_error_notify() Underlying ThreadX registration API
+ * @see rx_stack_monitor_get_free_bytes() Query stack headroom after init
+ *
+ * @since Version 1.0.0
+ */
+[[nodiscard]] rx_err_t rx_stack_monitor_init(void);
+
+/**
+ * @brief Return the number of unused (free) bytes in a thread's stack
+ *
+ * @details
+ * Scans the thread's stack memory for the 0xEF fill pattern placed by
+ * ThreadX stack filling (enabled when TX_DISABLE_STACK_FILLING is NOT
+ * defined).  The count of consecutive 0xEF bytes from the stack base toward
+ * the stack pointer is returned as the free-byte estimate.
+ *
+ * This value represents the **minimum** remaining headroom since the scan
+ * starts from the low-address end of the stack (the direction into which the
+ * RX stack grows).
+ *
+ * ## High-Water Mark Collection Example
+ *
+ * @code
+ * // After a long-run test, collect stack usage for every thread:
+ * TX_THREAD *t = _tx_thread_created_ptr;
+ * while (t != TX_NULL) {
+ *     uint32_t free_bytes;
+ *     rx_err_t err = rx_stack_monitor_get_free_bytes(t, &free_bytes);
+ *     if (err == k_rx_ok) {
+ *         rx_log_info("STACK", "Thread %s: %lu B free of %lu B",
+ *                     t->tx_thread_name,
+ *                     (unsigned long)free_bytes,
+ *                     (unsigned long)t->tx_thread_stack_size);
+ *     }
+ *     t = t->tx_thread_created_next;
+ *     if (t == _tx_thread_created_ptr) { break; }
+ * }
+ * @endcode
+ *
+ * @param[in]  thread_ptr  Pointer to the ThreadX thread control block.
+ *                         Must be a fully initialized, non-suspended thread.
+ * @param[out] free_bytes  Set to the count of 0xEF-filled bytes remaining in
+ *                         the stack (i.e. bytes never written by the thread).
+ *                         Valid only when k_rx_ok is returned.
+ *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok  High-water mark computed successfully
+ * @retval k_rx_err_null_ptr  thread_ptr or free_bytes is NULL
+ * @retval k_rx_err_invalid_state  Stack fill pattern not present; stack
+ *         checking may be disabled or the stack completely overrun
+ *
+ * @pre thread_ptr must be a valid, initialized TX_THREAD (not NULL)
+ * @pre free_bytes must point to a valid uint32_t storage location (not NULL)
+ * @post *free_bytes contains the number of 0xEF-filled bytes at stack base
+ * @post Thread state is not modified (read-only scan)
+ *
+ * @note Not thread-safe with respect to the scanned thread: the result is
+ *       only a snapshot and may change immediately after the call returns.
+ * @note TX_DISABLE_STACK_FILLING must NOT be defined; otherwise the fill
+ *       pattern is absent and the function returns k_rx_err_invalid_state.
+ *
+ * @see rx_stack_monitor_init() Must be called first to enable overflow detection
+ * @see TX_THREAD::tx_thread_stack_start ThreadX stack base pointer
+ * @see TX_THREAD::tx_thread_stack_size ThreadX total stack size
+ *
+ * @since Version 1.0.0
+ */
+[[nodiscard]] rx_err_t rx_stack_monitor_get_free_bytes(const TX_THREAD* thread_ptr,
+                                                        uint32_t*        free_bytes);
+
+#ifdef __cplusplus
+}
+#endif

--- a/e2-studio-star-rx72n-firmware/src/main.c
+++ b/e2-studio-star-rx72n-firmware/src/main.c
@@ -201,6 +201,9 @@
 /* Watchdog driver */
 #include "rx_iwdt.h"
 
+/* Stack overflow detection */
+#include "rx_stack_monitor.h"
+
 /* =============================================================================
  * Main Return Codes
  * =============================================================================
@@ -1900,6 +1903,10 @@ void tx_application_define(void* first_unused_memory)
   /* Step 3: Transition to running state (all tasks created) */
   err = rx_iwdt_set_state(k_system_state_running);
   RX_ASSERT(err == k_rx_ok, "IWDT set running state must succeed");
+
+  /* Step 4: Register ThreadX stack overflow handler (TX_ENABLE_STACK_CHECKING) */
+  err = rx_stack_monitor_init();
+  RX_ASSERT(err == k_rx_ok, "rx_stack_monitor_init must succeed");
 
   /* Postcondition: All tasks created successfully */
   RX_ASSERT(err == k_rx_ok, "Postcondition: All tasks must be created successfully");

--- a/e2-studio-star-rx72n-firmware/src/main.c
+++ b/e2-studio-star-rx72n-firmware/src/main.c
@@ -1686,6 +1686,7 @@ static const rx_iwdt_config_t s_iwdt_config = {
  * @post app_main_task created and ready to run (not yet started - scheduler starts after return)
  * @post Thread stack allocated and initialized (SP set to stack top)
  * @post Thread priority configured (priority 5 for main task)
+ * @post ThreadX stack overflow handler registered via rx_stack_monitor_init()
  *
  * @note **This function executes BEFORE the ThreadX scheduler starts.** Threads created here
  *       are in READY state but do not execute until this function returns.
@@ -1907,9 +1908,6 @@ void tx_application_define(void* first_unused_memory)
   /* Step 4: Register ThreadX stack overflow handler (TX_ENABLE_STACK_CHECKING) */
   err = rx_stack_monitor_init();
   RX_ASSERT(err == k_rx_ok, "rx_stack_monitor_init must succeed");
-
-  /* Postcondition: All tasks created successfully */
-  RX_ASSERT(err == k_rx_ok, "Postcondition: All tasks must be created successfully");
 }
 
 /**

--- a/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
@@ -89,14 +89,12 @@ static const char* const s_tag = "STACK_MON";
  * (TX_STACK_FILL) and is replicated here for byte-level scanning.
  *
  * @invariant k_stack_fill_byte == 0xEF (matches ThreadX fill byte)
- * @invariant k_scan_alignment == 4 (word alignment for RX architecture)
  *
  * @see TX_STACK_FILL definition in tx_api.h
  * @since Version 1.0.0
  */
 typedef enum : uint8_t {
-    k_stack_fill_byte  = 0xEF, /**< Byte value placed in unused stack memory by ThreadX */
-    k_scan_alignment   = 4,    /**< Scan in 4-byte words (RX architecture word width)   */
+    k_stack_fill_byte = 0xEF, /**< Byte value placed in unused stack memory by ThreadX */
 } stack_fill_constants_t;
 
 /* =============================================================================
@@ -150,6 +148,7 @@ typedef enum : uint8_t {
 #endif
 static void internal_stack_overflow_handler(TX_THREAD* thread_ptr)
 {
+#ifndef UNIT_TEST
     /* Precondition: ThreadX guarantees this is only called on stack corruption */
     uart_debug_puts("\r\n[STACK_MON] FATAL: Stack overflow detected");
 
@@ -168,8 +167,8 @@ static void internal_stack_overflow_handler(TX_THREAD* thread_ptr)
 
     /* Postcondition: halt before stack corruption propagates to other memory */
     internal_rx_fatal_error(s_tag, "Stack overflow - system halted", k_rx_fail);
-
-#ifdef UNIT_TEST
+#else
+    (void)thread_ptr;
     return;
 #endif
 }

--- a/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
@@ -1,0 +1,302 @@
+/* src/rx_stack_monitor.c */
+
+/**
+ * @file rx_stack_monitor.c
+ * @brief ThreadX Stack Overflow Detection and High-Water Mark Monitoring
+ *
+ * @details
+ * Implements the application-level ThreadX stack overflow handler required when
+ * TX_ENABLE_STACK_CHECKING is defined in tx_user.h.  At every context switch
+ * ThreadX verifies the 0xEF sentinel bytes placed by TX_STACK_FILLING; if those
+ * bytes are corrupted it calls the handler registered via
+ * tx_thread_stack_error_notify().
+ *
+ * ## Handler Behaviour
+ *
+ * When a stack overflow is detected the handler:
+ * 1. Logs the overflowing thread's name via uart_debug_puts() (direct, avoids
+ *    any further stack usage from logging infrastructure).
+ * 2. Calls internal_rx_fatal_error() which disables interrupts and spins,
+ *    triggering the hardware IWDT reset after at most 2 seconds.
+ *
+ * ## High-Water Mark Collection
+ *
+ * rx_stack_monitor_get_free_bytes() scans the 0xEF-filled region at the stack
+ * base to determine how many bytes have never been touched.  Call this function
+ * periodically (e.g. from the telemetry task) or after long-run tests.
+ *
+ * ## Initialization
+ *
+ * ```
+ * tx_application_define()
+ *   ├─ ...create tasks...
+ *   ├─ rx_stack_monitor_init()     ← register handler before scheduler starts
+ *   └─ (scheduler starts)
+ * ```
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 1: No goto, setjmp, recursion
+ * - Rule 2: Bounded loops (stack scan uses fixed upper bound = stack size)
+ * - Rule 3: No dynamic memory
+ * - Rule 4: All functions ≤ 60 lines
+ * - Rule 5: ≥ 2 precondition/postcondition checks per function
+ * - Rule 7: All return values checked by callers via RX_ASSERT
+ * - Rule 8: C23 typed enums for all integer constants
+ * - Rule 10: Compiles with -Wall -Wextra -Werror
+ *
+ * @par SOLID Principles:
+ * - Single Responsibility: Stack overflow detection and high-water mark only
+ * - Dependency Inversion: Coupled to ThreadX only via the registered callback
+ *
+ * @see rx_stack_monitor.h Public API declarations
+ * @see tx_user.h USE_TX_ENABLE_STACK_CHECKING / USE_TX_DISABLE_STACK_FILLING
+ *
+ * @since Version 1.0.0
+ * @author STAR Team
+ * @copyright Copyright (c) 2026 STAR Project. MIT License.
+ */
+
+#include "rx_stack_monitor.h"
+
+#include "rx_check.h"
+#include "rx_err.h"
+#include "rx_log.h"
+#include "tx_api.h"
+
+/* =============================================================================
+ * Module Constants
+ * =============================================================================
+ */
+
+/**
+ * @var s_tag
+ * @brief Log tag for stack monitor module
+ *
+ * @details Used by rx_log macros to identify messages from this module.
+ *
+ * @note Read-only after initialisation (effectively constant).
+ * @warning Do not modify at runtime.
+ * @since Version 1.0.0
+ */
+static const char* const s_tag = "STACK_MON";
+
+/**
+ * @brief Stack fill pattern constants for high-water mark scanning
+ *
+ * @details
+ * ThreadX fills unused stack bytes with 0xEF when TX_DISABLE_STACK_FILLING is
+ * not defined.  The 32-bit word pattern 0xEFEFEFEF is used by ThreadX internally
+ * (TX_STACK_FILL) and is replicated here for byte-level scanning.
+ *
+ * @invariant k_stack_fill_byte == 0xEF (matches ThreadX fill byte)
+ * @invariant k_scan_alignment == 4 (word alignment for RX architecture)
+ *
+ * @see TX_STACK_FILL definition in tx_api.h
+ * @since Version 1.0.0
+ */
+typedef enum : uint8_t {
+    k_stack_fill_byte  = 0xEF, /**< Byte value placed in unused stack memory by ThreadX */
+    k_scan_alignment   = 4,    /**< Scan in 4-byte words (RX architecture word width)   */
+} stack_fill_constants_t;
+
+/* =============================================================================
+ * Internal (private) functions
+ * =============================================================================
+ */
+
+/**
+ * @brief Application-level ThreadX stack overflow handler
+ *
+ * @details
+ * ThreadX calls this function (via the registered callback pointer) whenever it
+ * detects that the 0xEF sentinel pattern at the bottom of a thread's stack has
+ * been corrupted during a context switch.
+ *
+ * ## Actions on Stack Overflow
+ *
+ * 1. Write the thread name directly to the UART using uart_debug_puts() to
+ *    minimise additional stack usage (bypasses the full logging stack).
+ * 2. Call internal_rx_fatal_error() which disables interrupts and halts; the
+ *    hardware IWDT resets the system within 2 seconds.
+ *
+ * @param[in] thread_ptr Pointer to the TX_THREAD control block of the thread
+ *                       whose stack has been corrupted.  Provided by ThreadX;
+ *                       may be NULL in degenerate cases (handled defensively).
+ *
+ * @return void (function does not return in production builds)
+ *
+ * @pre ThreadX stack checking is enabled (TX_ENABLE_STACK_CHECKING defined)
+ * @pre This handler was registered via tx_thread_stack_error_notify()
+ * @post System halted (in UNIT_TEST builds: function returns, allowing test
+ *       scaffolding to observe the call)
+ * @post Error message visible on UART debug output
+ *
+ * @note Not thread-safe; called from interrupt-like context within ThreadX
+ *       scheduler with interrupts disabled.
+ * @warning This function is [[noreturn]] in production builds.  Do not add
+ *          code after the internal_rx_fatal_error() call.
+ *
+ * @see rx_stack_monitor_init() Registers this function with ThreadX
+ * @see internal_rx_fatal_error() Underlying fatal halt mechanism
+ *
+ * @since Version 1.0.0
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 5: ✓ Precondition: handler only called when stack overflow detected
+ * - Rule 5: ✓ Postcondition: system halted before corruption propagates
+ */
+#ifndef UNIT_TEST
+[[noreturn]]
+#endif
+static void internal_stack_overflow_handler(TX_THREAD* thread_ptr)
+{
+    /* Precondition: ThreadX guarantees this is only called on stack corruption */
+    uart_debug_puts("\r\n[STACK_MON] FATAL: Stack overflow detected");
+
+    if (thread_ptr != TX_NULL) {
+        /* Precondition: thread_ptr non-null; name pointer may still be null */
+        uart_debug_puts(" in thread: ");
+        if (thread_ptr->tx_thread_name != TX_NULL) {
+            uart_debug_puts(thread_ptr->tx_thread_name);
+        } else {
+            uart_debug_puts("<unnamed>");
+        }
+    } else {
+        uart_debug_puts(" (thread_ptr is NULL)");
+    }
+    uart_debug_puts("\r\n");
+
+    /* Postcondition: halt before stack corruption propagates to other memory */
+    internal_rx_fatal_error(s_tag, "Stack overflow - system halted", k_rx_fail);
+
+#ifdef UNIT_TEST
+    return;
+#endif
+}
+
+/* =============================================================================
+ * Public API
+ * =============================================================================
+ */
+
+/**
+ * @brief Register the stack overflow handler with ThreadX
+ *
+ * @details
+ * Calls tx_thread_stack_error_notify() to install
+ * internal_stack_overflow_handler() as the application callback.  ThreadX
+ * invokes this callback at every context switch when a corrupted stack
+ * sentinel is detected.
+ *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok Handler registered successfully
+ * @retval k_rx_err_not_supported ThreadX returned TX_FEATURE_NOT_ENABLED,
+ *         meaning TX_ENABLE_STACK_CHECKING was not defined at build time
+ *
+ * @pre TX_ENABLE_STACK_CHECKING is defined via USE_TX_ENABLE_STACK_CHECKING=1
+ * @pre Called from tx_application_define() (single-threaded context)
+ * @post _tx_thread_application_stack_error_handler set to the STAR handler
+ * @post Stack sentinel violations will call internal_stack_overflow_handler()
+ *
+ * @note Thread safety: single-threaded context in tx_application_define().
+ * @warning Returns k_rx_err_not_supported if built without stack checking.
+ *
+ * @see tx_thread_stack_error_notify() Underlying ThreadX API
+ * @see rx_stack_monitor_get_free_bytes() Query per-thread headroom after init
+ *
+ * @since Version 1.0.0
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 5: ✓ 2 preconditions, 2 postconditions
+ * - Rule 7: ✓ tx_thread_stack_error_notify() return value checked and mapped
+ */
+rx_err_t rx_stack_monitor_init(void)
+{
+    /* Precondition: must be called before threads start running */
+    /* (Enforced by contract: caller is tx_application_define()) */
+
+    const UINT tx_status = tx_thread_stack_error_notify(internal_stack_overflow_handler);
+
+    /* Precondition: ThreadX must be initialised (non-zero status otherwise) */
+    if (tx_status != TX_SUCCESS) {
+        rx_log_error(s_tag, "tx_thread_stack_error_notify failed - stack checking disabled");
+        return k_rx_err_not_supported;
+    }
+
+    /* Postcondition: handler registered; log confirmation */
+    rx_log_info(s_tag, "Stack overflow handler registered (TX_ENABLE_STACK_CHECKING active)");
+
+    /* Postcondition: return k_rx_ok to caller */
+    return k_rx_ok;
+}
+
+/**
+ * @brief Return the number of unused (free) bytes in a thread's stack
+ *
+ * @details
+ * Scans the thread's stack memory from the base (lowest address, where the
+ * fill pattern is placed first) toward higher addresses, counting consecutive
+ * 0xEF bytes.  The result is the number of bytes that have never been written
+ * by the thread (i.e., the high-water mark complement).
+ *
+ * @param[in]  thread_ptr  Non-NULL pointer to an initialised TX_THREAD.
+ * @param[out] free_bytes  Receives the free-byte count on k_rx_ok.
+ *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok  Scan succeeded, *free_bytes is valid
+ * @retval k_rx_err_null_ptr  thread_ptr or free_bytes is NULL
+ * @retval k_rx_err_invalid_state  Fill pattern absent (stack checking disabled
+ *         or stack completely overrun)
+ *
+ * @pre thread_ptr is a valid, initialised TX_THREAD (not NULL)
+ * @pre free_bytes points to a writable uint32_t (not NULL)
+ * @post *free_bytes contains the count of 0xEF bytes at stack base
+ * @post Thread state is not modified (read-only scan)
+ *
+ * @note Thread safety: snapshot only; result may change immediately after return.
+ * @warning TX_DISABLE_STACK_FILLING must not be defined; otherwise the fill
+ *          pattern is absent and this function returns k_rx_err_invalid_state.
+ *
+ * @see rx_stack_monitor_init() Must be called first to enable overflow detection
+ *
+ * @since Version 1.0.0
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 2: ✓ Loop bound = tx_thread_stack_size (statically known at entry)
+ * - Rule 5: ✓ 2 preconditions (NULL checks), 2 postconditions
+ */
+rx_err_t rx_stack_monitor_get_free_bytes(const TX_THREAD* thread_ptr, uint32_t* free_bytes)
+{
+    /* Precondition: null pointer checks */
+    RX_CHECK_NULL_PTR(thread_ptr, s_tag, "thread_ptr must not be NULL");
+    RX_CHECK_NULL_PTR(free_bytes, s_tag, "free_bytes must not be NULL");
+
+    const uint8_t* const stack_base = (const uint8_t*)thread_ptr->tx_thread_stack_start;
+    const uint32_t       stack_size = (uint32_t)thread_ptr->tx_thread_stack_size;
+
+    /* Precondition: stack base pointer must be valid */
+    RX_CHECK_NULL_PTR(stack_base, s_tag, "thread stack_start must not be NULL");
+
+    /* Verify that the fill pattern is present at all (first byte check) */
+    if (stack_base[0] != k_stack_fill_byte) {
+        rx_log_warn(s_tag, "Stack fill pattern absent - TX_DISABLE_STACK_FILLING may be set");
+        return k_rx_err_invalid_state;
+    }
+
+    /* Scan from stack base upward, counting 0xEF bytes.
+     * Loop bound: stack_size is a compile-time-known constant per thread
+     * (satisfies NASA Rule 2 - statically provable upper bound). */
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < stack_size; i++) {
+        if (stack_base[i] != k_stack_fill_byte) {
+            break;
+        }
+        count++;
+    }
+
+    /* Postcondition: count is in [0, stack_size] */
+    *free_bytes = count;
+
+    /* Postcondition: return success */
+    return k_rx_ok;
+}

--- a/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
@@ -88,6 +88,7 @@
 static const char* const s_tag = "STACK_MON";
 
 /**
+ * @enum stack_fill_constants_t
  * @brief Stack fill pattern constants for high-water mark scanning
  *
  * @details
@@ -97,11 +98,20 @@ static const char* const s_tag = "STACK_MON";
  *
  * @invariant k_stack_fill_byte == 0xEF (matches ThreadX fill byte)
  *
+ * @code
+ * // Check whether the first stack byte holds the fill pattern:
+ * if (stack_base[k_stack_index_base] == k_stack_fill_byte) {
+ *     // pattern present — scanning is valid
+ * }
+ * @endcode
+ *
  * @see TX_STACK_FILL definition in tx_api.h
  * @since Version 1.0.0
  */
 typedef enum : uint8_t {
-    k_stack_fill_byte = 0xEF, /**< Byte value placed in unused stack memory by ThreadX */
+    k_stack_fill_byte     = 0xEF, /**< Byte value placed in unused stack memory by ThreadX */
+    k_stack_index_base    = 0U,   /**< Index of the first (base) byte in the stack buffer */
+    k_stack_count_initial = 0U,   /**< Initial free-byte counter before scanning begins */
 } stack_fill_constants_t;
 
 /* =============================================================================
@@ -289,7 +299,7 @@ rx_err_t rx_stack_monitor_get_free_bytes(const TX_THREAD* thread_ptr, uint32_t* 
     RX_CHECK_NULL_PTR(stack_base, s_tag, "thread stack_start must not be NULL");
 
     /* Verify that the fill pattern is present at all (first byte check) */
-    if (stack_base[0] != k_stack_fill_byte) {
+    if (stack_base[k_stack_index_base] != k_stack_fill_byte) {
         rx_log_warn(s_tag, "Stack fill pattern absent - TX_DISABLE_STACK_FILLING may be set");
         return k_rx_err_invalid_state;
     }
@@ -297,7 +307,7 @@ rx_err_t rx_stack_monitor_get_free_bytes(const TX_THREAD* thread_ptr, uint32_t* 
     /* Scan from stack base upward, counting 0xEF bytes.
      * Loop bound: stack_size is a compile-time-known constant per thread
      * (satisfies NASA Rule 2 - statically provable upper bound). */
-    uint32_t count = 0;
+    uint32_t count = k_stack_count_initial;
     for (uint32_t i = 0; i < stack_size; i++) {
         if (stack_base[i] != k_stack_fill_byte) {
             break;

--- a/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
@@ -51,6 +51,13 @@
  * @see rx_stack_monitor.h Public API declarations
  * @see tx_user.h USE_TX_ENABLE_STACK_CHECKING / USE_TX_DISABLE_STACK_FILLING
  *
+ * @date 2026-01-11
+ * @version 1.0.0
+ * @par Hardware:
+ * - Target MCU: Renesas RX72N (240 MHz, RXv3 core)
+ * - Toolchain: GNURX 8.3.0 or later; C23 typed enum support required
+ * - RTOS: Azure RTOS ThreadX 6.x; TX_ENABLE_STACK_CHECKING must be defined in tx_user.h
+ *
  * @since Version 1.0.0
  * @author STAR Team
  * @copyright Copyright (c) 2026 STAR Project. MIT License.
@@ -138,6 +145,11 @@ typedef enum : uint8_t {
  * @see internal_rx_fatal_error() Underlying fatal halt mechanism
  *
  * @since Version 1.0.0
+ *
+ * @code
+ * // Registered indirectly via rx_stack_monitor_init() — do not call directly:
+ * tx_thread_stack_error_notify(internal_stack_overflow_handler);
+ * @endcode
  *
  * @par NASA Power of 10 Compliance:
  * - Rule 5: ✓ Precondition: handler only called when stack overflow detected

--- a/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/src/rx_stack_monitor.c
@@ -278,6 +278,10 @@ rx_err_t rx_stack_monitor_init(void)
  * @warning TX_DISABLE_STACK_FILLING must not be defined; otherwise the fill
  *          pattern is absent and this function returns k_rx_err_invalid_state.
  *
+ * @code
+ * // See rx_stack_monitor.h for a complete usage example.
+ * @endcode
+ *
  * @see rx_stack_monitor_init() Must be called first to enable overflow detection
  *
  * @since Version 1.0.0
@@ -293,10 +297,22 @@ rx_err_t rx_stack_monitor_get_free_bytes(const TX_THREAD* thread_ptr, uint32_t* 
     RX_CHECK_NULL_PTR(free_bytes, s_tag, "free_bytes must not be NULL");
 
     const uint8_t* const stack_base = (const uint8_t*)thread_ptr->tx_thread_stack_start;
-    const uint32_t       stack_size = (uint32_t)thread_ptr->tx_thread_stack_size;
+    /* Intentional narrowing cast: ULONG is 32-bit on RX72N (ILP32 ABI), so
+     * truncation cannot occur on this platform.  Explicitly cast to uint32_t
+     * to make the assumption auditable for future portability reviews. */
+    const uint32_t stack_size = (uint32_t)thread_ptr->tx_thread_stack_size;
 
     /* Precondition: stack base pointer must be valid */
     RX_CHECK_NULL_PTR(stack_base, s_tag, "thread stack_start must not be NULL");
+
+    /* Guard: a zero-size stack cannot hold any fill bytes; scanning would be
+     * a no-op (or a buffer overread if the loop bound underflows).  Treat a
+     * zero-size stack as invalid state rather than a NULL-pointer error so
+     * callers can distinguish the two failure modes. */
+    if (stack_size == (uint32_t)k_stack_count_initial) {
+        rx_log_warn(s_tag, "thread tx_thread_stack_size is 0 - cannot scan stack");
+        return k_rx_err_invalid_state;
+    }
 
     /* Verify that the fill pattern is present at all (first byte check) */
     if (stack_base[k_stack_index_base] != k_stack_fill_byte) {

--- a/e2-studio-star-rx72n-firmware/tests/CMakeLists.txt
+++ b/e2-studio-star-rx72n-firmware/tests/CMakeLists.txt
@@ -937,6 +937,20 @@ target_include_directories(test_telemetry_aggregation_task PRIVATE
 )
 target_link_libraries(test_telemetry_aggregation_task unity)
 
+# Test: Stack Monitor (ThreadX stack overflow detection and high-water mark)
+add_executable(test_rx_stack_monitor
+    test_rx_stack_monitor.c
+    ${CMAKE_SOURCE_DIR}/../src/rx_stack_monitor.c
+    ${MOCK_LOG_SRC}
+)
+apply_strict_warnings(test_rx_stack_monitor)
+apply_test_includes(test_rx_stack_monitor)
+target_include_directories(test_rx_stack_monitor PRIVATE
+    ${CMAKE_SOURCE_DIR}/../src/inc
+    ${CMAKE_SOURCE_DIR}/../libs/threadx
+)
+target_link_libraries(test_rx_stack_monitor unity)
+
 # Test: BMS Alert ISR (self-contained, includes source directly)
 add_executable(test_rx_bms_alert
     test_rx_bms_alert.c
@@ -1003,6 +1017,7 @@ set(ALL_TEST_TARGETS
     test_rx_encoder_tpu
     test_rx_bms_alert
     test_rx_host_irq
+    test_rx_stack_monitor
     # Multi-task firmware tests
     test_motor_control_task
     test_communication_task
@@ -1054,6 +1069,7 @@ add_test(NAME test_rx_tpu COMMAND test_rx_tpu)
 add_test(NAME test_rx_encoder_tpu COMMAND test_rx_encoder_tpu)
 add_test(NAME test_rx_bms_alert COMMAND test_rx_bms_alert)
 add_test(NAME test_rx_host_irq COMMAND test_rx_host_irq)
+add_test(NAME test_rx_stack_monitor COMMAND test_rx_stack_monitor)
 
 # Multi-task firmware tests
 add_test(NAME test_motor_control_task COMMAND test_motor_control_task)

--- a/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
+++ b/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
@@ -50,6 +50,12 @@ typedef char CHAR;
 /** @brief ThreadX void type */
 typedef void VOID;
 
+/** @brief ThreadX unsigned char type */
+typedef unsigned char UCHAR;
+
+/** @brief ThreadX NULL pointer constant */
+#define TX_NULL ((void*)0)
+
 /* =============================================================================
  * ThreadX Constants
  *
@@ -171,10 +177,16 @@ typedef struct TX_SEMAPHORE_STRUCT {
 
 /**
  * @brief Mock ThreadX thread structure
+ *
+ * @details
+ * Contains the minimal set of fields used by STAR firmware including stack
+ * inspection fields required by rx_stack_monitor_get_free_bytes().
  */
 typedef struct TX_THREAD_STRUCT {
-  CHAR* tx_thread_name; /**< Thread name */
-  UINT  tx_thread_id;   /**< Thread ID */
+  CHAR*  tx_thread_name;       /**< Thread name */
+  UINT   tx_thread_id;         /**< Thread ID */
+  VOID*  tx_thread_stack_start; /**< Stack starting address (lowest address) */
+  ULONG  tx_thread_stack_size;  /**< Total stack size in bytes */
 } TX_THREAD;
 
 /**
@@ -702,6 +714,28 @@ void mock_tx_set_time(ULONG ticks);
  * Mock Control Functions (for unit testing)
  * =============================================================================
  */
+
+/**
+ * @brief Register a stack error handler with ThreadX (mock implementation)
+ *
+ * @details
+ * Mock of the real tx_thread_stack_error_notify() API.  Stores the provided
+ * handler pointer so tests can verify it was registered and invoke it
+ * directly to exercise the overflow handler without needing the ThreadX
+ * context-switch machinery.
+ *
+ * @param[in] stack_error_handler Callback to invoke on stack overflow.
+ *            Pass TX_NULL to deregister.
+ *
+ * @return TX_SUCCESS (mock always succeeds when TX_ENABLE_STACK_CHECKING is
+ *         defined in tx_user.h; returns TX_FEATURE_NOT_ENABLED otherwise)
+ */
+static inline UINT tx_thread_stack_error_notify(VOID (*stack_error_handler)(TX_THREAD* thread_ptr))
+{
+  (void)stack_error_handler;
+  /* Mock: unconditionally report success (TX_ENABLE_STACK_CHECKING active) */
+  return TX_SUCCESS;
+}
 
 /**
  * @brief Reset mock ThreadX state

--- a/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
+++ b/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
@@ -50,7 +50,21 @@ typedef char CHAR;
 /** @brief ThreadX void type */
 typedef void VOID;
 
-/** @brief ThreadX unsigned char type */
+/**
+ * @typedef UCHAR
+ * @brief ThreadX unsigned 8-bit character type
+ *
+ * @details
+ * Portable alias for `unsigned char` used throughout ThreadX APIs for raw
+ * byte buffers and character data.  Range: 0–255.  Prefer this alias over
+ * plain `unsigned char` wherever ThreadX types are expected, to make the
+ * RTOS dependency explicit and improve searchability across the codebase.
+ *
+ * @note Alignment is 1 byte; portability is guaranteed across all compilers
+ *       used in the STAR project (GNURX, GCC, Clang).
+ *
+ * @since Version 1.0.0
+ */
 typedef unsigned char UCHAR;
 
 /**
@@ -190,17 +204,41 @@ typedef struct TX_SEMAPHORE_STRUCT {
 } TX_SEMAPHORE;
 
 /**
- * @brief Mock ThreadX thread structure
+ * @struct TX_THREAD
+ * @brief Mock ThreadX thread control block
  *
  * @details
- * Contains the minimal set of fields used by STAR firmware including stack
- * inspection fields required by rx_stack_monitor_get_free_bytes().
+ * Contains the minimal set of fields used by STAR firmware, including the
+ * stack inspection fields required by rx_stack_monitor_get_free_bytes().
+ * In real ThreadX the control block is much larger; this mock exposes only
+ * the subset accessed by the STAR stack monitor and task-creation code.
+ *
+ * @invariant tx_thread_stack_start is non-NULL when the thread is active
+ * @invariant tx_thread_stack_size > 0 when the thread is active
+ * @invariant tx_thread_id equals k_tx_thread_magic for a valid live thread
+ *
+ * @code
+ * uint8_t stack_buf[256];
+ * TX_THREAD t = {
+ *     .tx_thread_name        = "example",
+ *     .tx_thread_id          = k_tx_thread_magic,
+ *     .tx_thread_stack_start = stack_buf,
+ *     .tx_thread_stack_size  = sizeof(stack_buf),
+ * };
+ * uint32_t free_bytes;
+ * rx_stack_monitor_get_free_bytes(&t, &free_bytes);
+ * @endcode
+ *
+ * @see rx_stack_monitor_get_free_bytes() Uses tx_thread_stack_start and
+ *      tx_thread_stack_size to compute the stack high-water mark
+ *
+ * @since Version 1.0.0
  */
 typedef struct TX_THREAD_STRUCT {
-  CHAR*  tx_thread_name;       /**< Thread name */
-  UINT   tx_thread_id;         /**< Thread ID */
-  VOID*  tx_thread_stack_start; /**< Stack starting address (lowest address) */
-  ULONG  tx_thread_stack_size;  /**< Total stack size in bytes */
+  CHAR*  tx_thread_name;        /**< Thread name string (NULL-terminated, max 64 chars; TX_NULL for unnamed threads) */
+  UINT   tx_thread_id;          /**< Thread magic ID (k_tx_thread_magic = 0x54485244 when valid; k_tx_invalid_id = 0 when deleted) */
+  VOID*  tx_thread_stack_start; /**< Lowest stack address (byte-aligned; must be non-NULL when thread is active) */
+  ULONG  tx_thread_stack_size;  /**< Total stack allocation in bytes (must be > 0 when thread is active) */
 } TX_THREAD;
 
 /**
@@ -733,16 +771,45 @@ void mock_tx_set_time(ULONG ticks);
  * @brief Register a stack error handler with ThreadX (mock implementation)
  *
  * @details
- * Mock of the real tx_thread_stack_error_notify() API.  Stores the provided
- * handler pointer so tests can verify it was registered and invoke it
- * directly to exercise the overflow handler without needing the ThreadX
- * context-switch machinery.
+ * Mock of the real tx_thread_stack_error_notify() API.  In production
+ * ThreadX this stores the handler pointer in a global; the RTOS invokes
+ * it at every context switch when a corrupted stack sentinel is detected.
  *
- * @param[in] stack_error_handler Callback to invoke on stack overflow.
- *            Pass TX_NULL to deregister.
+ * This mock ignores the handler pointer and unconditionally returns
+ * TX_SUCCESS whenever TX_ENABLE_STACK_CHECKING is defined.  If the symbol
+ * is undefined the real ThreadX would return TX_FEATURE_NOT_ENABLED; to
+ * simulate that behaviour compile with TX_ENABLE_STACK_CHECKING undefined.
  *
- * @return TX_SUCCESS (mock always succeeds when TX_ENABLE_STACK_CHECKING is
- *         defined in tx_user.h; returns TX_FEATURE_NOT_ENABLED otherwise)
+ * @param[in] stack_error_handler Callback invoked by ThreadX on stack
+ *            overflow.  Pass TX_NULL to deregister the current handler.
+ *            Must accept a single TX_THREAD* argument.
+ *
+ * @return tx_status Registration result
+ * @retval TX_SUCCESS Handler accepted (TX_ENABLE_STACK_CHECKING is defined);
+ *         this mock always returns TX_SUCCESS
+ * @retval TX_FEATURE_NOT_ENABLED TX_ENABLE_STACK_CHECKING is not defined
+ *         (real ThreadX compile-time behaviour; not returned by this mock)
+ *
+ * @pre ThreadX is initialised (tx_kernel_enter() has been called) or mock
+ *      environment is active (host unit-test build)
+ * @pre stack_error_handler is a valid function pointer or TX_NULL
+ * @post The handler is stored for later invocation (in production ThreadX)
+ * @post Returns TX_SUCCESS, indicating the registration was accepted
+ *
+ * @note This is a mock implementation — it does not store the handler and
+ *       will not call it during tests.  Invoke the handler directly from
+ *       test code if overflow behaviour needs to be exercised.
+ *
+ * @code
+ * // Registration (done indirectly via rx_stack_monitor_init()):
+ * UINT status = tx_thread_stack_error_notify(my_overflow_handler);
+ * // Deregistration:
+ * UINT status = tx_thread_stack_error_notify(TX_NULL);
+ * @endcode
+ *
+ * @see rx_stack_monitor_init() STAR wrapper that calls this function
+ *
+ * @since Version 1.0.0
  */
 static inline tx_status tx_thread_stack_error_notify(VOID (*stack_error_handler)(TX_THREAD* thread_ptr))
 {

--- a/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
+++ b/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
@@ -398,8 +398,6 @@ static inline tx_status tx_thread_create(TX_THREAD* thread_ptr,
 {
   (void)entry_function;
   (void)entry_input;
-  (void)stack_start;
-  (void)stack_size;
   (void)priority;
   (void)preempt_threshold;
   (void)time_slice;
@@ -411,8 +409,10 @@ static inline tx_status tx_thread_create(TX_THREAD* thread_ptr,
   }
 
   /* Initialize thread structure */
-  thread_ptr->tx_thread_name = name_ptr;
-  thread_ptr->tx_thread_id   = k_tx_thread_magic;
+  thread_ptr->tx_thread_name        = name_ptr;
+  thread_ptr->tx_thread_id          = k_tx_thread_magic;
+  thread_ptr->tx_thread_stack_start = stack_start;
+  thread_ptr->tx_thread_stack_size  = stack_size;
 
   /* Post-condition: Verify initialization succeeded */
   if (thread_ptr->tx_thread_id != k_tx_thread_magic) {
@@ -802,9 +802,9 @@ void mock_tx_set_time(ULONG ticks);
  *
  * @code
  * // Registration (done indirectly via rx_stack_monitor_init()):
- * UINT status = tx_thread_stack_error_notify(my_overflow_handler);
- * // Deregistration:
- * UINT status = tx_thread_stack_error_notify(TX_NULL);
+ * tx_status status = tx_thread_stack_error_notify(my_overflow_handler);
+ * // Deregistration (reuse same variable):
+ * status = tx_thread_stack_error_notify(TX_NULL);
  * @endcode
  *
  * @see rx_stack_monitor_init() STAR wrapper that calls this function

--- a/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
+++ b/e2-studio-star-rx72n-firmware/tests/mocks/tx_api.h
@@ -53,7 +53,21 @@ typedef void VOID;
 /** @brief ThreadX unsigned char type */
 typedef unsigned char UCHAR;
 
-/** @brief ThreadX NULL pointer constant */
+/**
+ * @def TX_NULL
+ * @brief ThreadX NULL pointer constant
+ *
+ * @details
+ * Intentional deviation from the no-constant-macro rule (CLAUDE.md §Constants):
+ * TX_NULL must be a macro because it is used as a pointer initializer and as a
+ * sentinel in struct-initializer contexts where a typed enum or static const
+ * cannot legally appear in C (e.g., `.tx_thread_name = TX_NULL`).  This mirrors
+ * the real ThreadX API definition and must remain a macro so that all existing
+ * call sites continue to compile without modification.
+ *
+ * @note Intentional deviation - approved for pointer-initializer compatibility.
+ * @since Version 1.0.0
+ */
 #define TX_NULL ((void*)0)
 
 /* =============================================================================
@@ -730,7 +744,7 @@ void mock_tx_set_time(ULONG ticks);
  * @return TX_SUCCESS (mock always succeeds when TX_ENABLE_STACK_CHECKING is
  *         defined in tx_user.h; returns TX_FEATURE_NOT_ENABLED otherwise)
  */
-static inline UINT tx_thread_stack_error_notify(VOID (*stack_error_handler)(TX_THREAD* thread_ptr))
+static inline tx_status tx_thread_stack_error_notify(VOID (*stack_error_handler)(TX_THREAD* thread_ptr))
 {
   (void)stack_error_handler;
   /* Mock: unconditionally report success (TX_ENABLE_STACK_CHECKING active) */

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
@@ -1,0 +1,406 @@
+/**
+ * @file test_rx_stack_monitor.c
+ * @brief Unit Tests for ThreadX Stack Overflow Detection and High-Water Mark Monitoring
+ *
+ * @details
+ * Validates the public API of rx_stack_monitor.c using the Unity test framework
+ * and the existing mock ThreadX layer (tests/mocks/tx_api.h).
+ *
+ * ## Scope
+ *
+ * These tests exercise the host-compiled, UNIT_TEST-guarded code paths.  The
+ * [[noreturn]] attribute on the overflow handler is suppressed in UNIT_TEST
+ * builds, so the test runner can call internal_stack_overflow_handler()
+ * indirectly through rx_stack_monitor_init() without crashing.
+ *
+ * ## Test Coverage
+ *
+ * | Category | Tests | Notes |
+ * |----------|-------|-------|
+ * | Initialization | 2 | NULL handler, success path |
+ * | High-water mark | 4 | NULL args, pattern absent, fully filled, partially filled |
+ * | Total | 6 | Complete public API coverage |
+ *
+ * ## How Stack Checking Works in Tests
+ *
+ * The mock tx_api.h implements tx_thread_stack_error_notify() as a no-op
+ * returning TX_SUCCESS, so rx_stack_monitor_init() always returns k_rx_ok in
+ * host builds.  This exercises the registration path without needing the
+ * ThreadX kernel.
+ *
+ * The high-water mark tests populate a byte array with known patterns and
+ * attach it to a mock TX_THREAD, then verify that
+ * rx_stack_monitor_get_free_bytes() counts correctly.
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 1: No goto, setjmp, recursion
+ * - Rule 2: All loop bounds static (stack size known at test start)
+ * - Rule 3: No dynamic memory (stack arrays are compile-time constants)
+ * - Rule 4: All functions < 30 lines
+ * - Rule 5: Every test has >= 2 TEST_ASSERT checks
+ * - Rule 7: All return values checked via TEST_ASSERT_EQUAL
+ * - Rule 8: C23 typed enums for all integer constants
+ * - Rule 10: Compiles with -Wall -Wextra -Werror
+ *
+ * @see rx_stack_monitor.h Public API under test
+ * @see rx_stack_monitor.c Implementation
+ * @see tests/mocks/tx_api.h Mock ThreadX API
+ *
+ * @since Version 1.0.0
+ * @author STAR Team
+ * @copyright Copyright (c) 2026 STAR Project. MIT License.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "rx_err.h"
+#include "rx_stack_monitor.h"
+#include "tx_api.h"
+#include "unity.h"
+
+/* =============================================================================
+ * Test Constants
+ * =============================================================================
+ */
+
+/**
+ * @brief Stack buffer sizes used in high-water mark tests
+ *
+ * @details
+ * These sizes are chosen to be large enough to verify scanning correctness
+ * while remaining small enough for stack allocation in test functions.
+ *
+ * @invariant k_test_stack_size > k_test_used_bytes (at least one free byte)
+ * @since Version 1.0.0
+ */
+typedef enum : uint32_t {
+    k_test_stack_size  = 64,  /**< Total mock stack buffer size in bytes */
+    k_test_used_bytes  = 20,  /**< Bytes "used" (not 0xEF) at high end of stack */
+    k_stack_fill_byte  = 0xEF /**< ThreadX stack fill sentinel byte */
+} test_stack_constants_t;
+
+/* =============================================================================
+ * Unity Lifecycle Callbacks
+ * =============================================================================
+ */
+
+/**
+ * @brief Unity setUp - called before each test
+ *
+ * @details No global state to reset in this module.
+ *
+ * @since Version 1.0.0
+ */
+void setUp(void)
+{
+    /* No shared state to reset between tests */
+}
+
+/**
+ * @brief Unity tearDown - called after each test
+ *
+ * @details No resources to release in this module.
+ *
+ * @since Version 1.0.0
+ */
+void tearDown(void)
+{
+    /* No cleanup required */
+}
+
+/* =============================================================================
+ * rx_stack_monitor_init() Tests
+ * =============================================================================
+ */
+
+/**
+ * @brief Verify that rx_stack_monitor_init() returns k_rx_ok
+ *
+ * @details
+ * The mock tx_thread_stack_error_notify() always returns TX_SUCCESS, so
+ * rx_stack_monitor_init() must map that to k_rx_ok.
+ *
+ * @pre Mock tx_api.h in include path (TX_SUCCESS stub)
+ * @post rx_stack_monitor_init() returned k_rx_ok
+ *
+ * @test
+ * 1. Call rx_stack_monitor_init()
+ * 2. Verify return value is k_rx_ok
+ *
+ * @see rx_stack_monitor_init()
+ * @since Version 1.0.0
+ */
+static void test_init_succeeds(void)
+{
+    rx_err_t err = rx_stack_monitor_init();
+
+    /* Precondition: mock always returns TX_SUCCESS */
+    /* Postcondition: k_rx_ok returned */
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+}
+
+/**
+ * @brief Verify that calling rx_stack_monitor_init() twice is idempotent
+ *
+ * @details
+ * ThreadX allows re-registering the stack error handler; calling init twice
+ * must not fail.  This guards against accidental double-registration in
+ * tx_application_define().
+ *
+ * @pre rx_stack_monitor_init() succeeds once
+ * @post Second call also returns k_rx_ok
+ *
+ * @test
+ * 1. Call rx_stack_monitor_init() twice
+ * 2. Verify both calls return k_rx_ok
+ *
+ * @see rx_stack_monitor_init()
+ * @since Version 1.0.0
+ */
+static void test_init_idempotent(void)
+{
+    rx_err_t err_first  = rx_stack_monitor_init();
+    rx_err_t err_second = rx_stack_monitor_init();
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err_first);
+    TEST_ASSERT_EQUAL(k_rx_ok, err_second);
+}
+
+/* =============================================================================
+ * rx_stack_monitor_get_free_bytes() Tests
+ * =============================================================================
+ */
+
+/**
+ * @brief Verify that NULL thread_ptr returns k_rx_err_null_ptr
+ *
+ * @details
+ * Passes NULL as thread_ptr; expects the function to reject it with
+ * k_rx_err_null_ptr before touching free_bytes.
+ *
+ * @pre Nothing special
+ * @post Return value is k_rx_err_null_ptr
+ *
+ * @test
+ * 1. Call rx_stack_monitor_get_free_bytes(NULL, &free_bytes)
+ * 2. Verify return value is k_rx_err_null_ptr
+ *
+ * @see rx_stack_monitor_get_free_bytes()
+ * @since Version 1.0.0
+ */
+static void test_get_free_bytes_null_thread(void)
+{
+    uint32_t free_bytes = 0;
+
+    rx_err_t err = rx_stack_monitor_get_free_bytes(NULL, &free_bytes);
+
+    TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
+    /* free_bytes must not have been written */
+    TEST_ASSERT_EQUAL(0u, free_bytes);
+}
+
+/**
+ * @brief Verify that NULL free_bytes output pointer returns k_rx_err_null_ptr
+ *
+ * @details
+ * Passes a valid thread_ptr but NULL for the output pointer; function must
+ * not dereference the NULL and must return k_rx_err_null_ptr.
+ *
+ * @pre Valid TX_THREAD with stack set up
+ * @post Return value is k_rx_err_null_ptr
+ *
+ * @test
+ * 1. Create a mock TX_THREAD with valid stack fields
+ * 2. Call rx_stack_monitor_get_free_bytes(thread_ptr, NULL)
+ * 3. Verify return value is k_rx_err_null_ptr
+ *
+ * @see rx_stack_monitor_get_free_bytes()
+ * @since Version 1.0.0
+ */
+static void test_get_free_bytes_null_output(void)
+{
+    uint8_t  stack_buf[k_test_stack_size];
+    TX_THREAD thread = {
+        .tx_thread_name        = "MockThread",
+        .tx_thread_id          = 0,
+        .tx_thread_stack_start = stack_buf,
+        .tx_thread_stack_size  = k_test_stack_size,
+    };
+
+    memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);
+
+    rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, NULL);
+
+    TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
+}
+
+/**
+ * @brief Verify return value when fill pattern is absent
+ *
+ * @details
+ * Simulates a stack where the fill pattern was never written (e.g.,
+ * TX_DISABLE_STACK_FILLING was defined).  The first byte is 0x00 rather
+ * than 0xEF, so the function should detect the absent pattern and return
+ * k_rx_err_invalid_state.
+ *
+ * @pre stack_buf[0] != 0xEF
+ * @post Return value is k_rx_err_invalid_state
+ *
+ * @test
+ * 1. Create stack_buf filled with 0x00
+ * 2. Attach to mock TX_THREAD
+ * 3. Call rx_stack_monitor_get_free_bytes()
+ * 4. Verify return value is k_rx_err_invalid_state
+ *
+ * @see rx_stack_monitor_get_free_bytes()
+ * @since Version 1.0.0
+ */
+static void test_get_free_bytes_pattern_absent(void)
+{
+    uint8_t   stack_buf[k_test_stack_size];
+    TX_THREAD thread = {
+        .tx_thread_name        = "MockThread",
+        .tx_thread_id          = 0,
+        .tx_thread_stack_start = stack_buf,
+        .tx_thread_stack_size  = k_test_stack_size,
+    };
+    uint32_t free_bytes = 0;
+
+    /* Fill with zeros - no 0xEF pattern present */
+    memset(stack_buf, 0x00, k_test_stack_size);
+
+    rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, &free_bytes);
+
+    TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+}
+
+/**
+ * @brief Verify high-water mark when the entire stack is unused
+ *
+ * @details
+ * Fills the entire stack buffer with 0xEF (thread has never executed).
+ * Expects free_bytes == k_test_stack_size (all bytes unused).
+ *
+ * @pre stack_buf completely filled with 0xEF
+ * @post free_bytes == k_test_stack_size
+ *
+ * @test
+ * 1. Fill k_test_stack_size bytes with 0xEF
+ * 2. Attach to mock TX_THREAD
+ * 3. Call rx_stack_monitor_get_free_bytes()
+ * 4. Verify return value is k_rx_ok
+ * 5. Verify free_bytes == k_test_stack_size
+ *
+ * @see rx_stack_monitor_get_free_bytes()
+ * @since Version 1.0.0
+ */
+static void test_get_free_bytes_all_unused(void)
+{
+    uint8_t   stack_buf[k_test_stack_size];
+    TX_THREAD thread = {
+        .tx_thread_name        = "MockThread",
+        .tx_thread_id          = 0,
+        .tx_thread_stack_start = stack_buf,
+        .tx_thread_stack_size  = k_test_stack_size,
+    };
+    uint32_t free_bytes = 0;
+
+    /* Entire stack is 0xEF - thread never used any stack */
+    memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);
+
+    rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, &free_bytes);
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL(k_test_stack_size, free_bytes);
+}
+
+/**
+ * @brief Verify high-water mark when part of the stack has been used
+ *
+ * @details
+ * Simulates a thread that has used k_test_used_bytes of stack.  The low
+ * (k_test_stack_size - k_test_used_bytes) bytes remain 0xEF; the top
+ * k_test_used_bytes bytes are 0x00 (simulating written data).
+ *
+ * Expected free_bytes == k_test_stack_size - k_test_used_bytes.
+ *
+ * @pre Lower (k_test_stack_size - k_test_used_bytes) bytes are 0xEF
+ * @pre Upper k_test_used_bytes are 0x00
+ * @post free_bytes == k_test_stack_size - k_test_used_bytes
+ *
+ * @test
+ * 1. Fill entire buffer with 0xEF
+ * 2. Overwrite last k_test_used_bytes with 0x00
+ * 3. Attach to mock TX_THREAD
+ * 4. Call rx_stack_monitor_get_free_bytes()
+ * 5. Verify return value is k_rx_ok
+ * 6. Verify free_bytes == k_test_stack_size - k_test_used_bytes
+ *
+ * @see rx_stack_monitor_get_free_bytes()
+ * @since Version 1.0.0
+ */
+static void test_get_free_bytes_partial_usage(void)
+{
+    uint8_t   stack_buf[k_test_stack_size];
+    TX_THREAD thread = {
+        .tx_thread_name        = "MockThread",
+        .tx_thread_id          = 0,
+        .tx_thread_stack_start = stack_buf,
+        .tx_thread_stack_size  = k_test_stack_size,
+    };
+    uint32_t free_bytes = 0;
+
+    /* Fill entire stack with sentinel, then "use" top k_test_used_bytes */
+    memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);
+    memset(&stack_buf[k_test_stack_size - k_test_used_bytes], 0x00, k_test_used_bytes);
+
+    rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, &free_bytes);
+
+    const uint32_t expected_free = k_test_stack_size - k_test_used_bytes;
+
+    TEST_ASSERT_EQUAL(k_rx_ok, err);
+    TEST_ASSERT_EQUAL(expected_free, free_bytes);
+}
+
+/* =============================================================================
+ * Test Runner
+ * =============================================================================
+ */
+
+/**
+ * @brief Main test entry point - runs all stack monitor tests
+ *
+ * @details
+ * Initialises the Unity test framework, runs all test cases, and returns
+ * the Unity exit code (0 = all pass, non-zero = failures detected).
+ *
+ * @return int Unity result code (0 on success)
+ *
+ * @pre Unity test framework available (FetchContent from CMakeLists.txt)
+ * @post Test results printed to stdout
+ * @post Non-zero exit code if any test fails
+ *
+ * @see UNITY_BEGIN() Start Unity harness
+ * @see UNITY_END() Finalize and return exit code
+ * @see RUN_TEST() Execute individual test
+ *
+ * @since Version 1.0.0
+ */
+int main(void)
+{
+    UNITY_BEGIN();
+
+    /* rx_stack_monitor_init() tests */
+    RUN_TEST(test_init_succeeds);
+    RUN_TEST(test_init_idempotent);
+
+    /* rx_stack_monitor_get_free_bytes() tests */
+    RUN_TEST(test_get_free_bytes_null_thread);
+    RUN_TEST(test_get_free_bytes_null_output);
+    RUN_TEST(test_get_free_bytes_pattern_absent);
+    RUN_TEST(test_get_free_bytes_all_unused);
+    RUN_TEST(test_get_free_bytes_partial_usage);
+
+    return UNITY_END();
+}

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
@@ -46,6 +46,15 @@
  * @see rx_stack_monitor.c Implementation
  * @see tests/mocks/tx_api.h Mock ThreadX API
  *
+ * @par SOLID Adherence:
+ * - Single Responsibility: Tests one module (rx_stack_monitor) only
+ * - Dependency Inversion: Firmware coupled to mock ThreadX via include path
+ *
+ * @date 2026-01-11
+ * @version 1.0.0
+ * @par Hardware:
+ * - Runs on host (x86-64/aarch64) under CTest; no RX72N hardware required
+ *
  * @since Version 1.0.0
  * @author STAR Team
  * @copyright Copyright (c) 2026 STAR Project. MIT License.
@@ -75,9 +84,10 @@
  * @since Version 1.0.0
  */
 typedef enum : uint32_t {
-    k_test_stack_size  = 64,  /**< Total mock stack buffer size in bytes */
-    k_test_used_bytes  = 20,  /**< Bytes "used" (not 0xEF) at high end of stack */
-    k_stack_fill_byte  = 0xEF /**< ThreadX stack fill sentinel byte */
+    k_test_stack_size  = 64,   /**< Total mock stack buffer size in bytes */
+    k_test_used_bytes  = 20,   /**< Bytes "used" (not 0xEF) at high end of stack */
+    k_stack_fill_byte  = 0xEF, /**< ThreadX stack fill sentinel byte */
+    k_zero_u32         = 0U,   /**< Named zero constant (avoids raw 0 literals; NASA Rule 8) */
 } test_stack_constants_t;
 
 /* =============================================================================
@@ -135,9 +145,10 @@ static void test_init_succeeds(void)
 {
     rx_err_t err = rx_stack_monitor_init();
 
-    /* Precondition: mock always returns TX_SUCCESS */
-    /* Postcondition: k_rx_ok returned */
+    /* Postcondition 1: mock TX_SUCCESS maps to k_rx_ok */
     TEST_ASSERT_EQUAL(k_rx_ok, err);
+    /* Postcondition 2: stack checking feature was not reported as absent */
+    TEST_ASSERT_NOT_EQUAL(k_rx_err_not_supported, err);
 }
 
 /**
@@ -191,13 +202,13 @@ static void test_init_idempotent(void)
  */
 static void test_get_free_bytes_null_thread(void)
 {
-    uint32_t free_bytes = 0;
+    uint32_t free_bytes = k_zero_u32;
 
     rx_err_t err = rx_stack_monitor_get_free_bytes(NULL, &free_bytes);
 
     TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
     /* free_bytes must not have been written */
-    TEST_ASSERT_EQUAL(0U, free_bytes);
+    TEST_ASSERT_EQUAL(k_zero_u32, free_bytes);
 }
 
 /**
@@ -223,7 +234,7 @@ static void test_get_free_bytes_null_output(void)
     uint8_t  stack_buf[k_test_stack_size];
     TX_THREAD thread = {
         .tx_thread_name        = "MockThread",
-        .tx_thread_id          = 0,
+        .tx_thread_id          = k_tx_invalid_id,
         .tx_thread_stack_start = stack_buf,
         .tx_thread_stack_size  = k_test_stack_size,
     };
@@ -266,11 +277,11 @@ static void test_get_free_bytes_pattern_absent(void)
     uint8_t   stack_buf[k_test_stack_size];
     TX_THREAD thread = {
         .tx_thread_name        = "MockThread",
-        .tx_thread_id          = 0,
+        .tx_thread_id          = k_tx_invalid_id,
         .tx_thread_stack_start = stack_buf,
         .tx_thread_stack_size  = k_test_stack_size,
     };
-    uint32_t free_bytes = 0;
+    uint32_t free_bytes = k_zero_u32;
 
     /* Fill with zeros - no 0xEF pattern present */
     memset(stack_buf, 0x00, k_test_stack_size);
@@ -305,11 +316,11 @@ static void test_get_free_bytes_all_unused(void)
     uint8_t   stack_buf[k_test_stack_size];
     TX_THREAD thread = {
         .tx_thread_name        = "MockThread",
-        .tx_thread_id          = 0,
+        .tx_thread_id          = k_tx_invalid_id,
         .tx_thread_stack_start = stack_buf,
         .tx_thread_stack_size  = k_test_stack_size,
     };
-    uint32_t free_bytes = 0;
+    uint32_t free_bytes = k_zero_u32;
 
     /* Entire stack is 0xEF - thread never used any stack */
     memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);
@@ -350,11 +361,11 @@ static void test_get_free_bytes_partial_usage(void)
     uint8_t   stack_buf[k_test_stack_size];
     TX_THREAD thread = {
         .tx_thread_name        = "MockThread",
-        .tx_thread_id          = 0,
+        .tx_thread_id          = k_tx_invalid_id,
         .tx_thread_stack_start = stack_buf,
         .tx_thread_stack_size  = k_test_stack_size,
     };
-    uint32_t free_bytes = 0;
+    uint32_t free_bytes = k_zero_u32;
 
     /* Fill entire stack with sentinel, then "use" top k_test_used_bytes */
     memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
@@ -17,9 +17,9 @@
  *
  * | Category | Tests | Notes |
  * |----------|-------|-------|
- * | Initialization | 2 | NULL handler, success path |
- * | High-water mark | 5 | NULL args, pattern absent, fully filled, partially filled, null output buf check |
- * | Total | 7 | Complete public API coverage |
+ * | Initialization | 2 | success, idempotent re-registration |
+ * | High-water mark | 6 | NULL args, null stack_start, pattern absent, fully filled, partially filled, null output buf check |
+ * | Total | 8 | Complete public API coverage |
  *
  * ## How Stack Checking Works in Tests
  *
@@ -156,7 +156,11 @@ void tearDown(void)
  * rx_stack_monitor_init() must map that to k_rx_ok.
  *
  * @pre Mock tx_api.h in include path (TX_SUCCESS stub)
+ * @pre UNIT_TEST build context active (mock tx_thread_stack_error_notify present)
  * @post rx_stack_monitor_init() returned k_rx_ok
+ * @post No k_rx_err_not_supported error was logged (stack checking feature present in mock)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Call rx_stack_monitor_init()
@@ -183,8 +187,12 @@ static void test_init_succeeds(void)
  * must not fail.  This guards against accidental double-registration in
  * tx_application_define().
  *
- * @pre rx_stack_monitor_init() succeeds once
- * @post Second call also returns k_rx_ok
+ * @pre rx_stack_monitor_init() succeeds on the first call
+ * @pre Mock tx_thread_stack_error_notify() always returns TX_SUCCESS
+ * @post Second call also returns k_rx_ok (both err_first and err_second are k_rx_ok)
+ * @post No error or not-supported code is returned by either call
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Call rx_stack_monitor_init() twice
@@ -214,8 +222,12 @@ static void test_init_idempotent(void)
  * Passes NULL as thread_ptr; expects the function to reject it with
  * k_rx_err_null_ptr before touching free_bytes.
  *
- * @pre Nothing special
+ * @pre free_bytes is initialised to k_zero_u32 before the call
+ * @pre No valid TX_THREAD is required; thread_ptr is intentionally NULL
  * @post Return value is k_rx_err_null_ptr
+ * @post free_bytes remains unchanged at k_zero_u32 (not written on error)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Call rx_stack_monitor_get_free_bytes(NULL, &free_bytes)
@@ -242,8 +254,12 @@ static void test_get_free_bytes_null_thread(void)
  * Passes a valid thread_ptr but NULL for the output pointer; function must
  * not dereference the NULL and must return k_rx_err_null_ptr.
  *
- * @pre Valid TX_THREAD with stack set up
- * @post Return value is k_rx_err_null_ptr
+ * @pre Valid TX_THREAD with stack_buf filled with k_stack_fill_byte (0xEF)
+ * @pre tx_thread_stack_size is set to k_test_stack_size (non-zero)
+ * @post Return value is k_rx_err_null_ptr (not k_rx_ok)
+ * @post stack_buf contents are unchanged (no bytes were written by the function)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Create a mock TX_THREAD with valid stack fields
@@ -284,8 +300,12 @@ static void test_get_free_bytes_null_output(void)
  * than 0xEF, so the function should detect the absent pattern and return
  * k_rx_err_invalid_state.
  *
- * @pre stack_buf[0] != 0xEF
+ * @pre stack_buf[0] != 0xEF (filled with k_stack_fill_absent_byte = 0x00)
+ * @pre free_bytes is initialised to k_zero_u32 before the call
  * @post Return value is k_rx_err_invalid_state
+ * @post free_bytes remains k_zero_u32 (not written on error)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Create stack_buf filled with 0x00
@@ -324,8 +344,12 @@ static void test_get_free_bytes_pattern_absent(void)
  * Fills the entire stack buffer with 0xEF (thread has never executed).
  * Expects free_bytes == k_test_stack_size (all bytes unused).
  *
- * @pre stack_buf completely filled with 0xEF
- * @post free_bytes == k_test_stack_size
+ * @pre stack_buf completely filled with k_stack_fill_byte (0xEF) for all k_test_stack_size bytes
+ * @pre free_bytes is initialised to k_zero_u32 before the call
+ * @post free_bytes == k_test_stack_size (all bytes reported as unused)
+ * @post err == k_rx_ok (scan succeeded without error)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Fill k_test_stack_size bytes with 0xEF
@@ -367,9 +391,12 @@ static void test_get_free_bytes_all_unused(void)
  *
  * Expected free_bytes == k_test_stack_size - k_test_used_bytes.
  *
- * @pre Lower (k_test_stack_size - k_test_used_bytes) bytes are 0xEF
- * @pre Upper k_test_used_bytes are 0x00
+ * @pre Lower (k_test_stack_size - k_test_used_bytes) bytes are k_stack_fill_byte (0xEF)
+ * @pre Upper k_test_used_bytes are k_stack_fill_absent_byte (0x00, simulating written data)
  * @post free_bytes == k_test_stack_size - k_test_used_bytes
+ * @post err == k_rx_ok (scan succeeded; partial fill pattern detected correctly)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
  *
  * @test
  * 1. Fill entire buffer with 0xEF
@@ -405,6 +432,49 @@ static void test_get_free_bytes_partial_usage(void)
     TEST_ASSERT_EQUAL(expected_free, free_bytes);
 }
 
+/**
+ * @brief Verify that NULL tx_thread_stack_start returns k_rx_err_null_ptr
+ *
+ * @details
+ * Passes a TX_THREAD whose tx_thread_stack_start is TX_NULL but has a valid
+ * non-zero tx_thread_stack_size.  The function must detect the NULL stack
+ * base pointer before attempting to read any stack bytes, and must return
+ * k_rx_err_null_ptr without modifying free_bytes.
+ *
+ * @pre TX_THREAD has tx_thread_stack_start == TX_NULL and tx_thread_stack_size == k_test_stack_size
+ * @pre free_bytes is initialised to k_zero_u32 before the call
+ * @post Return value is k_rx_err_null_ptr
+ * @post free_bytes remains k_zero_u32 (not written on error)
+ *
+ * @note Not thread-safe; Unity executes tests serially in a single-threaded context.
+ *
+ * @test
+ * 1. Construct a mock TX_THREAD with tx_thread_stack_start = TX_NULL
+ * 2. Set tx_thread_stack_size to k_test_stack_size (non-zero)
+ * 3. Call rx_stack_monitor_get_free_bytes(&thread, &free_bytes)
+ * 4. Verify return value is k_rx_err_null_ptr
+ * 5. Verify free_bytes is still k_zero_u32
+ *
+ * @see rx_stack_monitor_get_free_bytes()
+ * @since Version 1.0.0
+ */
+static void test_get_free_bytes_null_stack_start(void)
+{
+    TX_THREAD thread = {
+        .tx_thread_name        = "NullStackThread",
+        .tx_thread_id          = k_tx_invalid_id,
+        .tx_thread_stack_start = TX_NULL,
+        .tx_thread_stack_size  = k_test_stack_size,
+    };
+    uint32_t free_bytes = k_zero_u32;
+
+    rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, &free_bytes);
+
+    TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
+    /* Postcondition: free_bytes must not have been written on error */
+    TEST_ASSERT_EQUAL(k_zero_u32, free_bytes);
+}
+
 /* =============================================================================
  * Test Runner
  * =============================================================================
@@ -420,8 +490,12 @@ static void test_get_free_bytes_partial_usage(void)
  * @return int Unity result code (0 on success)
  *
  * @pre Unity test framework available (FetchContent from CMakeLists.txt)
+ * @pre Test environment and hardware mocks initialised (mock tx_api.h in include path)
  * @post Test results printed to stdout
  * @post Non-zero exit code if any test fails
+ *
+ * @note Not thread-safe; the test harness and these tests must be executed serially
+ *       in a single-threaded context.
  *
  * @see UNITY_BEGIN() Start Unity harness
  * @see UNITY_END() Finalize and return exit code
@@ -439,6 +513,7 @@ int main(void)
 
     /* rx_stack_monitor_get_free_bytes() tests */
     RUN_TEST(test_get_free_bytes_null_thread);
+    RUN_TEST(test_get_free_bytes_null_stack_start);
     RUN_TEST(test_get_free_bytes_null_output);
     RUN_TEST(test_get_free_bytes_pattern_absent);
     RUN_TEST(test_get_free_bytes_all_unused);

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
@@ -74,20 +74,30 @@
  */
 
 /**
- * @brief Stack buffer sizes used in high-water mark tests
+ * @enum test_stack_constants_t
+ * @brief Stack buffer sizes and fill-pattern constants for high-water mark tests
  *
  * @details
  * These sizes are chosen to be large enough to verify scanning correctness
  * while remaining small enough for stack allocation in test functions.
  *
  * @invariant k_test_stack_size > k_test_used_bytes (at least one free byte)
+ *
+ * @code
+ * uint8_t stack_buf[k_test_stack_size];
+ * memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);
+ * memset(&stack_buf[k_test_stack_size - k_test_used_bytes],
+ *        (int)k_stack_fill_absent_byte, k_test_used_bytes);
+ * @endcode
+ *
  * @since Version 1.0.0
  */
 typedef enum : uint32_t {
-    k_test_stack_size  = 64,   /**< Total mock stack buffer size in bytes */
-    k_test_used_bytes  = 20,   /**< Bytes "used" (not 0xEF) at high end of stack */
-    k_stack_fill_byte  = 0xEF, /**< ThreadX stack fill sentinel byte */
-    k_zero_u32         = 0U,   /**< Named zero constant (avoids raw 0 literals; NASA Rule 8) */
+    k_test_stack_size       = 64U,   /**< Total mock stack buffer size in bytes */
+    k_test_used_bytes       = 20U,   /**< Bytes "used" (not 0xEF) at high end of stack */
+    k_stack_fill_byte       = 0xEFU, /**< ThreadX stack fill sentinel byte */
+    k_stack_fill_absent_byte = 0x00U, /**< Fill byte used to simulate absent fill pattern */
+    k_zero_u32              = 0U,    /**< Named zero constant (avoids raw 0 literals; NASA Rule 8) */
 } test_stack_constants_t;
 
 /* =============================================================================
@@ -100,6 +110,13 @@ typedef enum : uint32_t {
  *
  * @details No global state to reset in this module.
  *
+ * @pre Unity test framework has been initialised via UNITY_BEGIN()
+ * @pre No test has left residual side-effects (module has no shared state)
+ * @post Test environment is clean; no state carried in from prior tests
+ * @post No dynamic resources have been allocated
+ *
+ * @note Not thread-safe; Unity runs tests single-threaded
+ *
  * @since Version 1.0.0
  */
 void setUp(void)
@@ -111,6 +128,13 @@ void setUp(void)
  * @brief Unity tearDown - called after each test
  *
  * @details No resources to release in this module.
+ *
+ * @pre The preceding test has completed (pass or fail)
+ * @pre No dynamic resources were allocated during the test
+ * @post All stack buffers declared in the test are out of scope
+ * @post No allocated resources remain; heap is unchanged
+ *
+ * @note Not thread-safe; Unity runs tests single-threaded
  *
  * @since Version 1.0.0
  */
@@ -246,7 +270,7 @@ static void test_get_free_bytes_null_output(void)
     TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
 
     /* Postcondition (NASA Rule 5): stack buffer must not have been modified */
-    for (uint32_t i = 0; i < k_test_stack_size; i++) {
+    for (uint32_t i = k_zero_u32; i < k_test_stack_size; i++) {
         TEST_ASSERT_EQUAL((uint8_t)k_stack_fill_byte, stack_buf[i]);
     }
 }
@@ -283,12 +307,14 @@ static void test_get_free_bytes_pattern_absent(void)
     };
     uint32_t free_bytes = k_zero_u32;
 
-    /* Fill with zeros - no 0xEF pattern present */
-    memset(stack_buf, 0x00, k_test_stack_size);
+    /* Fill with absent-pattern byte - no 0xEF sentinel present */
+    memset(stack_buf, (int)k_stack_fill_absent_byte, k_test_stack_size);
 
     rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, &free_bytes);
 
     TEST_ASSERT_EQUAL(k_rx_err_invalid_state, err);
+    /* Postcondition: output parameter must not be modified on error */
+    TEST_ASSERT_EQUAL(k_zero_u32, free_bytes);
 }
 
 /**
@@ -369,7 +395,7 @@ static void test_get_free_bytes_partial_usage(void)
 
     /* Fill entire stack with sentinel, then "use" top k_test_used_bytes */
     memset(stack_buf, (int)k_stack_fill_byte, k_test_stack_size);
-    memset(&stack_buf[k_test_stack_size - k_test_used_bytes], 0x00, k_test_used_bytes);
+    memset(&stack_buf[k_test_stack_size - k_test_used_bytes], (int)k_stack_fill_absent_byte, k_test_used_bytes);
 
     rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, &free_bytes);
 

--- a/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
+++ b/e2-studio-star-rx72n-firmware/tests/test_rx_stack_monitor.c
@@ -18,8 +18,8 @@
  * | Category | Tests | Notes |
  * |----------|-------|-------|
  * | Initialization | 2 | NULL handler, success path |
- * | High-water mark | 4 | NULL args, pattern absent, fully filled, partially filled |
- * | Total | 6 | Complete public API coverage |
+ * | High-water mark | 5 | NULL args, pattern absent, fully filled, partially filled, null output buf check |
+ * | Total | 7 | Complete public API coverage |
  *
  * ## How Stack Checking Works in Tests
  *
@@ -197,7 +197,7 @@ static void test_get_free_bytes_null_thread(void)
 
     TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
     /* free_bytes must not have been written */
-    TEST_ASSERT_EQUAL(0u, free_bytes);
+    TEST_ASSERT_EQUAL(0U, free_bytes);
 }
 
 /**
@@ -233,6 +233,11 @@ static void test_get_free_bytes_null_output(void)
     rx_err_t err = rx_stack_monitor_get_free_bytes(&thread, NULL);
 
     TEST_ASSERT_EQUAL(k_rx_err_null_ptr, err);
+
+    /* Postcondition (NASA Rule 5): stack buffer must not have been modified */
+    for (uint32_t i = 0; i < k_test_stack_size; i++) {
+        TEST_ASSERT_EQUAL((uint8_t)k_stack_fill_byte, stack_buf[i]);
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes #298

- **Enable TX_ENABLE_STACK_CHECKING** in `libs/threadx/tx_user.h` (`USE_TX_ENABLE_STACK_CHECKING` 0 → 1) so ThreadX validates the 0xEF sentinel at every context switch. Stack filling remains enabled (`USE_TX_DISABLE_STACK_FILLING = 0`) to allow high-water mark measurement.
- **Add `rx_stack_monitor` module** (`src/rx_stack_monitor.c` / `src/inc/rx_stack_monitor.h`) which registers an application-level overflow handler via `tx_thread_stack_error_notify()` and exposes `rx_stack_monitor_get_free_bytes()` for per-thread high-water mark collection.
- **Wire handler into `tx_application_define()`** in `src/main.c` (Step 4, after all tasks are created).
- **Extend mock `tx_api.h`** with `TX_NULL`, `UCHAR`, stack fields on `TX_THREAD`, and a `tx_thread_stack_error_notify()` stub so the new tests compile on the host runner.
- **Add 7 Unity tests** in `tests/test_rx_stack_monitor.c` covering init success, idempotency, null-ptr guards, absent fill pattern, all-unused, and partial-usage scenarios.

## Behaviour on overflow

When ThreadX detects a corrupted sentinel:
1. Thread name is written directly to UART via `uart_debug_puts()` (minimises additional stack usage).
2. `internal_rx_fatal_error()` disables interrupts and halts; the hardware IWDT resets within 2 seconds.

## High-water mark collection

Call `rx_stack_monitor_get_free_bytes(thread_ptr, &free_bytes)` after a long-run test to collect remaining headroom per thread. The function counts consecutive 0xEF bytes from the stack base upward.

## Test plan

- [x] `cmake --build build --target test_rx_stack_monitor` compiles cleanly with `-Wall -Wextra -Werror`
- [x] All 7 Unity tests pass (init_succeeds, init_idempotent, null_thread, null_output, pattern_absent, all_unused, partial_usage)
- [ ] Full unit test suite: `cd tests && cmake -S . -B build && cmake --build build && ctest --output-on-failure`
- [ ] Hardware validation: Flash firmware, observe UART log `[STACK_MON] Stack overflow handler registered` at boot
- [ ] Intentional overflow test (dev only): Allocate excess stack in a test thread and confirm UART message + IWDT reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime stack checking enabled by default; stack-error handling is registered during startup.
  * New stack-monitoring API to report per-thread free-stack (high-water mark) and detect overflows.

* **Documentation**
  * Clarified stack-checking, stack-fill semantics, sentinel validation, and integration guidance.

* **Tests**
  * Added unit tests validating initialization, overflow handling, free-bytes reporting, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->