### PR TITLE
docs: update ROS2 README and add Pi deployment guide

### DIFF
--- a/docs/PI_DEPLOYMENT.md
+++ b/docs/PI_DEPLOYMENT.md
@@ -64,8 +64,16 @@ Use a scoped deploy key -- one key per Pi, scoped to this repo only.
 ### Generate the Key
 
 ```bash
-ssh-keygen -t ed25519 -C "star-pi5@star-desktop" -f ~/.ssh/id_ed25519_star -N ""
+ssh-keygen -t ed25519 -C "star-pi5@star-desktop" -f ~/.ssh/id_ed25519_star
 cat ~/.ssh/id_ed25519_star.pub   # copy this output
+```
+
+Use a strong passphrase when prompted. On the Pi, use `ssh-agent` so you only unlock once
+per session:
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519_star
 ```
 
 ### Add to GitHub
@@ -73,11 +81,14 @@ cat ~/.ssh/id_ed25519_star.pub   # copy this output
 1. Go to the repo: **Settings -> Deploy Keys -> Add deploy key**
 2. Title: `Star Pi 5 - star-desktop`
 3. Paste the public key
-4. Check **Allow write access** (needed to push branches from the Pi)
+4. **Write access:** only enable if the Pi needs to push commits or branches. If the Pi
+   is used only to pull and build, leave this unchecked (read-only is safer on embedded
+   hardware). This Pi is used for development (creating PRs from the Pi), so write
+   access is enabled here.
 
 ### Configure SSH
 
-```
+```ssh-config
 # ~/.ssh/config
 Host github.com
     HostName github.com
@@ -135,19 +146,19 @@ To get native aarch64 test results from this Pi:
 2. Select: **Linux / ARM64**
 3. On the Pi, follow the commands GitHub shows (they include a one-time token):
 
-```bash
-mkdir ~/actions-runner && cd ~/actions-runner
-curl -o actions-runner-linux-arm64.tar.gz -L <URL-from-GitHub>
-tar xzf ./actions-runner-linux-arm64.tar.gz
-./config.sh --url https://github.com/Locked-Inc/STAR --token <ONE-TIME-TOKEN>
-```
+    ```bash
+    mkdir ~/actions-runner && cd ~/actions-runner
+    curl -o actions-runner-linux-arm64.tar.gz -L <URL-from-GitHub>
+    tar xzf ./actions-runner-linux-arm64.tar.gz
+    ./config.sh --url https://github.com/Locked-Inc/STAR --token <ONE-TIME-TOKEN>
+    ```
 
 4. Install as a systemd service so it survives reboots:
 
-```bash
-sudo ./svc.sh install
-sudo ./svc.sh start
-```
+    ```bash
+    sudo ./svc.sh install
+    sudo ./svc.sh start
+    ```
 
 The runner will appear in **Settings -> Actions -> Runners** as `star-desktop`.
 
@@ -165,9 +176,14 @@ build-and-test-pi:
   steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: ./build-ros2.sh
-    - name: Test
+      shell: bash
       run: |
+        source /opt/ros/jazzy/setup.bash
+        ./build-ros2.sh
+    - name: Test
+      shell: bash
+      run: |
+        source /opt/ros/jazzy/setup.bash
         cd star-ros2
         source install/local_setup.bash
         colcon test
@@ -175,6 +191,8 @@ build-and-test-pi:
 ```
 
 Note: no `container:` directive -- this runs directly on the Pi's native environment.
+The explicit `source /opt/ros/jazzy/setup.bash` is required because GitHub Actions uses
+a non-interactive shell and does not source `.bashrc`.
 
 ---
 

