### PR TITLE
feat(firmware): wire SPI HARQ link initialization into comm task

### DIFF
--- a/e2-studio-star-rx72n-firmware/.clangd
+++ b/e2-studio-star-rx72n-firmware/.clangd
@@ -3,6 +3,17 @@ CompileFlags:
   Add:
     - -I/opt/gnurx/rx-elf/rx-elf/include
     - -I../src
+  # Strip RX72N-specific gnurx flags that clangd's clang frontend does not
+  # recognize. These are valid for rx-elf-gcc but cause spurious "unknown
+  # argument" errors in the editor. The actual build uses rx-elf-gcc directly.
+  Remove:
+    - -mcpu=*
+    - -misa=*
+    - -mlittle-endian-data
+    - -m64bit-doubles
+    - -mtfu=*
+    - -mtfu-version=*
+    - -mdfpu
 
 Index:
   Background: Build
@@ -10,7 +21,11 @@ Index:
 
 Diagnostics:
   UnusedIncludes: Strict
-  MissingIncludes: Strict
+  # Use Loose instead of Strict: Strict requires the header that *directly*
+  # defines each symbol, which produces false positives for ThreadX types
+  # (ULONG/UINT defined in tx_port.h, accessed via tx_api.h) and nanopb
+  # generated types that come through top-level pb.h aggregates.
+  MissingIncludes: Loose
 
 InlayHints:
   Enabled: Yes

