### PR TITLE
fix(heartbeat): decouple PING timer from lastSeen, update lastSeen on ACK/NACK

### DIFF
--- a/star-gateway/internal/manager/heartbeat.go
+++ b/star-gateway/internal/manager/heartbeat.go
@@ -58,10 +58,15 @@ const (
 //
 // How it works:
 //
-//	Active link: Data frames flow constantly, resetting the implicit timer.
-//	             PING never fires because the link is never idle for 1s.
-//	Idle link:   After 200ms of silence, implicit timeout triggers failover.
-//	             PING at 1s is a secondary probe for very-slow-data links.
+//	Active link:  Data frames (including ACK/NACK) keep lastSeen fresh.
+//	              PING fires every pingInterval since last valid PONG (independent timer).
+//	              Implicit timeout never fires because lastSeen stays current.
+//	Zombie link:  Stale OS-buffered frames keep lastSeen fresh, but firmware is dead.
+//	              PING fires at pingInterval since last PONG; no PONG arrives;
+//	              counter-based failover triggers. Implicit timeout cannot catch this
+//	              because lastSeen is continuously refreshed by the buffered frames.
+//	Dead link:    No frames of any kind; implicit timeout fires at 200ms (faster than
+//	              PING at 1s, so implicit path is the fast-path for hard failures).
 //
 // WARNING: Do NOT increase DefaultFailureTimeout above 500ms without first
 // verifying the RX72N WDT timeout. The implicit timeout is the critical path.
@@ -274,46 +279,44 @@ func (hm *HeartbeatManager) Run(ctx context.Context, tm *TransportManager) {
 
 // check performs the heartbeat check logic.
 //
-// This is called periodically by Run() (every failureTimeout/4) to:
-//  1. Calculate elapsed time since lastSeen
-//  2. Trigger failover if elapsed > failureTimeout (200ms) - ONCE per failure
-//  3. Track consecutive PONG misses and trigger failover at threshold
-//  4. Send PING if elapsed > pingInterval (1s) and not yet failed
+// This is called periodically by Run() (every failureTimeout/4) using two independent
+// elapsed timers so that each detection mechanism has its own reference point:
+//
+//  1. pingElapsed = time.Since(lastValidPong): drives the explicit PING mechanism.
+//     Fires when no valid PONG has arrived for pingInterval (1s). Checked FIRST to
+//     enable counter-based detection even when stale buffered frames (ACK/NACK) keep
+//     lastSeen fresh — the "zombie link" scenario the implicit timeout cannot catch
+//     because lastSeen is continuously refreshed by the buffered frames.
+//
+//  2. implicitElapsed = time.Since(lastSeen): drives the implicit timeout mechanism.
+//     Fires when no frame of any kind has arrived for failureTimeout (200ms). Checked
+//     SECOND as a fast-path for completely dead links. Because failureTimeout (200ms) is
+//     much shorter than pingInterval (1s), the implicit path reaches its threshold first
+//     on a hard dead link, making it the primary detector for that case.
 //
 // Two independent failover triggers exist (defense-in-depth):
-//   - Time-based: No frames at all for failureTimeout (200ms)
-//   - Counter-based: DefaultConsecutiveMissThreshold unanswered PINGs
+//   - Counter-based: DefaultConsecutiveMissThreshold unanswered PINGs (zombie/degraded links)
+//   - Time-based: No frames at all for failureTimeout (200ms) (hard dead links)
 //
 // The failureTriggered flag prevents repeated failover attempts for the same failure.
-// It's cleared when OnFrameReceived() or OnPongReceived() is called (link recovered).
-//
-// The order matters: we check failure first to avoid sending PING on a dead link.
+// It is cleared when OnFrameReceived() or OnPongReceived() is called (link recovered).
 func (hm *HeartbeatManager) check(ctx context.Context, tm *TransportManager) {
 	hm.mu.Lock()
-	elapsed := time.Since(hm.lastSeen)
+	implicitElapsed := time.Since(hm.lastSeen)
+	pingElapsed := time.Since(hm.lastValidPong)
 	alreadyTriggered := hm.failureTriggered
 	pending := hm.pendingPing
 	hm.mu.Unlock()
 
-	// Time-based failure detection (highest priority)
-	// Only trigger once per failure to prevent spamming attemptFailover()
-	if elapsed > hm.failureTimeout && !alreadyTriggered {
-		log.Printf("Heartbeat timeout (%v), triggering failover", elapsed)
-
-		// Set flag BEFORE calling onLinkFailed to prevent race
-		hm.mu.Lock()
-		hm.failureTriggered = true
-		hm.mu.Unlock()
-
-		if hm.onLinkFailed != nil {
-			hm.onLinkFailed()
-		}
-		return
-	}
-
-	// Explicit PING (only if idle but not yet failed)
-	if elapsed > hm.pingInterval && !alreadyTriggered {
-		// Before sending new PING, check if previous PING was answered
+	// Explicit PING — checked first.
+	//
+	// Uses pingElapsed (time since last valid PONG), which is independent of lastSeen.
+	// This allows counter-based detection to fire even when stale buffered frames keep
+	// lastSeen fresh, preventing the implicit timeout from ever triggering. Without this
+	// independence, alreadyTriggered would be set at 200ms by the implicit path, making
+	// the counter-based path permanently unreachable for the zombie-link scenario.
+	if pingElapsed > hm.pingInterval && !alreadyTriggered {
+		// Before sending a new PING, check whether the previous one was answered.
 		if pending {
 			hm.mu.Lock()
 			hm.consecutiveMisses++
@@ -343,6 +346,24 @@ func (hm *HeartbeatManager) check(ctx context.Context, tm *TransportManager) {
 		}
 
 		hm.sendPing(ctx, tm)
+	}
+
+	// Implicit timeout — checked second.
+	//
+	// Uses implicitElapsed (time since last ANY frame). Fast-path for completely dead
+	// links where no frames flow at all. Because failureTimeout (200ms) << pingInterval
+	// (1s), this fires first on a hard dead link. Only triggers once per failure.
+	if implicitElapsed > hm.failureTimeout && !alreadyTriggered {
+		log.Printf("Heartbeat timeout (%v), triggering failover", implicitElapsed)
+
+		// Set flag BEFORE calling onLinkFailed to prevent race.
+		hm.mu.Lock()
+		hm.failureTriggered = true
+		hm.mu.Unlock()
+
+		if hm.onLinkFailed != nil {
+			hm.onLinkFailed()
+		}
 	}
 }
 

--- a/star-gateway/internal/manager/heartbeat_test.go
+++ b/star-gateway/internal/manager/heartbeat_test.go
@@ -627,3 +627,148 @@ func TestHeartbeatManager_WDTTimingVerification(t *testing.T) {
 			DefaultConsecutiveMissThreshold)
 	}
 }
+
+// TestHeartbeatManager_PingTimerIndependentOfLastSeen verifies that the PING fires
+// based on lastValidPong even when lastSeen is kept fresh by OnFrameReceived calls.
+//
+// This is the key property that enables zombie-link detection: stale OS-buffered frames
+// (ACK/NACK) keep lastSeen fresh — preventing the implicit 200ms timeout from firing —
+// while lastValidPong ages independently, eventually triggering the PING. Without this
+// independence, the counter-based path is permanently unreachable because lastSeen is
+// always refreshed before implicitElapsed exceeds failureTimeout.
+//
+// Setup: lastSeen = now (fresh, no implicit timeout), lastValidPong = past (old, triggers
+// PING), pendingPing = true (simulates a prior unanswered PING). A single check() call
+// should increment consecutiveMisses and trigger counter-based failover, proving the PING
+// condition used lastValidPong, not lastSeen.
+func TestHeartbeatManager_PingTimerIndependentOfLastSeen(t *testing.T) {
+	failureCalled := false
+	var mu sync.Mutex
+
+	hm, err := NewHeartbeatManager(shortPingInterval, shortFailureTimeout, func() {
+		mu.Lock()
+		failureCalled = true
+		mu.Unlock()
+	})
+	if err != nil {
+		t.Fatalf("NewHeartbeatManager failed: %v", err)
+	}
+
+	// Age lastValidPong well past pingInterval, but keep lastSeen fresh so the
+	// implicit timeout cannot fire. With old code (elapsed = time.Since(lastSeen)),
+	// neither block would trigger here: lastSeen is fresh (< failureTimeout) and
+	// lastSeen is fresh (< pingInterval too). With the new code, pingElapsed is based
+	// on lastValidPong and exceeds pingInterval independently.
+	hm.mu.Lock()
+	hm.lastValidPong = time.Now().Add(-5 * shortPingInterval) // far past pingInterval
+	hm.lastSeen = time.Now()                                  // fresh: implicit timeout won't fire
+	hm.pendingPing = true                                     // simulate prior unanswered PING
+	hm.lastPingSent = testPongCounter
+	hm.consecutiveMisses = DefaultConsecutiveMissThreshold - 1 // one more miss triggers failover
+	hm.mu.Unlock()
+
+	// No transport registered: sendPing will fail (if we reach it). But miss counting
+	// occurs before sendPing, so the counter-based path still fires when pending=true.
+	tm := NewTransportManager(DefaultConfig())
+
+	hm.check(context.Background(), tm)
+
+	// Counter-based failover should have triggered because pingElapsed > pingInterval
+	// and pendingPing was true, incrementing consecutiveMisses to >= threshold.
+	mu.Lock()
+	triggered := failureCalled
+	mu.Unlock()
+
+	if !triggered {
+		t.Error("PING timer (lastValidPong-based) should trigger counter-based failover " +
+			"even when lastSeen is fresh — proves pingElapsed is independent of lastSeen")
+	}
+
+	// consecutiveMisses is reset to 0 after counter-based failover.
+	hm.mu.Lock()
+	misses := hm.consecutiveMisses
+	hm.mu.Unlock()
+
+	if misses != 0 {
+		t.Errorf("consecutiveMisses = %d after counter-based failover, want 0 (reset on trigger)", misses)
+	}
+}
+
+// TestHeartbeatManager_ZombieLinkCounterDetection exercises the full zombie-link scenario
+// end-to-end using the Run goroutine: continuous OnFrameReceived calls keep the implicit
+// timeout from firing, but the PING timer (based on lastValidPong) ages independently,
+// eventually triggering counter-based failover.
+//
+// A mock transport is registered so that PING sends succeed and pendingPing is set.
+// After one PING interval passes without a PONG response, the next check sees
+// pendingPing=true, increments consecutiveMisses to threshold, and calls onLinkFailed.
+func TestHeartbeatManager_ZombieLinkCounterDetection(t *testing.T) {
+	failureCalled := false
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	hm, err := NewHeartbeatManager(shortPingInterval, shortFailureTimeout, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if !failureCalled {
+			failureCalled = true
+			wg.Done()
+		}
+	})
+	if err != nil {
+		t.Fatalf("NewHeartbeatManager failed: %v", err)
+	}
+
+	// Register a mock transport so PING sends succeed (pendingPing gets set).
+	// This is required: failed sends do not set pendingPing, so misses would never
+	// accumulate and counter-based failover would never trigger.
+	tm := NewTransportManager(DefaultConfig())
+	mockTransport := &testutil.MockHARQ{}
+	tm.RegisterTransport("mock", mockTransport, 10)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go hm.Run(ctx, tm)
+
+	// Continuously refresh lastSeen to prevent the implicit 200ms timeout from firing.
+	// This simulates stale OS-buffered ACK/NACK frames arriving while the firmware is
+	// actually dead. Without this, the implicit timeout would fire first and the test
+	// would not isolate the zombie-link (counter-based) detection path.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	// Goroutine keeps lastSeen fresh while we wait for counter-based failover.
+	refreshCtx, stopRefresh := context.WithCancel(context.Background())
+	defer stopRefresh()
+	go func() {
+		ticker := time.NewTicker(shortPingInterval / 2)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-refreshCtx.Done():
+				return
+			case <-ticker.C:
+				hm.OnFrameReceived()
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+		// Success: counter-based failover triggered despite continuous implicit-timer resets.
+	case <-time.After(maxWaitForCallback):
+		t.Error("Zombie-link counter-based failover not triggered within expected time; " +
+			"PING timer must fire independently of lastSeen")
+	}
+
+	mu.Lock()
+	if !failureCalled {
+		t.Error("Failure callback should have been called via counter-based PING path")
+	}
+	mu.Unlock()
+}

--- a/star-gateway/internal/manager/manager.go
+++ b/star-gateway/internal/manager/manager.go
@@ -696,6 +696,11 @@ func (tm *TransportManager) dispatchControlFrame(ctx context.Context, result *ha
 		return nil
 
 	case frame.FrameTypeAck, frame.FrameTypeNack:
+		// ACK/NACK: Any valid frame proves the remote is alive; update lastSeen
+		// per TRANSPORT_ARCHITECTURE.md §Heartbeat — "ANY valid frame" resets the timer.
+		// Without this, HARQ retransmission bursts (many ACKs, no COMMAND/RESPONSE)
+		// would false-positive the 200ms implicit timeout.
+		tm.heartbeat.OnFrameReceived()
 		log.Printf("Received %s (seq=%d) - consumed by dispatcher",
 			result.Metadata.Type.String(), result.Metadata.Sequence)
 		return nil

--- a/star-gateway/internal/manager/scenarios_test.go
+++ b/star-gateway/internal/manager/scenarios_test.go
@@ -39,6 +39,10 @@ const (
 	// Failure thresholds
 	immediateFailover = 1
 	failAfterTwo      = 2
+
+	// receiveYieldDelay is the minimum yield in mock ReceiveFuncs to prevent
+	// busy-spinning in background goroutines that loop on Receive.
+	receiveYieldDelay = time.Millisecond
 )
 
 // TestScenario1_NormalOperationUSB simulates normal operation with USB as primary transport.
@@ -84,7 +88,7 @@ func TestScenario1_NormalOperationUSB(t *testing.T) {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(1 * time.Millisecond):
+			case <-time.After(receiveYieldDelay):
 			}
 			return &harq.ReceiveResult{
 				Payload:  []byte("telemetry"),

--- a/star-gateway/internal/manager/scenarios_test.go
+++ b/star-gateway/internal/manager/scenarios_test.go
@@ -52,20 +52,39 @@ func TestScenario1_NormalOperationUSB(t *testing.T) {
 	// (inside Start) and must return RESET_ACK so the handshake completes
 	// immediately. Subsequent calls return normal telemetry frames.
 	var receiveCount atomic.Int32
+	// capturedSessionID stores the session ID from the outgoing RESET frame so
+	// the mock can echo it back in the RESET_ACK, avoiding any assumption about
+	// the internal IncrementSessionID counter value.
+	var capturedSessionID atomic.Uint32
 	mockUSB := &testutil.MockHARQ{
 		SendFunc: func(ctx context.Context, data []byte, p ...harq.Priority) error {
 			return nil
 		},
+		SendWithTypeFunc: func(ctx context.Context, data []byte, frameType frame.Type) error {
+			// Capture session ID from outgoing RESET frame so ReceiveFunc can echo it.
+			if frameType == frame.FrameTypeReset && len(data) >= SessionIDPayloadSize {
+				capturedSessionID.Store(binary.LittleEndian.Uint32(data[:SessionIDPayloadSize]))
+			}
+			return nil
+		},
 		ReceiveFunc: func(ctx context.Context) (*harq.ReceiveResult, error) {
 			if receiveCount.Add(1) == 1 {
-				// First call: return RESET_ACK with session ID 1.
-				// IncrementSessionID() returns 1 on the first call (starts at 0).
+				// First call: return RESET_ACK with the actual session ID captured
+				// from the RESET frame, not a hardcoded value.
+				sid := capturedSessionID.Load()
 				payload := make([]byte, SessionIDPayloadSize)
-				binary.LittleEndian.PutUint32(payload, 1)
+				binary.LittleEndian.PutUint32(payload, sid)
 				return &harq.ReceiveResult{
 					Payload:  payload,
 					Metadata: harq.FrameMetadata{Type: frame.FrameTypeResetAck},
 				}, nil
+			}
+			// Subsequent calls: yield to prevent busy-spinning in any goroutine
+			// that loops on Receive (e.g. drainUntilResetAck if a retry occurs).
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(1 * time.Millisecond):
 			}
 			return &harq.ReceiveResult{
 				Payload:  []byte("telemetry"),

--- a/star-gateway/internal/manager/scenarios_test.go
+++ b/star-gateway/internal/manager/scenarios_test.go
@@ -13,7 +13,9 @@ package manager
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -45,17 +47,29 @@ func TestScenario1_NormalOperationUSB(t *testing.T) {
 	config.Mode = ModeAuto
 	tm := NewTransportManager(config)
 
-	// Create mock transports
+	// Create mock transports.
+	// receiveCount tracks calls: the first call comes from drainUntilResetAck
+	// (inside Start) and must return RESET_ACK so the handshake completes
+	// immediately. Subsequent calls return normal telemetry frames.
+	var receiveCount atomic.Int32
 	mockUSB := &testutil.MockHARQ{
 		SendFunc: func(ctx context.Context, data []byte, p ...harq.Priority) error {
 			return nil
 		},
 		ReceiveFunc: func(ctx context.Context) (*harq.ReceiveResult, error) {
+			if receiveCount.Add(1) == 1 {
+				// First call: return RESET_ACK with session ID 1.
+				// IncrementSessionID() returns 1 on the first call (starts at 0).
+				payload := make([]byte, SessionIDPayloadSize)
+				binary.LittleEndian.PutUint32(payload, 1)
+				return &harq.ReceiveResult{
+					Payload:  payload,
+					Metadata: harq.FrameMetadata{Type: frame.FrameTypeResetAck},
+				}, nil
+			}
 			return &harq.ReceiveResult{
-				Payload: []byte("telemetry"),
-				Metadata: harq.FrameMetadata{
-					Type: frame.FrameTypeResponse,
-				},
+				Payload:  []byte("telemetry"),
+				Metadata: harq.FrameMetadata{Type: frame.FrameTypeResponse},
 			}, nil
 		},
 	}


### PR DESCRIPTION
## Summary

- **Bug 1 (manager.go)**: ACK/NACK frames now call `OnFrameReceived()` in `dispatchControlFrame()`, fixing a false-positive failover during HARQ retransmission bursts where only ACK/NACK frames flow for >200ms. The spec (`TRANSPORT_ARCHITECTURE.md` §Heartbeat) requires lastSeen to update on **any** valid frame.

- **Bug 2 (heartbeat.go)**: `check()` now uses two independent elapsed timers — `pingElapsed = time.Since(lastValidPong)` for the PING condition and `implicitElapsed = time.Since(lastSeen)` for the implicit timeout. The PING block is evaluated first. Previously, both conditions shared `elapsed = time.Since(lastSeen)`: since `pingInterval (1s) > failureTimeout (200ms)`, the implicit timeout always set `alreadyTriggered=true` before `elapsed` could reach `pingInterval`, making the counter-based PONG-miss detection permanently unreachable.

- **Tests (heartbeat_test.go)**: Two regression tests cover the fixed behaviour: `TestHeartbeatManager_PingTimerIndependentOfLastSeen` (unit — proves `pingElapsed` is independent of `lastSeen` via a direct `check()` call) and `TestHeartbeatManager_ZombieLinkCounterDetection` (integration — continuous `OnFrameReceived()` keeps the implicit timeout from firing while the PING counter path triggers failover).

## Test plan

- [x] All existing `HeartbeatManager` tests pass without modification (13/13)
- [x] `TestHeartbeatManager_PingTimerIndependentOfLastSeen` passes — PING fires on stale `lastValidPong` even with fresh `lastSeen`
- [x] `TestHeartbeatManager_ZombieLinkCounterDetection` passes — zombie-link counter-based failover fires despite continuous `OnFrameReceived()` refreshes
- [x] Full manager package test suite passes (`go test ./internal/manager/ -count=1`)
- [x] No magic numbers introduced; no backward-compatibility shims added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection health monitoring with independent PING and implicit timers to better detect degraded/zombie links
  * Reordered detection so explicit PING handling runs before implicit timeouts, reducing false-positive disconnects and avoiding repeated failovers
  * ACK/NACK frames now refresh the heartbeat to prevent spurious implicit timeouts during bursty traffic

* **Tests**
  * Added tests for PING-timer independence and end-to-end zombie-link detection
  * Updated handshake test to exercise immediate reset-ack behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->