--- a/docs/PI_DEPLOYMENT.md
+++ b/docs/PI_DEPLOYMENT.md
@@ -1,0 +1,189 @@
+# Pi Deployment Guide
+
+Setup and GitHub integration reference for the STAR Raspberry Pi 5 (native aarch64).
+
+---
+
+## Pi Native Environment
+
+### What's Installed
+
+| Package | Version / Notes |
+|---------|----------------|
+| ROS2 Jazzy Desktop | via apt (packages.ros.org) |
+| `ros-jazzy-nav2-lifecycle-manager` | required by `safety_monitor.launch.py` |
+| `ros-jazzy-rmw-cyclonedds-cpp` | RMW middleware |
+| Go | 1.25.7 at `/usr/local/go` |
+| golangci-lint | v2.10.1 at `/usr/local/bin/golangci-lint` |
+| buf CLI | v1.50.0 at `/usr/local/bin/buf` |
+| libprotobuf-dev, libgrpc++-dev, protobuf-compiler-grpc | system packages |
+
+### Required `.bashrc` Additions
+
+```bash
+source /opt/ros/jazzy/setup.bash
+if [ -f /workspaces/STAR/star-ros2/install/local_setup.bash ]; then
+    source /workspaces/STAR/star-ros2/install/local_setup.bash
+fi
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+export PATH="$PATH:/usr/local/go/bin"
+export GOPATH="$HOME/go"
+export PATH="$PATH:$GOPATH/bin"
+```
+
+### SPI Setup (for `star_spi_bridge` with hardware)
+
+```bash
+sudo groupadd -f spi
+sudo usermod -aG spi $USER
+echo 'SUBSYSTEM=="spidev", GROUP="spi", MODE="0660"' | sudo tee /etc/udev/rules.d/99-spi.rules
+sudo udevadm control --reload-rules && sudo udevadm trigger
+# Reboot or re-login for group membership to take effect
+```
+
+> **Note:** Use `99-spi.rules` (not `50-spi.rules`) -- the higher priority is needed for
+> the rule to apply correctly on Raspberry Pi OS / Ubuntu.
+
+### Build
+
+```bash
+cd /workspaces/STAR
+git pull
+./build-ros2.sh   # handles proto gen + colcon build
+```
+
+After any apt package additions, update the "What's Installed" table above so the setup
+is reproducible if the Pi is reimaged.
+
+---
+
+## Pi to GitHub: SSH Access
+
+Use a scoped deploy key -- one key per Pi, scoped to this repo only.
+
+### Generate the Key
+
+```bash
+ssh-keygen -t ed25519 -C "star-pi5@star-desktop" -f ~/.ssh/id_ed25519_star -N ""
+cat ~/.ssh/id_ed25519_star.pub   # copy this output
+```
+
+### Add to GitHub
+
+1. Go to the repo: **Settings -> Deploy Keys -> Add deploy key**
+2. Title: `Star Pi 5 - star-desktop`
+3. Paste the public key
+4. Check **Allow write access** (needed to push branches from the Pi)
+
+### Configure SSH
+
+```
+# ~/.ssh/config
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_ed25519_star
+    IdentitiesOnly yes
+```
+
+Test: `ssh -T git@github.com` -- should print "Hi Locked-Inc/STAR! You've authenticated..."
+
+### Why Deploy Keys Over Personal Account Keys
+
+- Scoped to one repo only -- no access to other repos
+- Revokable per device without affecting other developers
+- No personal credentials on shared or embedded hardware
+
+---
+
+## What Belongs in the Repo vs Stays Local
+
+| Belongs in repo (commit) | Stays local on Pi (never commit) |
+|--------------------------|----------------------------------|
+| `src/` package source code | `build/`, `install/`, `log/` |
+| `config/*.yaml` params | `compile_commands.json` (machine-specific) |
+| `launch/*.py` files | `.bashrc` / shell environment additions |
+| `.gitignore`, CI configs | SSH private keys (`~/.ssh/id_ed25519_star`) |
+| Scripts in `scripts/` | Baseline run result files (use CI artifacts) |
+| `star-ros2/.gitignore` | WiFi passwords, network topology, IP addresses |
+| Proto schemas and gen output | Device paths if they vary per machine |
+
+---
+
+## Secrets and Environment Variables
+
+Set these in `.bashrc` only -- document the variable name here, never its value in the repo:
+
+| Variable | Purpose |
+|----------|---------|
+| `ROS_DOMAIN_ID` | Isolates DDS traffic. `0` = default (single machine). Use a non-zero value (e.g. `42`) to isolate from other ROS2 systems on the same LAN. |
+| `RMW_IMPLEMENTATION` | Already in `.bashrc`; also set in launch files for portability. |
+| Hardware serials, API keys, network credentials | Store in `.bashrc` or a local `.env` (gitignored). |
+
+The repo's `.gitignore` already excludes `.env` and `.local` files at the root level.
+
+---
+
+## Self-Hosted GitHub Actions Runner (Native ARM64 CI)
+
+The existing `ros2.yml` runs in `osrf/ros:jazzy-desktop` on x86 GitHub-hosted runners.
+To get native aarch64 test results from this Pi:
+
+### Register the Runner
+
+1. Go to: **Settings -> Actions -> Runners -> New self-hosted runner**
+2. Select: **Linux / ARM64**
+3. On the Pi, follow the commands GitHub shows (they include a one-time token):
+
+```bash
+mkdir ~/actions-runner && cd ~/actions-runner
+curl -o actions-runner-linux-arm64.tar.gz -L <URL-from-GitHub>
+tar xzf ./actions-runner-linux-arm64.tar.gz
+./config.sh --url https://github.com/Locked-Inc/STAR --token <ONE-TIME-TOKEN>
+```
+
+4. Install as a systemd service so it survives reboots:
+
+```bash
+sudo ./svc.sh install
+sudo ./svc.sh start
+```
+
+The runner will appear in **Settings -> Actions -> Runners** as `star-desktop`.
+
+> The registration token is one-time and short-lived. The Pi persists as a registered
+> runner after setup -- only the initial `config.sh` step needs the token.
+
+### Add a Pi Job to `ros2.yml`
+
+To use the runner, add a second job to `.github/workflows/ros2.yml`:
+
+```yaml
+build-and-test-pi:
+  name: Build ROS2 Packages (Pi5 native)
+  runs-on: [self-hosted, linux, ARM64]
+  steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: ./build-ros2.sh
+    - name: Test
+      run: |
+        cd star-ros2
+        source install/local_setup.bash
+        colcon test
+        colcon test-result --verbose
+```
+
+Note: no `container:` directive -- this runs directly on the Pi's native environment.
+
+---
+
+## Keeping the Pi in Sync
+
+Daily workflow:
+
+```bash
+cd /workspaces/STAR
+git pull
+./build-ros2.sh   # rebuild if star-ros2/ or star-proto/ changed
+```