--- a/e2-studio-star-rx72n-firmware/CMakeLists.txt
+++ b/e2-studio-star-rx72n-firmware/CMakeLists.txt
@@ -43,21 +43,10 @@ set(CMAKE_ASM_FLAGS_RELEASE "-g0")
 file(GLOB APP_SOURCES_ROOT CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/src/*.c
 )
-
-# When running unit tests we often cross-compile with host toolchain and cannot
-# build assembly boot code. The TESTS_ONLY option allows skipping those sources
-# so the test project can compile cleanly on the host.
-option(TESTS_ONLY "Skip building application boot sources (tests-only build)" OFF)
-
 file(GLOB_RECURSE APP_BOOT_SOURCES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/src/boot/*.c
     ${CMAKE_SOURCE_DIR}/src/boot/*.S
 )
-if(TESTS_ONLY)
-    # drop boot/asm files during test-only builds
-    set(APP_BOOT_SOURCES "")
-endif()
-
 file(GLOB_RECURSE APP_TASKS_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/tasks/*.c)
 file(GLOB_RECURSE APP_SHARED_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/shared/*.c)
 file(GLOB_RECURSE APP_RTOS_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/rtos_config/*.c)

--- a/e2-studio-star-rx72n-firmware/CMakeLists.txt
+++ b/e2-studio-star-rx72n-firmware/CMakeLists.txt
@@ -43,10 +43,21 @@ set(CMAKE_ASM_FLAGS_RELEASE "-g0")
 file(GLOB APP_SOURCES_ROOT CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/src/*.c
 )
+
+# When running unit tests we often cross-compile with host toolchain and cannot
+# build assembly boot code. The TESTS_ONLY option allows skipping those sources
+# so the test project can compile cleanly on the host.
+option(TESTS_ONLY "Skip building application boot sources (tests-only build)" OFF)
+
 file(GLOB_RECURSE APP_BOOT_SOURCES CONFIGURE_DEPENDS
     ${CMAKE_SOURCE_DIR}/src/boot/*.c
     ${CMAKE_SOURCE_DIR}/src/boot/*.S
 )
+if(TESTS_ONLY)
+    # drop boot/asm files during test-only builds
+    set(APP_BOOT_SOURCES "")
+endif()
+
 file(GLOB_RECURSE APP_TASKS_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/tasks/*.c)
 file(GLOB_RECURSE APP_SHARED_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/shared/*.c)
 file(GLOB_RECURSE APP_RTOS_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/src/rtos_config/*.c)

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -904,13 +904,16 @@ rx_err_t comm_task_create(void)
  * 2. **Handle USB failure**: Log error if init fails, set handle to nullptr
  * 3. **Initialize SPI transport**: Call rx_spi_comm_init() with shared session state
  * 4. **Handle SPI failure**: Log error if init fails, set handle to nullptr
- * 5. **Wire handles**: Assign valid or nullptr handles to config structure
- * 6. **Validate transports**: Log critical error if both transports failed
- * 7. **Log success**: Log info for each successfully initialized transport
+ * 5. **Initialize HARQ link**: If spi_ok, call rx_spi_link_init(&s_spi_link, &link_cfg);
+ *    config->spi_link = &s_spi_link on k_rx_ok, nullptr otherwise (or when spi_ok is false)
+ * 6. **Wire handles**: Assign valid or nullptr handles to config structure
+ * 7. **Validate transports**: Log critical error if both transports failed
+ * 8. **Log success**: Log info for each successfully initialized transport
  *
  * **Graceful Degradation:**
  * - If one transport fails: Other transport continues (logged warning)
  * - If both transports fail: Config wired with nullptr handles (logged critical error)
+ * - If SPI transport fails: config->spi_link is set to nullptr (HARQ skipped)
  * - Comm manager will return k_rx_err_timeout on poll for nullptr handles
  *
  * @param[out] config Comm manager configuration to populate
@@ -932,8 +935,8 @@ rx_err_t comm_task_create(void)
  * @note This function does NOT initialize RSPI hardware - caller must ensure
  *       RSPI2 peripheral is initialized before calling
  * @note Called once during single-threaded task initialization; not thread-safe
- * @warning Function has no return value - check config->usb_handle and
- *          config->spi_handle for nullptr to detect complete failure
+ * @warning Function has no return value - check config->usb_handle,
+ *          config->spi_handle, and config->spi_link for nullptr to detect degraded modes
  *
  * @par Thread Safety:
  * This function is **not thread-safe**. It must be called only once during
@@ -944,6 +947,7 @@ rx_err_t comm_task_create(void)
  * @since Version 1.0.0
  * @see rx_usb_comm_init() USB transport layer initialization
  * @see rx_spi_comm_init() SPI transport layer initialization
+ * @see rx_spi_link_init() HARQ link layer initialization (called internally when spi_ok)
  */
 static void internal_init_transports(rx_comm_manager_config_t* config)
 {

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -388,8 +388,6 @@
 
 #include "comm_task.h"
 
-#include <string.h>
-
 #include "rx_check.h"
 #include "rx_comm_manager.h"
 #include "rx_frame.h"
@@ -547,6 +545,26 @@ static rx_usb_comm_handle_t s_usb_comm_handle;
  * @see rx_spi_comm_init() Initialization function
  */
 static rx_spi_comm_handle_t s_spi_comm_handle;
+
+/**
+ * @var s_spi_link
+ * @brief HARQ link-layer instance for SPI transport reliability
+ *
+ * @details
+ * Stores runtime state and configuration for the SPI HARQ link layer
+ * (forward-error correction plus retransmission control). Initialized during
+ * transport setup via rx_spi_link_init() using a configuration structure that
+ * references s_spi_comm_handle and default retry/FEC settings. Used by the
+ * communication manager through config->spi_link when link initialization
+ * succeeds.
+ *
+ * @note File-scoped static owned by comm_task.c. Access is confined to comm_task
+ *       initialization and callback flow in this module.
+ * @warning Not safe for unsynchronized external mutation. Do not access or modify
+ *          internals directly; use rx_spi_link API functions and initialization path.
+ * @since Version 1.1.0
+ */
+static rx_spi_link_t s_spi_link;
 
 /* =============================================================================
  * Forward Declarations
@@ -949,6 +967,16 @@ static void internal_init_transports(rx_comm_manager_config_t* config)
     rx_log_error(s_tag, "SPI comm init failed");
   }
 
+  rx_spi_link_config_t link_cfg = {
+    .spi_handle  = &s_spi_comm_handle,
+    .fec_enabled = k_spi_link_default_fec_enabled,  // true
+    .max_retries = k_spi_link_default_max_retries,  // 3
+  };
+
+  bool link_ok = (rx_spi_link_init(&s_spi_link, &link_cfg) == k_rx_ok);
+  if (!link_ok) { rx_log_error(s_tag, "SPI link (HARQ) init failed"); }
+  config->spi_link = link_ok ? &s_spi_link : nullptr;
+
   /* Wire handles - pass nullptr for failed transports (triggers timeout in comm_manager) */
   config->usb_handle = usb_ok ? &s_usb_comm_handle : nullptr;
   config->spi_handle = spi_ok ? &s_spi_comm_handle : nullptr;
@@ -962,6 +990,9 @@ static void internal_init_transports(rx_comm_manager_config_t* config)
     }
     if (spi_ok) {
       rx_log_info(s_tag, "SPI transport initialized");
+    }
+    if (link_ok) {
+      rx_log_info(s_tag, "SPI HARQ link initialized (FEC + Chase Combining)");
     }
   }
 }

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -916,7 +916,7 @@ rx_err_t comm_task_create(void)
  * @param[out] config Comm manager configuration to populate
  *   - **Valid range**: Non-nullptr to rx_comm_manager_config_t
  *   - **Constraints**: Must be zeroed before calling this function
- *   - **Side effects**: usb_handle and spi_handle fields populated
+ *   - **Side effects**: usb_handle, spi_handle, and spi_link fields populated
  *
  * @return void This function does not return a value
  *
@@ -925,6 +925,7 @@ rx_err_t comm_task_create(void)
  * @pre RSPI2 peripheral must be initialized before calling this function
  * @post config->usb_handle set to &s_usb_comm_handle or nullptr
  * @post config->spi_handle set to &s_spi_comm_handle or nullptr
