### PR TITLE
fix(firmware): replace wildcard proto glob with explicit source list

### DIFF
--- a/e2-studio-star-rx72n-firmware/CMakeLists.txt
+++ b/e2-studio-star-rx72n-firmware/CMakeLists.txt
@@ -169,7 +169,7 @@ file(GLOB_RECURSE LIB_RX_NANOPB_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/li
 set(PROTOBUF_SOURCES
     ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/common.pb.c
     ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.c
-    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.c  # KEEP: provides star_v1_SetPIDGainsRequest_fields (and related nanopb symbol registrations) used by rx_nanopb.c; removing this file breaks the link
     ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.c
     ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
     ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/google/protobuf/duration.pb.c

--- a/e2-studio-star-rx72n-firmware/CMakeLists.txt
+++ b/e2-studio-star-rx72n-firmware/CMakeLists.txt
@@ -165,10 +165,15 @@ set(NANOPB_SOURCES
 # nanopb wrapper
 file(GLOB_RECURSE LIB_RX_NANOPB_SOURCES CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/src/*.c)
 
-# Generated protobuf files
-file(GLOB PROTOBUF_SOURCES CONFIGURE_DEPENDS
-    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/*.c
-    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/google/protobuf/*.c
+# Generated protobuf files - only include messages used by firmware
+set(PROTOBUF_SOURCES
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/common.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/google/protobuf/duration.pb.c
+    ${CMAKE_SOURCE_DIR}/libs/rx_nanopb/inc/gen/google/protobuf/timestamp.pb.c
 )
 
 # Combine all sources


### PR DESCRIPTION
## Summary

- Replaces `file(GLOB PROTOBUF_SOURCES ...)` wildcard in `e2-studio-star-rx72n-firmware/CMakeLists.txt` with an explicit `set()` listing only the proto files the firmware actually uses.
- Excludes five unused files from the build: `controller.pb.c`, `diagnostics.pb.c`, `firmware_update.pb.c`, `ui.pb.c`, and `wire.pb.c`.
- Retains `gateway_service.pb.c` because `rx_nanopb.c` references `star_v1_SetPIDGainsRequest_fields`, which resolves to `&star_v1_SetPIDGainsRequest_msg` defined in that translation unit — removing it would produce an unresolved symbol at link time.

Closes #376

## Files changed

- `e2-studio-star-rx72n-firmware/CMakeLists.txt` — swap glob for explicit proto source list.

## Investigation note

Issue #376 listed `gateway_service.pb.h/.c` as unused, but a source audit of `rx_nanopb.c` shows it uses `star_v1_SetPIDGainsRequest_fields` (a `pb_field_t` array that points to `star_v1_SetPIDGainsRequest_msg`). That symbol is defined in `gateway_service.pb.c`, so the file must stay in the build.

## Test plan

- [ ] Build firmware with CMake (`star-rx72n-firmware` CMake target) and confirm zero warnings and zero errors.
- [ ] Verify `.text` section size is <= 199,076 bytes (no unexpected code pulled in).
- [ ] Confirm the five excluded files (`controller.pb.c`, `diagnostics.pb.c`, `firmware_update.pb.c`, `ui.pb.c`, `wire.pb.c`) are absent from the build log.
- [ ] Confirm `gateway_service.pb.c` still appears in the build log and the linker resolves `star_v1_SetPIDGainsRequest_fields` without error.
- [ ] Confirm PID gains decode path still works end-to-end (SPI frame with `SetPIDGainsRequest` decoded correctly by `rx_nanopb`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use an explicit list of protobuf source files instead of dynamic file discovery, improving build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->