--- a/star-ros2/.gitignore
+++ b/star-ros2/.gitignore
@@ -30,4 +30,5 @@ COLCON_IGNORE
 AMENT_IGNORE
 
 # Baseline run results - store as CI artifacts, not source
-baselines/
+baselines/*
+!baselines/.gitkeep

--- a/star-ros2/.gitignore
+++ b/star-ros2/.gitignore
@@ -21,3 +21,13 @@ __pycache__/
 # Phase 2 tracker (untracked)
 PHASE2_TRACKER.md
 star-gateway/PHASE2_TRACKER.md
+
+# Generated per-machine during colcon build
+compile_commands.json
+
+# colcon workspace markers
+COLCON_IGNORE
+AMENT_IGNORE
+
+# Baseline run results - store as CI artifacts, not source
+baselines/

--- a/star-ros2/README.md
+++ b/star-ros2/README.md
@@ -40,15 +40,15 @@ map (RTAB-Map - global, corrected)
 
 ### Prerequisites
 
-- **Docker** (for containerized ROS2 environment)
-- **VS Code** with **Dev Containers** extension
-- **Hardware** (for deployment): Raspberry Pi 5, SPI/USB/video device passthrough
+- **Docker** (for containerized ROS2 environment) -- or --
+- **Raspberry Pi 5** with ROS2 Jazzy natively installed (see [docs/PI_DEPLOYMENT.md](../docs/PI_DEPLOYMENT.md))
+- **VS Code** with **Dev Containers** extension (devcontainer path only)
 
-### Setup
+### Setup -- Devcontainer (x86/macOS development)
 
 1. **Open the repository in VS Code**
    ```bash
-   code /Users/cesarmagana/Documents/GitHub/STAR
+   code /path/to/STAR
    ```
 
 2. **Reopen in Container**
@@ -63,6 +63,28 @@ map (RTAB-Map - global, corrected)
    ```bash
    ros2 doctor  # Should show ROS2 Jazzy setup
    ```
+
+### Setup -- Pi Native (Raspberry Pi 5 aarch64)
+
+```bash
+# Source ROS2 and workspace
+source /opt/ros/jazzy/setup.bash
+source /workspaces/STAR/star-ros2/install/local_setup.bash  # after first build
+
+# Set RMW
+export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+
+# Build everything (proto gen + colcon)
+cd /workspaces/STAR
+./build-ros2.sh
+```
+
+**Required apt package** (for `safety_monitor.launch.py`):
+```bash
+sudo apt install ros-jazzy-nav2-lifecycle-manager
+```
+
+See [docs/PI_DEPLOYMENT.md](../docs/PI_DEPLOYMENT.md) for full Pi setup including SPI, SSH keys, and GitHub integration.
 
 **Hardware Passthrough (for deployment on RPi5):**
 - `/dev/spidev*` - RX72N motor controller
@@ -97,47 +119,40 @@ colcon build --packages-select star_spi_bridge
 
 ## Verifying the Build
 
-This PR contains only infrastructure. To verify the build system works:
-
 ```bash
-# Open devcontainer
-code .
-
-# Build all packages (should succeed with star_bringup skeleton)
-colcon build
-
-# Verify build output
-ls -la build/ install/
-
-# Expected output:
-# build/star_bringup/ (CMake build artifacts)
-# install/star_bringup/ (install space with setup scripts)
+# Build all packages
+./build-ros2.sh   # from repo root -- handles proto gen + colcon
 
 # Source the workspace
-source install/setup.bash
+source star-ros2/install/local_setup.bash
 
 # List available packages
 ros2 pkg list | grep star
-# Expected output: star_bringup
-```
+# Expected output:
+# star_bringup
+# star_gateway_bridge
+# star_safety_monitor
+# star_spi_bridge
 
-**Application Nodes:**
-- `star_spi_bridge` - See [PR #145](https://github.com/Locked-Inc/STAR/pull/145)
-- `star_gateway_bridge` - See [PR #146](https://github.com/Locked-Inc/STAR/pull/146)
+# Run all tests
+cd star-ros2
+colcon test
+colcon test-result --verbose
+```
 
 ---
 
 ## Testing
 
 ```bash
-# Test all packages (star_bringup has no tests yet - skeleton only)
+# Test all packages
 colcon test
 
 # View test results
 colcon test-result --verbose
 ```
 
-**Current Status:** This PR contains only infrastructure. Unit tests will be added in application node PRs ([#145](https://github.com/Locked-Inc/STAR/pull/145), [#146](https://github.com/Locked-Inc/STAR/pull/146)).
+**Current Status:** 134 tests, 0 failures across all 4 packages (9 gtest + linting).
 
 ---
 
@@ -235,15 +250,12 @@ For complete baseline methodology, analysis procedures, and troubleshooting:
 
 ## Package Status
 
-**This PR (#141) - Infrastructure Only**
-
-| Package | Status | Lines | Description | Pull Request |
-|---------|--------|-------|-------------|--------------|
-| `star_bringup` | [GREEN] Skeleton | 25 | Launch files and system bringup | This PR (#141) |
-| `star_spi_bridge` | [RED] Not Included | - | SPI communication to RX72N | [PR #145](https://github.com/Locked-Inc/STAR/pull/145) |
-| `star_gateway_bridge` | [RED] Not Included | - | gRPC bridge to Go gateway | [PR #146](https://github.com/Locked-Inc/STAR/pull/146) |
-
-**Note:** This PR establishes the foundation (Docker, devcontainer, CI/CD, docs). Application nodes are in separate PRs.
+| Package | Status | Description |
+|---------|--------|-------------|
+| `star_bringup` | [GREEN] Built | Launch files and system bringup |
+| `star_spi_bridge` | [GREEN] Built | SPI communication to RX72N |
+| `star_gateway_bridge` | [GREEN] Built | gRPC bridge to Go gateway |
+| `star_safety_monitor` | [GREEN] Built | Safety watchdog and diagnostics |
 
 **SLAM Configuration:** Not yet implemented. See [Issue #140](https://github.com/Locked-Inc/STAR/issues/140)
 
@@ -251,7 +263,7 @@ For complete baseline methodology, analysis procedures, and troubleshooting:
 
 ## Architecture
 
-**Note:** The diagrams below show the planned system architecture. This PR (#141) contains only infrastructure. Application nodes (`star_spi_bridge`, `star_gateway_bridge`) are in separate PRs ([#145](https://github.com/Locked-Inc/STAR/pull/145), [#146](https://github.com/Locked-Inc/STAR/pull/146)).
+**Note:** The diagrams below show the planned system architecture. SLAM packages (`rtabmap_ros`, `robot_localization`) are not yet configured.
 
 ### Node Graph
 
@@ -447,4 +459,4 @@ See root repository LICENSE file.
 
 ---
 
-**Status:** Infrastructure phase complete. Implementation tracked in Issues #137-#140.
+**Status:** All 4 packages built and tested on Raspberry Pi 5 (native aarch64). See [docs/PI_DEPLOYMENT.md](../docs/PI_DEPLOYMENT.md) for Pi setup.

--- a/star-ros2/README.md
+++ b/star-ros2/README.md
@@ -80,6 +80,7 @@ cd /workspaces/STAR
 ```
 
 **Required apt package** (for `safety_monitor.launch.py`):
+
 ```bash
 sudo apt install ros-jazzy-nav2-lifecycle-manager
 ```


### PR DESCRIPTION
## Summary

- **`star-ros2/README.md`**: All 4 packages now shown as GREEN/Built; removed stale PR status rows (#141/#145/#146); fixed hardcoded local path (`/Users/cesarmagana/...` -> `/path/to/STAR`); added Pi-native build section alongside devcontainer; updated test count to 134 tests/0 failures; rewrote Verifying the Build section for Pi-native workflow; removed stale footer
- **`docs/PI_DEPLOYMENT.md`** (new): Pi environment inventory, `.bashrc` setup, SPI udev config, GitHub deploy key setup, what belongs in repo vs stays local, secrets/env vars guidance, self-hosted ARM64 runner instructions, and daily sync workflow
- **`star-ros2/.gitignore`**: Added `compile_commands.json`, `COLCON_IGNORE`, `AMENT_IGNORE`, and `baselines/` (run results should be CI artifacts, not source)
- **`star-ros2/baselines/.gitkeep`**: Preserve `baselines/` directory on clone after gitignoring run results

## Test plan

- [ ] Verify README renders correctly on GitHub (package table, code blocks, links)
- [ ] Confirm `docs/PI_DEPLOYMENT.md` link in README resolves correctly
- [ ] Confirm `baselines/` run result files are not staged after this change (`git status` should not show them)
- [ ] Confirm `star-ros2/baselines/` directory exists after a fresh clone (via `.gitkeep`)

:robot: Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Raspberry Pi 5 native deployment guide covering environment setup, hardware/SPI notes, build steps, SSH/deploy key usage, secrets/env guidance, and self-hosted ARM64 runner integration with sample CI workflow.
  * Updated README with dual-path setup (Devcontainer or native Pi 5), Pi-specific setup/build instructions, testing/verifying steps, and revised architecture/status notes.

* **Chores**
  * Extended gitignore to exclude per-machine build artifacts and workspace marker files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->