+ * @post config->spi_link set to &s_spi_link when SPI transport and HARQ init both succeed, else nullptr
  * @post At least one transport handle set on success (best effort)
  * @post All init failures logged via rx_log_error
  *
@@ -975,8 +976,8 @@ static void internal_init_transports(rx_comm_manager_config_t* config)
      * undefined behaviour, so skip the whole block if spi_ok is false. */
     rx_spi_link_config_t link_cfg = {
       .spi_handle  = &s_spi_comm_handle,
-      .fec_enabled = k_spi_link_default_fec_enabled,  // true
-      .max_retries = k_spi_link_default_max_retries,  // 3
+      .fec_enabled = k_spi_link_default_fec_enabled,
+      .max_retries = k_spi_link_default_max_retries,
     };
 
     link_ok = (rx_spi_link_init(&s_spi_link, &link_cfg) == k_rx_ok);
@@ -1004,7 +1005,7 @@ static void internal_init_transports(rx_comm_manager_config_t* config)
       rx_log_info(s_tag, "SPI transport initialized");
     }
     if (link_ok) {
-      rx_log_info(s_tag, "SPI HARQ link initialized (FEC + Chase Combining)");
+      rx_log_info(s_tag, "SPI HARQ link initialized (FEC with Chase Combining)");
     }
   }
 }

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -967,15 +967,27 @@ static void internal_init_transports(rx_comm_manager_config_t* config)
     rx_log_error(s_tag, "SPI comm init failed");
   }
 
-  rx_spi_link_config_t link_cfg = {
-    .spi_handle  = &s_spi_comm_handle,
-    .fec_enabled = k_spi_link_default_fec_enabled,  // true
-    .max_retries = k_spi_link_default_max_retries,  // 3
-  };
+  bool link_ok = false;
 
-  bool link_ok = (rx_spi_link_init(&s_spi_link, &link_cfg) == k_rx_ok);
-  if (!link_ok) { rx_log_error(s_tag, "SPI link (HARQ) init failed"); }
-  config->spi_link = link_ok ? &s_spi_link : nullptr;
+  if (spi_ok) {
+    /* Only attempt to configure the HARQ link when the underlying SPI transport
+     * succeeded.  Passing an invalid handle into rx_spi_link_init would trigger
+     * undefined behaviour, so skip the whole block if spi_ok is false. */
+    rx_spi_link_config_t link_cfg = {
+      .spi_handle  = &s_spi_comm_handle,
+      .fec_enabled = k_spi_link_default_fec_enabled,  // true
+      .max_retries = k_spi_link_default_max_retries,  // 3
+    };
+
+    link_ok = (rx_spi_link_init(&s_spi_link, &link_cfg) == k_rx_ok);
+    if (!link_ok) {
+      rx_log_error(s_tag, "SPI link (HARQ) init failed");
+    }
+    config->spi_link = link_ok ? &s_spi_link : nullptr;
+  } else {
+    rx_log_warn(s_tag, "Skipping SPI HARQ link init because SPI transport failed");
+    config->spi_link = nullptr;
+  }
 
   /* Wire handles - pass nullptr for failed transports (triggers timeout in comm_manager) */
   config->usb_handle = usb_ok ? &s_usb_comm_handle : nullptr;


### PR DESCRIPTION
Closes #378

## Summary
- Initializes `rx_spi_link_t` with FEC and retransmit config during transport setup, activating HARQ for the SPI link layer (previously wired but never initialized)
- Wires the initialized link into `rx_comm_manager_config_t.spi_link` so retransmit processing is no longer a no-op
- Adds `TESTS_ONLY` CMake option to skip boot/assembly sources when building unit tests with a host toolchain
- Fixes clangd config: strips RX72N-specific compiler flags that cause spurious editor errors, and relaxes `MissingIncludes` to `Loose` to eliminate false positives from ThreadX and nanopb headers

## Test plan
- [ ] Firmware builds cleanly with `rx-elf-gcc` (no new warnings)
- [ ] `TESTS_ONLY=ON` build compiles on host toolchain without boot/ASM sources
- [ ] SPI HARQ link init log message appears on target: `"SPI HARQ link initialized (FEC + Chase Combining)"`
- [ ] Retransmit path exercised: send a frame, verify ACK/retransmit flow is active
- [ ] clangd in VSCode shows no spurious unknown-argument or missing-include diagnostics for ThreadX/nanopb headers
- [ ] Code review checklist:
  - [ ] NASA Power of 10 rules followed
  - [ ] SOLID principles applied
  - [ ] Doxygen documentation complete on `s_spi_link`
  - [ ] No magic numbers (uses `k_spi_link_default_*` enums)
  - [ ] Inclusive terminology used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Communication subsystem: improved SPI HARQ link initialization, transport wiring, logging, and error handling.

* **Chores**
  * Editor/diagnostics: relaxed missing-include checks, expanded inlay hints, and suppressed noisy nanopb diagnostics.
  * Build: added a TESTS_ONLY option to support test-focused builds and skip boot sources during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->