### PR TITLE
fix(telemetry): add obstacle detection data to telemetry stream (#371)

### DIFF
--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/common.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/common.pb.c
@@ -8,15 +8,24 @@
 
 PB_BIND(star_v1_RequestHeader, star_v1_RequestHeader, AUTO)
 
+
 PB_BIND(star_v1_ResponseHeader, star_v1_ResponseHeader, 2)
+
 
 PB_BIND(star_v1_Vector3, star_v1_Vector3, AUTO)
 
+
 PB_BIND(star_v1_Quaternion, star_v1_Quaternion, AUTO)
+
 
 PB_BIND(star_v1_SE2Pose, star_v1_SE2Pose, AUTO)
 
+
 PB_BIND(star_v1_SE2Velocity, star_v1_SE2Velocity, AUTO)
+
+
+
+
 
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
@@ -25,3 +34,4 @@ PB_BIND(star_v1_SE2Velocity, star_v1_SE2Velocity, AUTO)
  */
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 #endif
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/common.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/common.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_COMMON_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_COMMON_PB_H_INCLUDED
 #include <pb.h>
-
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/timestamp.pb.h"
 
@@ -16,240 +15,210 @@
 /* Response status codes following Boston Dynamics pattern.
  Zero value is STATUS_UNKNOWN per style guide. */
 typedef enum _star_v1_Status {
-  /* Unknown or unspecified status. Treat as error. */
-  star_v1_Status_STATUS_UNKNOWN = 0,
-  /* Request processed successfully. */
-  star_v1_Status_STATUS_OK = 1,
-  /* Request contained invalid parameters. */
-  star_v1_Status_STATUS_INVALID_REQUEST = 2,
-  /* Internal server error occurred. */
-  star_v1_Status_STATUS_INTERNAL_ERROR = 3,
-  /* Requested resource not found. */
-  star_v1_Status_STATUS_NOT_FOUND = 4,
-  /* Operation timed out. */
-  star_v1_Status_STATUS_TIMEOUT = 5,
-  /* Robot is in an invalid state for this operation. */
-  star_v1_Status_STATUS_INVALID_STATE = 6,
-  /* Emergency stop is active. */
-  star_v1_Status_STATUS_ESTOP_ACTIVE = 7
+    /* Unknown or unspecified status. Treat as error. */
+    star_v1_Status_STATUS_UNKNOWN = 0,
+    /* Request processed successfully. */
+    star_v1_Status_STATUS_OK = 1,
+    /* Request contained invalid parameters. */
+    star_v1_Status_STATUS_INVALID_REQUEST = 2,
+    /* Internal server error occurred. */
+    star_v1_Status_STATUS_INTERNAL_ERROR = 3,
+    /* Requested resource not found. */
+    star_v1_Status_STATUS_NOT_FOUND = 4,
+    /* Operation timed out. */
+    star_v1_Status_STATUS_TIMEOUT = 5,
+    /* Robot is in an invalid state for this operation. */
+    star_v1_Status_STATUS_INVALID_STATE = 6,
+    /* Emergency stop is active. */
+    star_v1_Status_STATUS_ESTOP_ACTIVE = 7
 } star_v1_Status;
 
 /* Struct definitions */
 /* Standard request header included in all requests.
  Provides tracing, versioning, and client identification. */
 typedef struct _star_v1_RequestHeader {
-  /* Client-generated request identifier for tracing.
+    /* Client-generated request identifier for tracing.
  Should be unique per request (UUID recommended). */
-  char request_id[64];
-  /* Client timestamp when request was created. */
-  bool                      has_client_timestamp;
-  google_protobuf_Timestamp client_timestamp;
-  /* Client software version string (e.g., "1.0.0"). */
-  char client_version[32];
-  /* Optional deadline for request processing. */
-  bool                     has_timeout;
-  google_protobuf_Duration timeout;
+    char request_id[64];
+    /* Client timestamp when request was created. */
+    bool has_client_timestamp;
+    google_protobuf_Timestamp client_timestamp;
+    /* Client software version string (e.g., "1.0.0"). */
+    char client_version[32];
+    /* Optional deadline for request processing. */
+    bool has_timeout;
+    google_protobuf_Duration timeout;
 } star_v1_RequestHeader;
 
 /* Standard response header included in all responses.
  Provides status, timing, and error information. */
 typedef struct _star_v1_ResponseHeader {
-  /* Echo of the request_id from RequestHeader. */
-  char request_id[64];
-  /* Server timestamp when response was generated. */
-  bool                      has_server_timestamp;
-  google_protobuf_Timestamp server_timestamp;
-  /* Processing status. */
-  star_v1_Status status;
-  /* Human-readable error message if status is not STATUS_OK. */
-  char error_message[256];
-  /* Round-trip latency in microseconds. */
-  int64_t latency_us;
+    /* Echo of the request_id from RequestHeader. */
+    char request_id[64];
+    /* Server timestamp when response was generated. */
+    bool has_server_timestamp;
+    google_protobuf_Timestamp server_timestamp;
+    /* Processing status. */
+    star_v1_Status status;
+    /* Human-readable error message if status is not STATUS_OK. */
+    char error_message[256];
+    /* Round-trip latency in microseconds. */
+    int64_t latency_us;
 } star_v1_ResponseHeader;
 
 /* 3D vector with MKS units.
  Usage context determines units (meters for position, m/s for velocity). */
 typedef struct _star_v1_Vector3 {
-  /* X component. */
-  double x;
-  /* Y component. */
-  double y;
-  /* Z component. */
-  double z;
+    /* X component. */
+    double x;
+    /* Y component. */
+    double y;
+    /* Z component. */
+    double z;
 } star_v1_Vector3;
 
 /* Quaternion for orientation representation.
  Normalized quaternion (w, x, y, z) with w as scalar component. */
 typedef struct _star_v1_Quaternion {
-  /* W component (scalar part). */
-  double w;
-  /* X component. */
-  double x;
-  /* Y component. */
-  double y;
-  /* Z component. */
-  double z;
+    /* W component (scalar part). */
+    double w;
+    /* X component. */
+    double x;
+    /* Y component. */
+    double y;
+    /* Z component. */
+    double z;
 } star_v1_Quaternion;
 
 /* SE2 pose for 2D navigation (position + heading).
  Uses MKS units: meters for position, radians for angle. */
 typedef struct _star_v1_SE2Pose {
-  /* X position in meters. */
-  double x_m;
-  /* Y position in meters. */
-  double y_m;
-  /* Heading angle in radians.
+    /* X position in meters. */
+    double x_m;
+    /* Y position in meters. */
+    double y_m;
+    /* Heading angle in radians.
  Range: -pi to pi, 0 = facing positive X axis. */
-  double angle_rad;
+    double angle_rad;
 } star_v1_SE2Pose;
 
 /* SE2 velocity for 2D motion.
  Uses MKS units: m/s for linear, rad/s for angular. */
 typedef struct _star_v1_SE2Velocity {
-  /* Linear velocity X in meters per second. */
-  double vx_mps;
-  /* Linear velocity Y in meters per second. */
-  double vy_mps;
-  /* Angular velocity in radians per second.
+    /* Linear velocity X in meters per second. */
+    double vx_mps;
+    /* Linear velocity Y in meters per second. */
+    double vy_mps;
+    /* Angular velocity in radians per second.
  Positive = counter-clockwise. */
-  double omega_rad_per_s;
+    double omega_rad_per_s;
 } star_v1_SE2Velocity;
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Helper constants for enums */
-#define _star_v1_Status_MIN       star_v1_Status_STATUS_UNKNOWN
-#define _star_v1_Status_MAX       star_v1_Status_STATUS_ESTOP_ACTIVE
-#define _star_v1_Status_ARRAYSIZE ((star_v1_Status)(star_v1_Status_STATUS_ESTOP_ACTIVE + 1))
+#define _star_v1_Status_MIN star_v1_Status_STATUS_UNKNOWN
+#define _star_v1_Status_MAX star_v1_Status_STATUS_ESTOP_ACTIVE
+#define _star_v1_Status_ARRAYSIZE ((star_v1_Status)(star_v1_Status_STATUS_ESTOP_ACTIVE+1))
+
 
 #define star_v1_ResponseHeader_status_ENUMTYPE star_v1_Status
 
+
+
+
+
+
 /* Initializer values for message structs */
-#define star_v1_RequestHeader_init_default                                                         \
-  {                                                                                                \
-    "", false, google_protobuf_Timestamp_init_default, "", false,                                  \
-      google_protobuf_Duration_init_default                                                        \
-  }
-#define star_v1_ResponseHeader_init_default                                                        \
-  {                                                                                                \
-    "", false, google_protobuf_Timestamp_init_default, _star_v1_Status_MIN, "", 0                  \
-  }
-#define star_v1_Vector3_init_default                                                               \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_Quaternion_init_default                                                            \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_SE2Pose_init_default                                                               \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_SE2Velocity_init_default                                                           \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_RequestHeader_init_zero                                                            \
-  {                                                                                                \
-    "", false, google_protobuf_Timestamp_init_zero, "", false, google_protobuf_Duration_init_zero  \
-  }
-#define star_v1_ResponseHeader_init_zero                                                           \
-  {                                                                                                \
-    "", false, google_protobuf_Timestamp_init_zero, _star_v1_Status_MIN, "", 0                     \
-  }
-#define star_v1_Vector3_init_zero                                                                  \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_Quaternion_init_zero                                                               \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_SE2Pose_init_zero                                                                  \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_SE2Velocity_init_zero                                                              \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
+#define star_v1_RequestHeader_init_default       {"", false, google_protobuf_Timestamp_init_default, "", false, google_protobuf_Duration_init_default}
+#define star_v1_ResponseHeader_init_default      {"", false, google_protobuf_Timestamp_init_default, _star_v1_Status_MIN, "", 0}
+#define star_v1_Vector3_init_default             {0, 0, 0}
+#define star_v1_Quaternion_init_default          {0, 0, 0, 0}
+#define star_v1_SE2Pose_init_default             {0, 0, 0}
+#define star_v1_SE2Velocity_init_default         {0, 0, 0}
+#define star_v1_RequestHeader_init_zero          {"", false, google_protobuf_Timestamp_init_zero, "", false, google_protobuf_Duration_init_zero}
+#define star_v1_ResponseHeader_init_zero         {"", false, google_protobuf_Timestamp_init_zero, _star_v1_Status_MIN, "", 0}
+#define star_v1_Vector3_init_zero                {0, 0, 0}
+#define star_v1_Quaternion_init_zero             {0, 0, 0, 0}
+#define star_v1_SE2Pose_init_zero                {0, 0, 0}
+#define star_v1_SE2Velocity_init_zero            {0, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_RequestHeader_request_id_tag        1
-#define star_v1_RequestHeader_client_timestamp_tag  2
-#define star_v1_RequestHeader_client_version_tag    3
-#define star_v1_RequestHeader_timeout_tag           4
-#define star_v1_ResponseHeader_request_id_tag       1
+#define star_v1_RequestHeader_request_id_tag     1
+#define star_v1_RequestHeader_client_timestamp_tag 2
+#define star_v1_RequestHeader_client_version_tag 3
+#define star_v1_RequestHeader_timeout_tag        4
+#define star_v1_ResponseHeader_request_id_tag    1
 #define star_v1_ResponseHeader_server_timestamp_tag 2
-#define star_v1_ResponseHeader_status_tag           3
-#define star_v1_ResponseHeader_error_message_tag    4
-#define star_v1_ResponseHeader_latency_us_tag       5
-#define star_v1_Vector3_x_tag                       1
-#define star_v1_Vector3_y_tag                       2
-#define star_v1_Vector3_z_tag                       3
-#define star_v1_Quaternion_w_tag                    1
-#define star_v1_Quaternion_x_tag                    2
-#define star_v1_Quaternion_y_tag                    3
-#define star_v1_Quaternion_z_tag                    4
-#define star_v1_SE2Pose_x_m_tag                     1
-#define star_v1_SE2Pose_y_m_tag                     2
-#define star_v1_SE2Pose_angle_rad_tag               3
-#define star_v1_SE2Velocity_vx_mps_tag              1
-#define star_v1_SE2Velocity_vy_mps_tag              2
-#define star_v1_SE2Velocity_omega_rad_per_s_tag     3
+#define star_v1_ResponseHeader_status_tag        3
+#define star_v1_ResponseHeader_error_message_tag 4
+#define star_v1_ResponseHeader_latency_us_tag    5
+#define star_v1_Vector3_x_tag                    1
+#define star_v1_Vector3_y_tag                    2
+#define star_v1_Vector3_z_tag                    3
+#define star_v1_Quaternion_w_tag                 1
+#define star_v1_Quaternion_x_tag                 2
+#define star_v1_Quaternion_y_tag                 3
+#define star_v1_Quaternion_z_tag                 4
+#define star_v1_SE2Pose_x_m_tag                  1
+#define star_v1_SE2Pose_y_m_tag                  2
+#define star_v1_SE2Pose_angle_rad_tag            3
+#define star_v1_SE2Velocity_vx_mps_tag           1
+#define star_v1_SE2Velocity_vy_mps_tag           2
+#define star_v1_SE2Velocity_omega_rad_per_s_tag  3
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_RequestHeader_FIELDLIST(X, a)                                                      \
-  X(a, STATIC, SINGULAR, STRING, request_id, 1)                                                    \
-  X(a, STATIC, OPTIONAL, MESSAGE, client_timestamp, 2)                                             \
-  X(a, STATIC, SINGULAR, STRING, client_version, 3)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, timeout, 4)
-#define star_v1_RequestHeader_CALLBACK                 NULL
-#define star_v1_RequestHeader_DEFAULT                  NULL
+#define star_v1_RequestHeader_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, STRING,   request_id,        1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  client_timestamp,   2) \
+X(a, STATIC,   SINGULAR, STRING,   client_version,    3) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  timeout,           4)
+#define star_v1_RequestHeader_CALLBACK NULL
+#define star_v1_RequestHeader_DEFAULT NULL
 #define star_v1_RequestHeader_client_timestamp_MSGTYPE google_protobuf_Timestamp
-#define star_v1_RequestHeader_timeout_MSGTYPE          google_protobuf_Duration
+#define star_v1_RequestHeader_timeout_MSGTYPE google_protobuf_Duration
 
-#define star_v1_ResponseHeader_FIELDLIST(X, a)                                                     \
-  X(a, STATIC, SINGULAR, STRING, request_id, 1)                                                    \
-  X(a, STATIC, OPTIONAL, MESSAGE, server_timestamp, 2)                                             \
-  X(a, STATIC, SINGULAR, UENUM, status, 3)                                                         \
-  X(a, STATIC, SINGULAR, STRING, error_message, 4)                                                 \
-  X(a, STATIC, SINGULAR, INT64, latency_us, 5)
-#define star_v1_ResponseHeader_CALLBACK                 NULL
-#define star_v1_ResponseHeader_DEFAULT                  NULL
+#define star_v1_ResponseHeader_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, STRING,   request_id,        1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  server_timestamp,   2) \
+X(a, STATIC,   SINGULAR, UENUM,    status,            3) \
+X(a, STATIC,   SINGULAR, STRING,   error_message,     4) \
+X(a, STATIC,   SINGULAR, INT64,    latency_us,        5)
+#define star_v1_ResponseHeader_CALLBACK NULL
+#define star_v1_ResponseHeader_DEFAULT NULL
 #define star_v1_ResponseHeader_server_timestamp_MSGTYPE google_protobuf_Timestamp
 
-#define star_v1_Vector3_FIELDLIST(X, a)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, x, 1)                                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, y, 2)                                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, z, 3)
+#define star_v1_Vector3_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   x,                 1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   y,                 2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   z,                 3)
 #define star_v1_Vector3_CALLBACK NULL
-#define star_v1_Vector3_DEFAULT  NULL
+#define star_v1_Vector3_DEFAULT NULL
 
-#define star_v1_Quaternion_FIELDLIST(X, a)                                                         \
-  X(a, STATIC, SINGULAR, DOUBLE, w, 1)                                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, x, 2)                                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, y, 3)                                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, z, 4)
+#define star_v1_Quaternion_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   w,                 1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   x,                 2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   y,                 3) \
+X(a, STATIC,   SINGULAR, DOUBLE,   z,                 4)
 #define star_v1_Quaternion_CALLBACK NULL
-#define star_v1_Quaternion_DEFAULT  NULL
+#define star_v1_Quaternion_DEFAULT NULL
 
-#define star_v1_SE2Pose_FIELDLIST(X, a)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, x_m, 1)                                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, y_m, 2)                                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, angle_rad, 3)
+#define star_v1_SE2Pose_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   x_m,               1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   y_m,               2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   angle_rad,         3)
 #define star_v1_SE2Pose_CALLBACK NULL
-#define star_v1_SE2Pose_DEFAULT  NULL
+#define star_v1_SE2Pose_DEFAULT NULL
 
-#define star_v1_SE2Velocity_FIELDLIST(X, a)                                                        \
-  X(a, STATIC, SINGULAR, DOUBLE, vx_mps, 1)                                                        \
-  X(a, STATIC, SINGULAR, DOUBLE, vy_mps, 2)                                                        \
-  X(a, STATIC, SINGULAR, DOUBLE, omega_rad_per_s, 3)
+#define star_v1_SE2Velocity_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   vx_mps,            1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   vy_mps,            2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   omega_rad_per_s,   3)
 #define star_v1_SE2Velocity_CALLBACK NULL
-#define star_v1_SE2Velocity_DEFAULT  NULL
+#define star_v1_SE2Velocity_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_RequestHeader_msg;
 extern const pb_msgdesc_t star_v1_ResponseHeader_msg;
@@ -259,21 +228,21 @@ extern const pb_msgdesc_t star_v1_SE2Pose_msg;
 extern const pb_msgdesc_t star_v1_SE2Velocity_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_RequestHeader_fields  &star_v1_RequestHeader_msg
+#define star_v1_RequestHeader_fields &star_v1_RequestHeader_msg
 #define star_v1_ResponseHeader_fields &star_v1_ResponseHeader_msg
-#define star_v1_Vector3_fields        &star_v1_Vector3_msg
-#define star_v1_Quaternion_fields     &star_v1_Quaternion_msg
-#define star_v1_SE2Pose_fields        &star_v1_SE2Pose_msg
-#define star_v1_SE2Velocity_fields    &star_v1_SE2Velocity_msg
+#define star_v1_Vector3_fields &star_v1_Vector3_msg
+#define star_v1_Quaternion_fields &star_v1_Quaternion_msg
+#define star_v1_SE2Pose_fields &star_v1_SE2Pose_msg
+#define star_v1_SE2Velocity_fields &star_v1_SE2Velocity_msg
 
 /* Maximum encoded size of messages (where known) */
-#define STAR_V1_STAR_V1_COMMON_PB_H_MAX_SIZE star_v1_ResponseHeader_size
-#define star_v1_Quaternion_size              36
-#define star_v1_RequestHeader_size           146
-#define star_v1_ResponseHeader_size          360
-#define star_v1_SE2Pose_size                 27
-#define star_v1_SE2Velocity_size             27
-#define star_v1_Vector3_size                 27
+#define STAR_V1_STAR_V1_COMMON_PB_H_MAX_SIZE     star_v1_ResponseHeader_size
+#define star_v1_Quaternion_size                  36
+#define star_v1_RequestHeader_size               146
+#define star_v1_ResponseHeader_size              360
+#define star_v1_SE2Pose_size                     27
+#define star_v1_SE2Velocity_size                 27
+#define star_v1_Vector3_size                     27
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.c
@@ -8,55 +8,86 @@
 
 PB_BIND(star_v1_GetConfigurationRequest, star_v1_GetConfigurationRequest, AUTO)
 
+
 PB_BIND(star_v1_GetConfigurationResponse, star_v1_GetConfigurationResponse, 2)
+
 
 PB_BIND(star_v1_SetConfigurationRequest, star_v1_SetConfigurationRequest, 2)
 
+
 PB_BIND(star_v1_SetConfigurationResponse, star_v1_SetConfigurationResponse, 4)
+
 
 PB_BIND(star_v1_ResetToDefaultsRequest, star_v1_ResetToDefaultsRequest, AUTO)
 
+
 PB_BIND(star_v1_ResetToDefaultsResponse, star_v1_ResetToDefaultsResponse, 2)
+
 
 PB_BIND(star_v1_ValidateConfigurationRequest, star_v1_ValidateConfigurationRequest, 2)
 
+
 PB_BIND(star_v1_ValidateConfigurationResponse, star_v1_ValidateConfigurationResponse, 4)
+
 
 PB_BIND(star_v1_SaveConfigurationRequest, star_v1_SaveConfigurationRequest, AUTO)
 
+
 PB_BIND(star_v1_SaveConfigurationResponse, star_v1_SaveConfigurationResponse, 2)
+
 
 PB_BIND(star_v1_GetMotorPidConfigRequest, star_v1_GetMotorPidConfigRequest, AUTO)
 
+
 PB_BIND(star_v1_GetMotorPidConfigResponse, star_v1_GetMotorPidConfigResponse, 2)
+
 
 PB_BIND(star_v1_SetMotorPidConfigRequest, star_v1_SetMotorPidConfigRequest, AUTO)
 
+
 PB_BIND(star_v1_SetMotorPidConfigResponse, star_v1_SetMotorPidConfigResponse, 4)
+
 
 PB_BIND(star_v1_RetransmitConfig, star_v1_RetransmitConfig, AUTO)
 
+
 PB_BIND(star_v1_SetRetransmitConfigRequest, star_v1_SetRetransmitConfigRequest, AUTO)
+
 
 PB_BIND(star_v1_SetRetransmitConfigResponse, star_v1_SetRetransmitConfigResponse, 2)
 
+
 PB_BIND(star_v1_SystemConfiguration, star_v1_SystemConfiguration, 2)
+
 
 PB_BIND(star_v1_MotorPidConfiguration, star_v1_MotorPidConfiguration, AUTO)
 
+
 PB_BIND(star_v1_CurrentSensorCalibration, star_v1_CurrentSensorCalibration, AUTO)
+
 
 PB_BIND(star_v1_TemperatureCalibration, star_v1_TemperatureCalibration, AUTO)
 
+
 PB_BIND(star_v1_SafetyThresholds, star_v1_SafetyThresholds, AUTO)
+
 
 PB_BIND(star_v1_EncoderConfiguration, star_v1_EncoderConfiguration, AUTO)
 
+
 PB_BIND(star_v1_TimingConfiguration, star_v1_TimingConfiguration, AUTO)
+
 
 PB_BIND(star_v1_ConfigValidationResult, star_v1_ConfigValidationResult, 4)
 
+
 PB_BIND(star_v1_ConfigValidationError, star_v1_ConfigValidationError, 2)
+
+
+
+
+
+
 
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
@@ -65,3 +96,4 @@ PB_BIND(star_v1_ConfigValidationError, star_v1_ConfigValidationError, 2)
  */
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 #endif
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/configuration.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_CONFIGURATION_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_CONFIGURATION_PB_H_INCLUDED
 #include <pb.h>
-
 #include "star/v1/common.pb.h"
 #include "star/v1/motor_control.pb.h"
 
@@ -15,142 +14,142 @@
 /* Enum definitions */
 /* Configuration validation status. */
 typedef enum _star_v1_ConfigValidationStatus {
-  /* Unknown validation status. */
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_UNKNOWN = 0,
-  /* Configuration is valid and can be applied. */
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VALID = 1,
-  /* Configuration has invalid parameters. */
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_INVALID = 2,
-  /* Configuration has warnings but can be applied. */
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_WARNING = 3,
-  /* CRC checksum mismatch. */
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_CRC_MISMATCH = 4,
-  /* Configuration version incompatible. */
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VERSION_MISMATCH = 5
+    /* Unknown validation status. */
+    star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_UNKNOWN = 0,
+    /* Configuration is valid and can be applied. */
+    star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VALID = 1,
+    /* Configuration has invalid parameters. */
+    star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_INVALID = 2,
+    /* Configuration has warnings but can be applied. */
+    star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_WARNING = 3,
+    /* CRC checksum mismatch. */
+    star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_CRC_MISMATCH = 4,
+    /* Configuration version incompatible. */
+    star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VERSION_MISMATCH = 5
 } star_v1_ConfigValidationStatus;
 
 /* Configuration error codes. */
 typedef enum _star_v1_ConfigErrorCode {
-  /* Unknown error. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_UNKNOWN = 0,
-  /* Value is below minimum allowed. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_VALUE_TOO_LOW = 1,
-  /* Value is above maximum allowed. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_VALUE_TOO_HIGH = 2,
-  /* Value is NaN or infinity. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_INVALID_NUMBER = 3,
-  /* Required field is missing. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_MISSING_FIELD = 4,
-  /* Array has wrong number of elements. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_WRONG_ARRAY_SIZE = 5,
-  /* CRC checksum failed. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_CRC_FAILED = 6,
-  /* Version is not supported. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_UNSUPPORTED_VERSION = 7,
-  /* NVS storage error. */
-  star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_STORAGE_ERROR = 8
+    /* Unknown error. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_UNKNOWN = 0,
+    /* Value is below minimum allowed. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_VALUE_TOO_LOW = 1,
+    /* Value is above maximum allowed. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_VALUE_TOO_HIGH = 2,
+    /* Value is NaN or infinity. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_INVALID_NUMBER = 3,
+    /* Required field is missing. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_MISSING_FIELD = 4,
+    /* Array has wrong number of elements. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_WRONG_ARRAY_SIZE = 5,
+    /* CRC checksum failed. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_CRC_FAILED = 6,
+    /* Version is not supported. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_UNSUPPORTED_VERSION = 7,
+    /* NVS storage error. */
+    star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_STORAGE_ERROR = 8
 } star_v1_ConfigErrorCode;
 
 /* Struct definitions */
 /* Request for current configuration. */
 typedef struct _star_v1_GetConfigurationRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_GetConfigurationRequest;
 
 /* Request to reset configuration. */
 typedef struct _star_v1_ResetToDefaultsRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* If true, automatically save defaults to NVS. */
-  bool persist_to_nvs;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* If true, automatically save defaults to NVS. */
+    bool persist_to_nvs;
 } star_v1_ResetToDefaultsRequest;
 
 /* Request to save configuration to NVS. */
 typedef struct _star_v1_SaveConfigurationRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_SaveConfigurationRequest;
 
 /* Response to save configuration. */
 typedef struct _star_v1_SaveConfigurationResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if save was successful. */
-  bool saved;
-  /* Updated CRC-32 checksum after save. */
-  uint32_t config_crc;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if save was successful. */
+    bool saved;
+    /* Updated CRC-32 checksum after save. */
+    uint32_t config_crc;
 } star_v1_SaveConfigurationResponse;
 
 /* Request for motor PID configuration. */
 typedef struct _star_v1_GetMotorPidConfigRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Motor index (0-3 for 4-motor system). */
-  int32_t motor_id;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Motor index (0-3 for 4-motor system). */
+    int32_t motor_id;
 } star_v1_GetMotorPidConfigRequest;
 
 /* Response with motor PID configuration. */
 typedef struct _star_v1_GetMotorPidConfigResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Motor index. */
-  int32_t motor_id;
-  /* PID configuration for this motor. */
-  bool              has_pid_config;
-  star_v1_PidConfig pid_config;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Motor index. */
+    int32_t motor_id;
+    /* PID configuration for this motor. */
+    bool has_pid_config;
+    star_v1_PidConfig pid_config;
 } star_v1_GetMotorPidConfigResponse;
 
 /* Request to set motor PID configuration. */
 typedef struct _star_v1_SetMotorPidConfigRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Motor index (0-3 for 4-motor system). */
-  int32_t motor_id;
-  /* PID configuration to apply. */
-  bool              has_pid_config;
-  star_v1_PidConfig pid_config;
-  /* If true, automatically save to NVS. */
-  bool persist_to_nvs;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Motor index (0-3 for 4-motor system). */
+    int32_t motor_id;
+    /* PID configuration to apply. */
+    bool has_pid_config;
+    star_v1_PidConfig pid_config;
+    /* If true, automatically save to NVS. */
+    bool persist_to_nvs;
 } star_v1_SetMotorPidConfigRequest;
 
 /* Retransmit configuration for SPI communication layer. */
 typedef struct _star_v1_RetransmitConfig {
-  /* Enable automatic retransmission. */
-  bool enabled;
-  /* Maximum retransmit attempts before giving up.
+    /* Enable automatic retransmission. */
+    bool enabled;
+    /* Maximum retransmit attempts before giving up.
  Valid range: 1-10. Default: 3. */
-  uint32_t max_retries;
-  /* Initial ACK timeout in milliseconds.
+    uint32_t max_retries;
+    /* Initial ACK timeout in milliseconds.
  Valid range: 10-1000. Default: 50. */
-  uint32_t ack_timeout_ms;
-  /* Maximum backoff cap in milliseconds.
+    uint32_t ack_timeout_ms;
+    /* Maximum backoff cap in milliseconds.
  Valid range: 50-5000. Default: 400. */
-  uint32_t max_backoff_ms;
+    uint32_t max_backoff_ms;
 } star_v1_RetransmitConfig;
 
 /* Request to set retransmit configuration (RPi5 -> RX72N). */
 typedef struct _star_v1_SetRetransmitConfigRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Retransmit configuration to apply. */
-  bool                     has_retransmit_config;
-  star_v1_RetransmitConfig retransmit_config;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Retransmit configuration to apply. */
+    bool has_retransmit_config;
+    star_v1_RetransmitConfig retransmit_config;
 } star_v1_SetRetransmitConfigRequest;
 
 /* Response to set retransmit configuration. */
 typedef struct _star_v1_SetRetransmitConfigResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
 } star_v1_SetRetransmitConfigResponse;
 
 /* Motor PID configuration for a single motor.
@@ -159,740 +158,573 @@ typedef struct _star_v1_SetRetransmitConfigResponse {
  identifies the motor. This enables server-side validation and
  clearer debugging of serialized messages. */
 typedef struct _star_v1_MotorPidConfiguration {
-  /* Motor index (0-3).
+    /* Motor index (0-3).
  Should match array index in SystemConfiguration.motor_configs. */
-  int32_t motor_id;
-  /* PID gains configuration.
+    int32_t motor_id;
+    /* PID gains configuration.
  Reuses PidConfig from motor_control.proto. */
-  bool              has_pid_config;
-  star_v1_PidConfig pid_config;
+    bool has_pid_config;
+    star_v1_PidConfig pid_config;
 } star_v1_MotorPidConfiguration;
 
 /* Current sensor calibration data.
  Applied to all motor current sense readings. */
 typedef struct _star_v1_CurrentSensorCalibration {
-  /* ADC offset when motor stopped, in milliamps.
+    /* ADC offset when motor stopped, in milliamps.
  One per motor (max 4). */
-  pb_callback_t offset_ma;
-  /* Scaling factor adjustment for each motor.
+    pb_callback_t offset_ma;
+    /* Scaling factor adjustment for each motor.
  Multiplied with raw ADC reading.
  One per motor (max 4). */
-  pb_callback_t scale_factor;
+    pb_callback_t scale_factor;
 } star_v1_CurrentSensorCalibration;
 
 /* Temperature sensor calibration. */
 typedef struct _star_v1_TemperatureCalibration {
-  /* Temperature offset correction in Celsius.
+    /* Temperature offset correction in Celsius.
  Added to raw temperature reading. */
-  double offset_celsius;
+    double offset_celsius;
 } star_v1_TemperatureCalibration;
 
 /* Safety thresholds for motor protection. */
 typedef struct _star_v1_SafetyThresholds {
-  /* Motor overcurrent limit in milliamps.
+    /* Motor overcurrent limit in milliamps.
  Motors disabled if current exceeds this.
  Valid range: 1000-20000 mA. */
-  uint32_t overcurrent_threshold_ma;
-  /* Emergency temperature cutoff in deci-celsius (0.1C units).
+    uint32_t overcurrent_threshold_ma;
+    /* Emergency temperature cutoff in deci-celsius (0.1C units).
  System enters safe mode above this temperature.
  Valid range: 500-1000 (50.0-100.0 C). */
-  int32_t thermal_shutdown_deci_celsius;
-  /* Motor phase imbalance threshold in millivolts.
+    int32_t thermal_shutdown_deci_celsius;
+    /* Motor phase imbalance threshold in millivolts.
  Valid range: 50-500 mV. */
-  uint32_t cell_imbalance_threshold_mv;
+    uint32_t cell_imbalance_threshold_mv;
 } star_v1_SafetyThresholds;
 
 /* Encoder configuration parameters. */
 typedef struct _star_v1_EncoderConfiguration {
-  /* Encoder edges per motor revolution.
+    /* Encoder edges per motor revolution.
  Used for velocity calculation.
  Common values: 500, 1000, 2000, 4000. */
-  uint32_t edges_per_revolution;
-  /* Wheel diameter in meters (for linear velocity). */
-  double wheel_diameter_m;
-  /* Gear ratio (motor revolutions per wheel revolution). */
-  double gear_ratio;
+    uint32_t edges_per_revolution;
+    /* Wheel diameter in meters (for linear velocity). */
+    double wheel_diameter_m;
+    /* Gear ratio (motor revolutions per wheel revolution). */
+    double gear_ratio;
 } star_v1_EncoderConfiguration;
 
 /* Timing configuration for control loops and communication. */
 typedef struct _star_v1_TimingConfiguration {
-  /* Motor control loop period in milliseconds.
+    /* Motor control loop period in milliseconds.
  Lower = faster response, higher CPU usage.
  Valid range: 1-100 ms. Typical: 10 ms (100 Hz). */
-  uint32_t motor_control_period_ms;
-  /* Telemetry reporting period in milliseconds.
+    uint32_t motor_control_period_ms;
+    /* Telemetry reporting period in milliseconds.
  Valid range: 10-1000 ms. Typical: 100 ms (10 Hz). */
-  uint32_t telemetry_period_ms;
-  /* RPi5 communication watchdog timeout in milliseconds.
+    uint32_t telemetry_period_ms;
+    /* RPi5 communication watchdog timeout in milliseconds.
  Motors stopped if no command received within timeout.
  Valid range: 100-5000 ms. Typical: 500 ms. */
-  uint32_t communication_timeout_ms;
+    uint32_t communication_timeout_ms;
 } star_v1_TimingConfiguration;
 
 /* Complete system configuration.
  Maps to star_config_t structure. */
 typedef struct _star_v1_SystemConfiguration {
-  /* Motor PID configuration for all motors (max 4 motors).
+    /* Motor PID configuration for all motors (max 4 motors).
  Array index corresponds to motor ID (0-3). */
-  pb_size_t                     motor_configs_count;
-  star_v1_MotorPidConfiguration motor_configs[4];
-  /* Current sensor calibration for all motors. */
-  bool                             has_current_calibration;
-  star_v1_CurrentSensorCalibration current_calibration;
-  /* Temperature sensor calibration. */
-  bool                           has_temperature_calibration;
-  star_v1_TemperatureCalibration temperature_calibration;
-  /* Safety thresholds. */
-  bool                     has_safety_thresholds;
-  star_v1_SafetyThresholds safety_thresholds;
-  /* Encoder configuration. */
-  bool                         has_encoder_config;
-  star_v1_EncoderConfiguration encoder_config;
-  /* Timing parameters. */
-  bool                        has_timing_config;
-  star_v1_TimingConfiguration timing_config;
-  /* Configuration schema version.
+    pb_size_t motor_configs_count;
+    star_v1_MotorPidConfiguration motor_configs[4];
+    /* Current sensor calibration for all motors. */
+    bool has_current_calibration;
+    star_v1_CurrentSensorCalibration current_calibration;
+    /* Temperature sensor calibration. */
+    bool has_temperature_calibration;
+    star_v1_TemperatureCalibration temperature_calibration;
+    /* Safety thresholds. */
+    bool has_safety_thresholds;
+    star_v1_SafetyThresholds safety_thresholds;
+    /* Encoder configuration. */
+    bool has_encoder_config;
+    star_v1_EncoderConfiguration encoder_config;
+    /* Timing parameters. */
+    bool has_timing_config;
+    star_v1_TimingConfiguration timing_config;
+    /* Configuration schema version.
  Used for migration between firmware versions. */
-  uint32_t config_version;
-  /* CRC-32 checksum for integrity validation.
+    uint32_t config_version;
+    /* CRC-32 checksum for integrity validation.
  Computed over all fields except this one. */
-  uint32_t config_crc;
+    uint32_t config_crc;
 } star_v1_SystemConfiguration;
 
 /* Response with current configuration. */
 typedef struct _star_v1_GetConfigurationResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Current system configuration. */
-  bool                        has_configuration;
-  star_v1_SystemConfiguration configuration;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Current system configuration. */
+    bool has_configuration;
+    star_v1_SystemConfiguration configuration;
 } star_v1_GetConfigurationResponse;
 
 /* Request to set configuration. */
 typedef struct _star_v1_SetConfigurationRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Configuration to apply. */
-  bool                        has_configuration;
-  star_v1_SystemConfiguration configuration;
-  /* If true, automatically save to NVS after validation.
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Configuration to apply. */
+    bool has_configuration;
+    star_v1_SystemConfiguration configuration;
+    /* If true, automatically save to NVS after validation.
  If false, configuration is only held in memory. */
-  bool persist_to_nvs;
+    bool persist_to_nvs;
 } star_v1_SetConfigurationRequest;
 
 /* Response to reset configuration. */
 typedef struct _star_v1_ResetToDefaultsResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Default configuration that was applied. */
-  bool                        has_configuration;
-  star_v1_SystemConfiguration configuration;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Default configuration that was applied. */
+    bool has_configuration;
+    star_v1_SystemConfiguration configuration;
 } star_v1_ResetToDefaultsResponse;
 
 /* Request to validate configuration. */
 typedef struct _star_v1_ValidateConfigurationRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Configuration to validate. */
-  bool                        has_configuration;
-  star_v1_SystemConfiguration configuration;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Configuration to validate. */
+    bool has_configuration;
+    star_v1_SystemConfiguration configuration;
 } star_v1_ValidateConfigurationRequest;
 
 /* Individual configuration validation error. */
 typedef struct _star_v1_ConfigValidationError {
-  /* Field that failed validation (dot notation, e.g., "motor_configs[0].pid_config.kp"). */
-  char field_path[128];
-  /* Error code for programmatic handling. */
-  star_v1_ConfigErrorCode error_code;
-  /* Human-readable error message. */
-  char message[256];
-  /* Actual value that failed validation. */
-  char actual_value[64];
-  /* Expected range or constraint description. */
-  char expected_constraint[128];
+    /* Field that failed validation (dot notation, e.g., "motor_configs[0].pid_config.kp"). */
+    char field_path[128];
+    /* Error code for programmatic handling. */
+    star_v1_ConfigErrorCode error_code;
+    /* Human-readable error message. */
+    char message[256];
+    /* Actual value that failed validation. */
+    char actual_value[64];
+    /* Expected range or constraint description. */
+    char expected_constraint[128];
 } star_v1_ConfigValidationError;
 
 /* Configuration validation result. */
 typedef struct _star_v1_ConfigValidationResult {
-  /* Overall validation status. */
-  star_v1_ConfigValidationStatus status;
-  /* List of validation errors (empty if valid). */
-  pb_size_t                     errors_count;
-  star_v1_ConfigValidationError errors[8];
+    /* Overall validation status. */
+    star_v1_ConfigValidationStatus status;
+    /* List of validation errors (empty if valid). */
+    pb_size_t errors_count;
+    star_v1_ConfigValidationError errors[8];
 } star_v1_ConfigValidationResult;
 
 /* Response to set configuration. */
 typedef struct _star_v1_SetConfigurationResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Validation result. */
-  bool                           has_validation_result;
-  star_v1_ConfigValidationResult validation_result;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Validation result. */
+    bool has_validation_result;
+    star_v1_ConfigValidationResult validation_result;
 } star_v1_SetConfigurationResponse;
 
 /* Response with validation results. */
 typedef struct _star_v1_ValidateConfigurationResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Detailed validation result. */
-  bool                           has_validation_result;
-  star_v1_ConfigValidationResult validation_result;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Detailed validation result. */
+    bool has_validation_result;
+    star_v1_ConfigValidationResult validation_result;
 } star_v1_ValidateConfigurationResponse;
 
 /* Response to set motor PID configuration. */
 typedef struct _star_v1_SetMotorPidConfigResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Validation result. */
-  bool                           has_validation_result;
-  star_v1_ConfigValidationResult validation_result;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Validation result. */
+    bool has_validation_result;
+    star_v1_ConfigValidationResult validation_result;
 } star_v1_SetMotorPidConfigResponse;
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Helper constants for enums */
-#define _star_v1_ConfigValidationStatus_MIN                                                        \
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_UNKNOWN
-#define _star_v1_ConfigValidationStatus_MAX                                                        \
-  star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VERSION_MISMATCH
-#define _star_v1_ConfigValidationStatus_ARRAYSIZE                                                              \
-  ((star_v1_ConfigValidationStatus)(star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VERSION_MISMATCH + \
-                                    1))
+#define _star_v1_ConfigValidationStatus_MIN star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_UNKNOWN
+#define _star_v1_ConfigValidationStatus_MAX star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VERSION_MISMATCH
+#define _star_v1_ConfigValidationStatus_ARRAYSIZE ((star_v1_ConfigValidationStatus)(star_v1_ConfigValidationStatus_CONFIG_VALIDATION_STATUS_VERSION_MISMATCH+1))
 
 #define _star_v1_ConfigErrorCode_MIN star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_UNKNOWN
 #define _star_v1_ConfigErrorCode_MAX star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_STORAGE_ERROR
-#define _star_v1_ConfigErrorCode_ARRAYSIZE                                                         \
-  ((star_v1_ConfigErrorCode)(star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_STORAGE_ERROR + 1))
+#define _star_v1_ConfigErrorCode_ARRAYSIZE ((star_v1_ConfigErrorCode)(star_v1_ConfigErrorCode_CONFIG_ERROR_CODE_STORAGE_ERROR+1))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 #define star_v1_ConfigValidationResult_status_ENUMTYPE star_v1_ConfigValidationStatus
 
 #define star_v1_ConfigValidationError_error_code_ENUMTYPE star_v1_ConfigErrorCode
 
+
 /* Initializer values for message structs */
-#define star_v1_GetConfigurationRequest_init_default                                               \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_GetConfigurationResponse_init_default                                              \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_SystemConfiguration_init_default    \
-  }
-#define star_v1_SetConfigurationRequest_init_default                                               \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_SystemConfiguration_init_default, 0  \
-  }
-#define star_v1_SetConfigurationResponse_init_default                                              \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_ConfigValidationResult_init_default \
-  }
-#define star_v1_ResetToDefaultsRequest_init_default                                                \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0                                                   \
-  }
-#define star_v1_ResetToDefaultsResponse_init_default                                               \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_SystemConfiguration_init_default    \
-  }
-#define star_v1_ValidateConfigurationRequest_init_default                                          \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_SystemConfiguration_init_default     \
-  }
-#define star_v1_ValidateConfigurationResponse_init_default                                         \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_ConfigValidationResult_init_default \
-  }
-#define star_v1_SaveConfigurationRequest_init_default                                              \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_SaveConfigurationResponse_init_default                                             \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, 0                                               \
-  }
-#define star_v1_GetMotorPidConfigRequest_init_default                                              \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0                                                   \
-  }
-#define star_v1_GetMotorPidConfigResponse_init_default                                             \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, false, star_v1_PidConfig_init_default           \
-  }
-#define star_v1_SetMotorPidConfigRequest_init_default                                              \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0, false, star_v1_PidConfig_init_default, 0         \
-  }
-#define star_v1_SetMotorPidConfigResponse_init_default                                             \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_ConfigValidationResult_init_default \
-  }
-#define star_v1_RetransmitConfig_init_default                                                      \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_SetRetransmitConfigRequest_init_default                                            \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_RetransmitConfig_init_default        \
-  }
-#define star_v1_SetRetransmitConfigResponse_init_default                                           \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default                                                     \
-  }
-#define star_v1_SystemConfiguration_init_default                                                   \
-  {                                                                                                \
-    0,                                                                                             \
-      {star_v1_MotorPidConfiguration_init_default,                                                 \
-       star_v1_MotorPidConfiguration_init_default,                                                 \
-       star_v1_MotorPidConfiguration_init_default,                                                 \
-       star_v1_MotorPidConfiguration_init_default},                                                \
-      false, star_v1_CurrentSensorCalibration_init_default, false,                                 \
-      star_v1_TemperatureCalibration_init_default, false, star_v1_SafetyThresholds_init_default,   \
-      false, star_v1_EncoderConfiguration_init_default, false,                                     \
-      star_v1_TimingConfiguration_init_default, 0, 0                                               \
-  }
-#define star_v1_MotorPidConfiguration_init_default                                                 \
-  {                                                                                                \
-    0, false, star_v1_PidConfig_init_default                                                       \
-  }
-#define star_v1_CurrentSensorCalibration_init_default                                              \
-  {                                                                                                \
-    {{NULL}, NULL},                                                                                \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_TemperatureCalibration_init_default                                                \
-  {                                                                                                \
-    0                                                                                              \
-  }
-#define star_v1_SafetyThresholds_init_default                                                      \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_EncoderConfiguration_init_default                                                  \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_TimingConfiguration_init_default                                                   \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_ConfigValidationResult_init_default                                                \
-  {                                                                                                \
-    _star_v1_ConfigValidationStatus_MIN, 0,                                                        \
-    {                                                                                              \
-      star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default,      \
-        star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default,    \
-        star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default,    \
-        star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default     \
-    }                                                                                              \
-  }
-#define star_v1_ConfigValidationError_init_default                                                 \
-  {                                                                                                \
-    "", _star_v1_ConfigErrorCode_MIN, "", "", ""                                                   \
-  }
-#define star_v1_GetConfigurationRequest_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_GetConfigurationResponse_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemConfiguration_init_zero          \
-  }
-#define star_v1_SetConfigurationRequest_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_SystemConfiguration_init_zero, 0        \
-  }
-#define star_v1_SetConfigurationResponse_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_ConfigValidationResult_init_zero       \
-  }
-#define star_v1_ResetToDefaultsRequest_init_zero                                                   \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0                                                      \
-  }
-#define star_v1_ResetToDefaultsResponse_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemConfiguration_init_zero          \
-  }
-#define star_v1_ValidateConfigurationRequest_init_zero                                             \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_SystemConfiguration_init_zero           \
-  }
-#define star_v1_ValidateConfigurationResponse_init_zero                                            \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_ConfigValidationResult_init_zero       \
-  }
-#define star_v1_SaveConfigurationRequest_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_SaveConfigurationResponse_init_zero                                                \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, 0                                                  \
-  }
-#define star_v1_GetMotorPidConfigRequest_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0                                                      \
-  }
-#define star_v1_GetMotorPidConfigResponse_init_zero                                                \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, false, star_v1_PidConfig_init_zero                 \
-  }
-#define star_v1_SetMotorPidConfigRequest_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0, false, star_v1_PidConfig_init_zero, 0               \
-  }
-#define star_v1_SetMotorPidConfigResponse_init_zero                                                \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_ConfigValidationResult_init_zero       \
-  }
-#define star_v1_RetransmitConfig_init_zero                                                         \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_SetRetransmitConfigRequest_init_zero                                               \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_RetransmitConfig_init_zero              \
-  }
-#define star_v1_SetRetransmitConfigResponse_init_zero                                              \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero                                                        \
-  }
-#define star_v1_SystemConfiguration_init_zero                                                      \
-  {                                                                                                \
-    0,                                                                                             \
-      {star_v1_MotorPidConfiguration_init_zero,                                                    \
-       star_v1_MotorPidConfiguration_init_zero,                                                    \
-       star_v1_MotorPidConfiguration_init_zero,                                                    \
-       star_v1_MotorPidConfiguration_init_zero},                                                   \
-      false, star_v1_CurrentSensorCalibration_init_zero, false,                                    \
-      star_v1_TemperatureCalibration_init_zero, false, star_v1_SafetyThresholds_init_zero, false,  \
-      star_v1_EncoderConfiguration_init_zero, false, star_v1_TimingConfiguration_init_zero, 0, 0   \
-  }
-#define star_v1_MotorPidConfiguration_init_zero                                                    \
-  {                                                                                                \
-    0, false, star_v1_PidConfig_init_zero                                                          \
-  }
-#define star_v1_CurrentSensorCalibration_init_zero                                                 \
-  {                                                                                                \
-    {{NULL}, NULL},                                                                                \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_TemperatureCalibration_init_zero                                                   \
-  {                                                                                                \
-    0                                                                                              \
-  }
-#define star_v1_SafetyThresholds_init_zero                                                         \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_EncoderConfiguration_init_zero                                                     \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_TimingConfiguration_init_zero                                                      \
-  {                                                                                                \
-    0, 0, 0                                                                                        \
-  }
-#define star_v1_ConfigValidationResult_init_zero                                                   \
-  {                                                                                                \
-    _star_v1_ConfigValidationStatus_MIN, 0,                                                        \
-    {                                                                                              \
-      star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero,            \
-        star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero,          \
-        star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero,          \
-        star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero           \
-    }                                                                                              \
-  }
-#define star_v1_ConfigValidationError_init_zero                                                    \
-  {                                                                                                \
-    "", _star_v1_ConfigErrorCode_MIN, "", "", ""                                                   \
-  }
+#define star_v1_GetConfigurationRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_GetConfigurationResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_SystemConfiguration_init_default}
+#define star_v1_SetConfigurationRequest_init_default {false, star_v1_RequestHeader_init_default, false, star_v1_SystemConfiguration_init_default, 0}
+#define star_v1_SetConfigurationResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_ConfigValidationResult_init_default}
+#define star_v1_ResetToDefaultsRequest_init_default {false, star_v1_RequestHeader_init_default, 0}
+#define star_v1_ResetToDefaultsResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_SystemConfiguration_init_default}
+#define star_v1_ValidateConfigurationRequest_init_default {false, star_v1_RequestHeader_init_default, false, star_v1_SystemConfiguration_init_default}
+#define star_v1_ValidateConfigurationResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_ConfigValidationResult_init_default}
+#define star_v1_SaveConfigurationRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_SaveConfigurationResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, 0}
+#define star_v1_GetMotorPidConfigRequest_init_default {false, star_v1_RequestHeader_init_default, 0}
+#define star_v1_GetMotorPidConfigResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, false, star_v1_PidConfig_init_default}
+#define star_v1_SetMotorPidConfigRequest_init_default {false, star_v1_RequestHeader_init_default, 0, false, star_v1_PidConfig_init_default, 0}
+#define star_v1_SetMotorPidConfigResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_ConfigValidationResult_init_default}
+#define star_v1_RetransmitConfig_init_default    {0, 0, 0, 0}
+#define star_v1_SetRetransmitConfigRequest_init_default {false, star_v1_RequestHeader_init_default, false, star_v1_RetransmitConfig_init_default}
+#define star_v1_SetRetransmitConfigResponse_init_default {false, star_v1_ResponseHeader_init_default}
+#define star_v1_SystemConfiguration_init_default {0, {star_v1_MotorPidConfiguration_init_default, star_v1_MotorPidConfiguration_init_default, star_v1_MotorPidConfiguration_init_default, star_v1_MotorPidConfiguration_init_default}, false, star_v1_CurrentSensorCalibration_init_default, false, star_v1_TemperatureCalibration_init_default, false, star_v1_SafetyThresholds_init_default, false, star_v1_EncoderConfiguration_init_default, false, star_v1_TimingConfiguration_init_default, 0, 0}
+#define star_v1_MotorPidConfiguration_init_default {0, false, star_v1_PidConfig_init_default}
+#define star_v1_CurrentSensorCalibration_init_default {{{NULL}, NULL}, {{NULL}, NULL}}
+#define star_v1_TemperatureCalibration_init_default {0}
+#define star_v1_SafetyThresholds_init_default    {0, 0, 0}
+#define star_v1_EncoderConfiguration_init_default {0, 0, 0}
+#define star_v1_TimingConfiguration_init_default {0, 0, 0}
+#define star_v1_ConfigValidationResult_init_default {_star_v1_ConfigValidationStatus_MIN, 0, {star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default, star_v1_ConfigValidationError_init_default}}
+#define star_v1_ConfigValidationError_init_default {"", _star_v1_ConfigErrorCode_MIN, "", "", ""}
+#define star_v1_GetConfigurationRequest_init_zero {false, star_v1_RequestHeader_init_zero}
+#define star_v1_GetConfigurationResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemConfiguration_init_zero}
+#define star_v1_SetConfigurationRequest_init_zero {false, star_v1_RequestHeader_init_zero, false, star_v1_SystemConfiguration_init_zero, 0}
+#define star_v1_SetConfigurationResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_ConfigValidationResult_init_zero}
+#define star_v1_ResetToDefaultsRequest_init_zero {false, star_v1_RequestHeader_init_zero, 0}
+#define star_v1_ResetToDefaultsResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemConfiguration_init_zero}
+#define star_v1_ValidateConfigurationRequest_init_zero {false, star_v1_RequestHeader_init_zero, false, star_v1_SystemConfiguration_init_zero}
+#define star_v1_ValidateConfigurationResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_ConfigValidationResult_init_zero}
+#define star_v1_SaveConfigurationRequest_init_zero {false, star_v1_RequestHeader_init_zero}
+#define star_v1_SaveConfigurationResponse_init_zero {false, star_v1_ResponseHeader_init_zero, 0, 0}
+#define star_v1_GetMotorPidConfigRequest_init_zero {false, star_v1_RequestHeader_init_zero, 0}
+#define star_v1_GetMotorPidConfigResponse_init_zero {false, star_v1_ResponseHeader_init_zero, 0, false, star_v1_PidConfig_init_zero}
+#define star_v1_SetMotorPidConfigRequest_init_zero {false, star_v1_RequestHeader_init_zero, 0, false, star_v1_PidConfig_init_zero, 0}
+#define star_v1_SetMotorPidConfigResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_ConfigValidationResult_init_zero}
+#define star_v1_RetransmitConfig_init_zero       {0, 0, 0, 0}
+#define star_v1_SetRetransmitConfigRequest_init_zero {false, star_v1_RequestHeader_init_zero, false, star_v1_RetransmitConfig_init_zero}
+#define star_v1_SetRetransmitConfigResponse_init_zero {false, star_v1_ResponseHeader_init_zero}
+#define star_v1_SystemConfiguration_init_zero    {0, {star_v1_MotorPidConfiguration_init_zero, star_v1_MotorPidConfiguration_init_zero, star_v1_MotorPidConfiguration_init_zero, star_v1_MotorPidConfiguration_init_zero}, false, star_v1_CurrentSensorCalibration_init_zero, false, star_v1_TemperatureCalibration_init_zero, false, star_v1_SafetyThresholds_init_zero, false, star_v1_EncoderConfiguration_init_zero, false, star_v1_TimingConfiguration_init_zero, 0, 0}
+#define star_v1_MotorPidConfiguration_init_zero  {0, false, star_v1_PidConfig_init_zero}
+#define star_v1_CurrentSensorCalibration_init_zero {{{NULL}, NULL}, {{NULL}, NULL}}
+#define star_v1_TemperatureCalibration_init_zero {0}
+#define star_v1_SafetyThresholds_init_zero       {0, 0, 0}
+#define star_v1_EncoderConfiguration_init_zero   {0, 0, 0}
+#define star_v1_TimingConfiguration_init_zero    {0, 0, 0}
+#define star_v1_ConfigValidationResult_init_zero {_star_v1_ConfigValidationStatus_MIN, 0, {star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero, star_v1_ConfigValidationError_init_zero}}
+#define star_v1_ConfigValidationError_init_zero  {"", _star_v1_ConfigErrorCode_MIN, "", "", ""}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_GetConfigurationRequest_header_tag                  1
-#define star_v1_ResetToDefaultsRequest_header_tag                   1
-#define star_v1_ResetToDefaultsRequest_persist_to_nvs_tag           2
-#define star_v1_SaveConfigurationRequest_header_tag                 1
-#define star_v1_SaveConfigurationResponse_header_tag                1
-#define star_v1_SaveConfigurationResponse_saved_tag                 2
-#define star_v1_SaveConfigurationResponse_config_crc_tag            3
-#define star_v1_GetMotorPidConfigRequest_header_tag                 1
-#define star_v1_GetMotorPidConfigRequest_motor_id_tag               2
-#define star_v1_GetMotorPidConfigResponse_header_tag                1
-#define star_v1_GetMotorPidConfigResponse_motor_id_tag              2
-#define star_v1_GetMotorPidConfigResponse_pid_config_tag            3
-#define star_v1_SetMotorPidConfigRequest_header_tag                 1
-#define star_v1_SetMotorPidConfigRequest_motor_id_tag               2
-#define star_v1_SetMotorPidConfigRequest_pid_config_tag             3
-#define star_v1_SetMotorPidConfigRequest_persist_to_nvs_tag         4
-#define star_v1_RetransmitConfig_enabled_tag                        1
-#define star_v1_RetransmitConfig_max_retries_tag                    2
-#define star_v1_RetransmitConfig_ack_timeout_ms_tag                 3
-#define star_v1_RetransmitConfig_max_backoff_ms_tag                 4
-#define star_v1_SetRetransmitConfigRequest_header_tag               1
-#define star_v1_SetRetransmitConfigRequest_retransmit_config_tag    2
-#define star_v1_SetRetransmitConfigResponse_header_tag              1
-#define star_v1_MotorPidConfiguration_motor_id_tag                  1
-#define star_v1_MotorPidConfiguration_pid_config_tag                2
-#define star_v1_CurrentSensorCalibration_offset_ma_tag              1
-#define star_v1_CurrentSensorCalibration_scale_factor_tag           2
-#define star_v1_TemperatureCalibration_offset_celsius_tag           1
-#define star_v1_SafetyThresholds_overcurrent_threshold_ma_tag       1
-#define star_v1_SafetyThresholds_thermal_shutdown_deci_celsius_tag  2
-#define star_v1_SafetyThresholds_cell_imbalance_threshold_mv_tag    3
-#define star_v1_EncoderConfiguration_edges_per_revolution_tag       1
-#define star_v1_EncoderConfiguration_wheel_diameter_m_tag           2
-#define star_v1_EncoderConfiguration_gear_ratio_tag                 3
-#define star_v1_TimingConfiguration_motor_control_period_ms_tag     1
-#define star_v1_TimingConfiguration_telemetry_period_ms_tag         2
-#define star_v1_TimingConfiguration_communication_timeout_ms_tag    3
-#define star_v1_SystemConfiguration_motor_configs_tag               1
-#define star_v1_SystemConfiguration_current_calibration_tag         2
-#define star_v1_SystemConfiguration_temperature_calibration_tag     3
-#define star_v1_SystemConfiguration_safety_thresholds_tag           4
-#define star_v1_SystemConfiguration_encoder_config_tag              5
-#define star_v1_SystemConfiguration_timing_config_tag               6
-#define star_v1_SystemConfiguration_config_version_tag              7
-#define star_v1_SystemConfiguration_config_crc_tag                  8
-#define star_v1_GetConfigurationResponse_header_tag                 1
-#define star_v1_GetConfigurationResponse_configuration_tag          2
-#define star_v1_SetConfigurationRequest_header_tag                  1
-#define star_v1_SetConfigurationRequest_configuration_tag           2
-#define star_v1_SetConfigurationRequest_persist_to_nvs_tag          3
-#define star_v1_ResetToDefaultsResponse_header_tag                  1
-#define star_v1_ResetToDefaultsResponse_configuration_tag           2
-#define star_v1_ValidateConfigurationRequest_header_tag             1
-#define star_v1_ValidateConfigurationRequest_configuration_tag      2
-#define star_v1_ConfigValidationError_field_path_tag                1
-#define star_v1_ConfigValidationError_error_code_tag                2
-#define star_v1_ConfigValidationError_message_tag                   3
-#define star_v1_ConfigValidationError_actual_value_tag              4
-#define star_v1_ConfigValidationError_expected_constraint_tag       5
-#define star_v1_ConfigValidationResult_status_tag                   1
-#define star_v1_ConfigValidationResult_errors_tag                   2
-#define star_v1_SetConfigurationResponse_header_tag                 1
-#define star_v1_SetConfigurationResponse_validation_result_tag      2
-#define star_v1_ValidateConfigurationResponse_header_tag            1
+#define star_v1_GetConfigurationRequest_header_tag 1
+#define star_v1_ResetToDefaultsRequest_header_tag 1
+#define star_v1_ResetToDefaultsRequest_persist_to_nvs_tag 2
+#define star_v1_SaveConfigurationRequest_header_tag 1
+#define star_v1_SaveConfigurationResponse_header_tag 1
+#define star_v1_SaveConfigurationResponse_saved_tag 2
+#define star_v1_SaveConfigurationResponse_config_crc_tag 3
+#define star_v1_GetMotorPidConfigRequest_header_tag 1
+#define star_v1_GetMotorPidConfigRequest_motor_id_tag 2
+#define star_v1_GetMotorPidConfigResponse_header_tag 1
+#define star_v1_GetMotorPidConfigResponse_motor_id_tag 2
+#define star_v1_GetMotorPidConfigResponse_pid_config_tag 3
+#define star_v1_SetMotorPidConfigRequest_header_tag 1
+#define star_v1_SetMotorPidConfigRequest_motor_id_tag 2
+#define star_v1_SetMotorPidConfigRequest_pid_config_tag 3
+#define star_v1_SetMotorPidConfigRequest_persist_to_nvs_tag 4
+#define star_v1_RetransmitConfig_enabled_tag     1
+#define star_v1_RetransmitConfig_max_retries_tag 2
+#define star_v1_RetransmitConfig_ack_timeout_ms_tag 3
+#define star_v1_RetransmitConfig_max_backoff_ms_tag 4
+#define star_v1_SetRetransmitConfigRequest_header_tag 1
+#define star_v1_SetRetransmitConfigRequest_retransmit_config_tag 2
+#define star_v1_SetRetransmitConfigResponse_header_tag 1
+#define star_v1_MotorPidConfiguration_motor_id_tag 1
+#define star_v1_MotorPidConfiguration_pid_config_tag 2
+#define star_v1_CurrentSensorCalibration_offset_ma_tag 1
+#define star_v1_CurrentSensorCalibration_scale_factor_tag 2
+#define star_v1_TemperatureCalibration_offset_celsius_tag 1
+#define star_v1_SafetyThresholds_overcurrent_threshold_ma_tag 1
+#define star_v1_SafetyThresholds_thermal_shutdown_deci_celsius_tag 2
+#define star_v1_SafetyThresholds_cell_imbalance_threshold_mv_tag 3
+#define star_v1_EncoderConfiguration_edges_per_revolution_tag 1
+#define star_v1_EncoderConfiguration_wheel_diameter_m_tag 2
+#define star_v1_EncoderConfiguration_gear_ratio_tag 3
+#define star_v1_TimingConfiguration_motor_control_period_ms_tag 1
+#define star_v1_TimingConfiguration_telemetry_period_ms_tag 2
+#define star_v1_TimingConfiguration_communication_timeout_ms_tag 3
+#define star_v1_SystemConfiguration_motor_configs_tag 1
+#define star_v1_SystemConfiguration_current_calibration_tag 2
+#define star_v1_SystemConfiguration_temperature_calibration_tag 3
+#define star_v1_SystemConfiguration_safety_thresholds_tag 4
+#define star_v1_SystemConfiguration_encoder_config_tag 5
+#define star_v1_SystemConfiguration_timing_config_tag 6
+#define star_v1_SystemConfiguration_config_version_tag 7
+#define star_v1_SystemConfiguration_config_crc_tag 8
+#define star_v1_GetConfigurationResponse_header_tag 1
+#define star_v1_GetConfigurationResponse_configuration_tag 2
+#define star_v1_SetConfigurationRequest_header_tag 1
+#define star_v1_SetConfigurationRequest_configuration_tag 2
+#define star_v1_SetConfigurationRequest_persist_to_nvs_tag 3
+#define star_v1_ResetToDefaultsResponse_header_tag 1
+#define star_v1_ResetToDefaultsResponse_configuration_tag 2
+#define star_v1_ValidateConfigurationRequest_header_tag 1
+#define star_v1_ValidateConfigurationRequest_configuration_tag 2
+#define star_v1_ConfigValidationError_field_path_tag 1
+#define star_v1_ConfigValidationError_error_code_tag 2
+#define star_v1_ConfigValidationError_message_tag 3
+#define star_v1_ConfigValidationError_actual_value_tag 4
+#define star_v1_ConfigValidationError_expected_constraint_tag 5
+#define star_v1_ConfigValidationResult_status_tag 1
+#define star_v1_ConfigValidationResult_errors_tag 2
+#define star_v1_SetConfigurationResponse_header_tag 1
+#define star_v1_SetConfigurationResponse_validation_result_tag 2
+#define star_v1_ValidateConfigurationResponse_header_tag 1
 #define star_v1_ValidateConfigurationResponse_validation_result_tag 2
-#define star_v1_SetMotorPidConfigResponse_header_tag                1
-#define star_v1_SetMotorPidConfigResponse_validation_result_tag     2
+#define star_v1_SetMotorPidConfigResponse_header_tag 1
+#define star_v1_SetMotorPidConfigResponse_validation_result_tag 2
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_GetConfigurationRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetConfigurationRequest_CALLBACK        NULL
-#define star_v1_GetConfigurationRequest_DEFAULT         NULL
-#define star_v1_GetConfigurationRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_GetConfigurationRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_GetConfigurationRequest_CALLBACK NULL
+#define star_v1_GetConfigurationRequest_DEFAULT NULL
+#define star_v1_GetConfigurationRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetConfigurationResponse_FIELDLIST(X, a)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)
-#define star_v1_GetConfigurationResponse_CALLBACK              NULL
-#define star_v1_GetConfigurationResponse_DEFAULT               NULL
-#define star_v1_GetConfigurationResponse_header_MSGTYPE        star_v1_ResponseHeader
+#define star_v1_GetConfigurationResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  configuration,     2)
+#define star_v1_GetConfigurationResponse_CALLBACK NULL
+#define star_v1_GetConfigurationResponse_DEFAULT NULL
+#define star_v1_GetConfigurationResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetConfigurationResponse_configuration_MSGTYPE star_v1_SystemConfiguration
 
-#define star_v1_SetConfigurationRequest_FIELDLIST(X, a)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)                                                \
-  X(a, STATIC, SINGULAR, BOOL, persist_to_nvs, 3)
-#define star_v1_SetConfigurationRequest_CALLBACK              NULL
-#define star_v1_SetConfigurationRequest_DEFAULT               NULL
-#define star_v1_SetConfigurationRequest_header_MSGTYPE        star_v1_RequestHeader
+#define star_v1_SetConfigurationRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  configuration,     2) \
+X(a, STATIC,   SINGULAR, BOOL,     persist_to_nvs,    3)
+#define star_v1_SetConfigurationRequest_CALLBACK NULL
+#define star_v1_SetConfigurationRequest_DEFAULT NULL
+#define star_v1_SetConfigurationRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_SetConfigurationRequest_configuration_MSGTYPE star_v1_SystemConfiguration
 
-#define star_v1_SetConfigurationResponse_FIELDLIST(X, a)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, validation_result, 2)
-#define star_v1_SetConfigurationResponse_CALLBACK                  NULL
-#define star_v1_SetConfigurationResponse_DEFAULT                   NULL
-#define star_v1_SetConfigurationResponse_header_MSGTYPE            star_v1_ResponseHeader
+#define star_v1_SetConfigurationResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  validation_result,   2)
+#define star_v1_SetConfigurationResponse_CALLBACK NULL
+#define star_v1_SetConfigurationResponse_DEFAULT NULL
+#define star_v1_SetConfigurationResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_SetConfigurationResponse_validation_result_MSGTYPE star_v1_ConfigValidationResult
 
-#define star_v1_ResetToDefaultsRequest_FIELDLIST(X, a)                                             \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, persist_to_nvs, 2)
-#define star_v1_ResetToDefaultsRequest_CALLBACK       NULL
-#define star_v1_ResetToDefaultsRequest_DEFAULT        NULL
+#define star_v1_ResetToDefaultsRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     persist_to_nvs,    2)
+#define star_v1_ResetToDefaultsRequest_CALLBACK NULL
+#define star_v1_ResetToDefaultsRequest_DEFAULT NULL
 #define star_v1_ResetToDefaultsRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_ResetToDefaultsResponse_FIELDLIST(X, a)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)
-#define star_v1_ResetToDefaultsResponse_CALLBACK              NULL
-#define star_v1_ResetToDefaultsResponse_DEFAULT               NULL
-#define star_v1_ResetToDefaultsResponse_header_MSGTYPE        star_v1_ResponseHeader
+#define star_v1_ResetToDefaultsResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  configuration,     2)
+#define star_v1_ResetToDefaultsResponse_CALLBACK NULL
+#define star_v1_ResetToDefaultsResponse_DEFAULT NULL
+#define star_v1_ResetToDefaultsResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_ResetToDefaultsResponse_configuration_MSGTYPE star_v1_SystemConfiguration
 
-#define star_v1_ValidateConfigurationRequest_FIELDLIST(X, a)                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, configuration, 2)
-#define star_v1_ValidateConfigurationRequest_CALLBACK              NULL
-#define star_v1_ValidateConfigurationRequest_DEFAULT               NULL
-#define star_v1_ValidateConfigurationRequest_header_MSGTYPE        star_v1_RequestHeader
+#define star_v1_ValidateConfigurationRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  configuration,     2)
+#define star_v1_ValidateConfigurationRequest_CALLBACK NULL
+#define star_v1_ValidateConfigurationRequest_DEFAULT NULL
+#define star_v1_ValidateConfigurationRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_ValidateConfigurationRequest_configuration_MSGTYPE star_v1_SystemConfiguration
 
-#define star_v1_ValidateConfigurationResponse_FIELDLIST(X, a)                                      \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, validation_result, 2)
-#define star_v1_ValidateConfigurationResponse_CALLBACK       NULL
-#define star_v1_ValidateConfigurationResponse_DEFAULT        NULL
+#define star_v1_ValidateConfigurationResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  validation_result,   2)
+#define star_v1_ValidateConfigurationResponse_CALLBACK NULL
+#define star_v1_ValidateConfigurationResponse_DEFAULT NULL
 #define star_v1_ValidateConfigurationResponse_header_MSGTYPE star_v1_ResponseHeader
-#define star_v1_ValidateConfigurationResponse_validation_result_MSGTYPE                            \
-  star_v1_ConfigValidationResult
+#define star_v1_ValidateConfigurationResponse_validation_result_MSGTYPE star_v1_ConfigValidationResult
 
-#define star_v1_SaveConfigurationRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SaveConfigurationRequest_CALLBACK        NULL
-#define star_v1_SaveConfigurationRequest_DEFAULT         NULL
-#define star_v1_SaveConfigurationRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_SaveConfigurationRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_SaveConfigurationRequest_CALLBACK NULL
+#define star_v1_SaveConfigurationRequest_DEFAULT NULL
+#define star_v1_SaveConfigurationRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_SaveConfigurationResponse_FIELDLIST(X, a)                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, saved, 2)                                                           \
-  X(a, STATIC, SINGULAR, UINT32, config_crc, 3)
-#define star_v1_SaveConfigurationResponse_CALLBACK       NULL
-#define star_v1_SaveConfigurationResponse_DEFAULT        NULL
+#define star_v1_SaveConfigurationResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     saved,             2) \
+X(a, STATIC,   SINGULAR, UINT32,   config_crc,        3)
+#define star_v1_SaveConfigurationResponse_CALLBACK NULL
+#define star_v1_SaveConfigurationResponse_DEFAULT NULL
 #define star_v1_SaveConfigurationResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_GetMotorPidConfigRequest_FIELDLIST(X, a)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 2)
-#define star_v1_GetMotorPidConfigRequest_CALLBACK       NULL
-#define star_v1_GetMotorPidConfigRequest_DEFAULT        NULL
+#define star_v1_GetMotorPidConfigRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          2)
+#define star_v1_GetMotorPidConfigRequest_CALLBACK NULL
+#define star_v1_GetMotorPidConfigRequest_DEFAULT NULL
 #define star_v1_GetMotorPidConfigRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetMotorPidConfigResponse_FIELDLIST(X, a)                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 2)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 3)
-#define star_v1_GetMotorPidConfigResponse_CALLBACK           NULL
-#define star_v1_GetMotorPidConfigResponse_DEFAULT            NULL
-#define star_v1_GetMotorPidConfigResponse_header_MSGTYPE     star_v1_ResponseHeader
+#define star_v1_GetMotorPidConfigResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  pid_config,        3)
+#define star_v1_GetMotorPidConfigResponse_CALLBACK NULL
+#define star_v1_GetMotorPidConfigResponse_DEFAULT NULL
+#define star_v1_GetMotorPidConfigResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetMotorPidConfigResponse_pid_config_MSGTYPE star_v1_PidConfig
 
-#define star_v1_SetMotorPidConfigRequest_FIELDLIST(X, a)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 2)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 3)                                                   \
-  X(a, STATIC, SINGULAR, BOOL, persist_to_nvs, 4)
-#define star_v1_SetMotorPidConfigRequest_CALLBACK           NULL
-#define star_v1_SetMotorPidConfigRequest_DEFAULT            NULL
-#define star_v1_SetMotorPidConfigRequest_header_MSGTYPE     star_v1_RequestHeader
+#define star_v1_SetMotorPidConfigRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  pid_config,        3) \
+X(a, STATIC,   SINGULAR, BOOL,     persist_to_nvs,    4)
+#define star_v1_SetMotorPidConfigRequest_CALLBACK NULL
+#define star_v1_SetMotorPidConfigRequest_DEFAULT NULL
+#define star_v1_SetMotorPidConfigRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_SetMotorPidConfigRequest_pid_config_MSGTYPE star_v1_PidConfig
 
-#define star_v1_SetMotorPidConfigResponse_FIELDLIST(X, a)                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, validation_result, 2)
-#define star_v1_SetMotorPidConfigResponse_CALLBACK                  NULL
-#define star_v1_SetMotorPidConfigResponse_DEFAULT                   NULL
-#define star_v1_SetMotorPidConfigResponse_header_MSGTYPE            star_v1_ResponseHeader
+#define star_v1_SetMotorPidConfigResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  validation_result,   2)
+#define star_v1_SetMotorPidConfigResponse_CALLBACK NULL
+#define star_v1_SetMotorPidConfigResponse_DEFAULT NULL
+#define star_v1_SetMotorPidConfigResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_SetMotorPidConfigResponse_validation_result_MSGTYPE star_v1_ConfigValidationResult
 
-#define star_v1_RetransmitConfig_FIELDLIST(X, a)                                                   \
-  X(a, STATIC, SINGULAR, BOOL, enabled, 1)                                                         \
-  X(a, STATIC, SINGULAR, UINT32, max_retries, 2)                                                   \
-  X(a, STATIC, SINGULAR, UINT32, ack_timeout_ms, 3)                                                \
-  X(a, STATIC, SINGULAR, UINT32, max_backoff_ms, 4)
+#define star_v1_RetransmitConfig_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, BOOL,     enabled,           1) \
+X(a, STATIC,   SINGULAR, UINT32,   max_retries,       2) \
+X(a, STATIC,   SINGULAR, UINT32,   ack_timeout_ms,    3) \
+X(a, STATIC,   SINGULAR, UINT32,   max_backoff_ms,    4)
 #define star_v1_RetransmitConfig_CALLBACK NULL
-#define star_v1_RetransmitConfig_DEFAULT  NULL
+#define star_v1_RetransmitConfig_DEFAULT NULL
 
-#define star_v1_SetRetransmitConfigRequest_FIELDLIST(X, a)                                         \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, retransmit_config, 2)
-#define star_v1_SetRetransmitConfigRequest_CALLBACK                  NULL
-#define star_v1_SetRetransmitConfigRequest_DEFAULT                   NULL
-#define star_v1_SetRetransmitConfigRequest_header_MSGTYPE            star_v1_RequestHeader
+#define star_v1_SetRetransmitConfigRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  retransmit_config,   2)
+#define star_v1_SetRetransmitConfigRequest_CALLBACK NULL
+#define star_v1_SetRetransmitConfigRequest_DEFAULT NULL
+#define star_v1_SetRetransmitConfigRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_SetRetransmitConfigRequest_retransmit_config_MSGTYPE star_v1_RetransmitConfig
 
-#define star_v1_SetRetransmitConfigResponse_FIELDLIST(X, a)                                        \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SetRetransmitConfigResponse_CALLBACK       NULL
-#define star_v1_SetRetransmitConfigResponse_DEFAULT        NULL
+#define star_v1_SetRetransmitConfigResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_SetRetransmitConfigResponse_CALLBACK NULL
+#define star_v1_SetRetransmitConfigResponse_DEFAULT NULL
 #define star_v1_SetRetransmitConfigResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_SystemConfiguration_FIELDLIST(X, a)                                                \
-  X(a, STATIC, REPEATED, MESSAGE, motor_configs, 1)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, current_calibration, 2)                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, temperature_calibration, 3)                                      \
-  X(a, STATIC, OPTIONAL, MESSAGE, safety_thresholds, 4)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, encoder_config, 5)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, timing_config, 6)                                                \
-  X(a, STATIC, SINGULAR, UINT32, config_version, 7)                                                \
-  X(a, STATIC, SINGULAR, UINT32, config_crc, 8)
-#define star_v1_SystemConfiguration_CALLBACK                        NULL
-#define star_v1_SystemConfiguration_DEFAULT                         NULL
-#define star_v1_SystemConfiguration_motor_configs_MSGTYPE           star_v1_MotorPidConfiguration
-#define star_v1_SystemConfiguration_current_calibration_MSGTYPE     star_v1_CurrentSensorCalibration
+#define star_v1_SystemConfiguration_FIELDLIST(X, a) \
+X(a, STATIC,   REPEATED, MESSAGE,  motor_configs,     1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  current_calibration,   2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  temperature_calibration,   3) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  safety_thresholds,   4) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  encoder_config,    5) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  timing_config,     6) \
+X(a, STATIC,   SINGULAR, UINT32,   config_version,    7) \
+X(a, STATIC,   SINGULAR, UINT32,   config_crc,        8)
+#define star_v1_SystemConfiguration_CALLBACK NULL
+#define star_v1_SystemConfiguration_DEFAULT NULL
+#define star_v1_SystemConfiguration_motor_configs_MSGTYPE star_v1_MotorPidConfiguration
+#define star_v1_SystemConfiguration_current_calibration_MSGTYPE star_v1_CurrentSensorCalibration
 #define star_v1_SystemConfiguration_temperature_calibration_MSGTYPE star_v1_TemperatureCalibration
-#define star_v1_SystemConfiguration_safety_thresholds_MSGTYPE       star_v1_SafetyThresholds
-#define star_v1_SystemConfiguration_encoder_config_MSGTYPE          star_v1_EncoderConfiguration
-#define star_v1_SystemConfiguration_timing_config_MSGTYPE           star_v1_TimingConfiguration
+#define star_v1_SystemConfiguration_safety_thresholds_MSGTYPE star_v1_SafetyThresholds
+#define star_v1_SystemConfiguration_encoder_config_MSGTYPE star_v1_EncoderConfiguration
+#define star_v1_SystemConfiguration_timing_config_MSGTYPE star_v1_TimingConfiguration
 
-#define star_v1_MotorPidConfiguration_FIELDLIST(X, a)                                              \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 2)
-#define star_v1_MotorPidConfiguration_CALLBACK           NULL
-#define star_v1_MotorPidConfiguration_DEFAULT            NULL
+#define star_v1_MotorPidConfiguration_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  pid_config,        2)
+#define star_v1_MotorPidConfiguration_CALLBACK NULL
+#define star_v1_MotorPidConfiguration_DEFAULT NULL
 #define star_v1_MotorPidConfiguration_pid_config_MSGTYPE star_v1_PidConfig
 
-#define star_v1_CurrentSensorCalibration_FIELDLIST(X, a)                                           \
-  X(a, CALLBACK, REPEATED, DOUBLE, offset_ma, 1)                                                   \
-  X(a, CALLBACK, REPEATED, DOUBLE, scale_factor, 2)
+#define star_v1_CurrentSensorCalibration_FIELDLIST(X, a) \
+X(a, CALLBACK, REPEATED, DOUBLE,   offset_ma,         1) \
+X(a, CALLBACK, REPEATED, DOUBLE,   scale_factor,      2)
 #define star_v1_CurrentSensorCalibration_CALLBACK pb_default_field_callback
-#define star_v1_CurrentSensorCalibration_DEFAULT  NULL
+#define star_v1_CurrentSensorCalibration_DEFAULT NULL
 
-#define star_v1_TemperatureCalibration_FIELDLIST(X, a)                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, offset_celsius, 1)
+#define star_v1_TemperatureCalibration_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   offset_celsius,    1)
 #define star_v1_TemperatureCalibration_CALLBACK NULL
-#define star_v1_TemperatureCalibration_DEFAULT  NULL
+#define star_v1_TemperatureCalibration_DEFAULT NULL
 
-#define star_v1_SafetyThresholds_FIELDLIST(X, a)                                                   \
-  X(a, STATIC, SINGULAR, UINT32, overcurrent_threshold_ma, 1)                                      \
-  X(a, STATIC, SINGULAR, INT32, thermal_shutdown_deci_celsius, 2)                                  \
-  X(a, STATIC, SINGULAR, UINT32, cell_imbalance_threshold_mv, 3)
+#define star_v1_SafetyThresholds_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   overcurrent_threshold_ma,   1) \
+X(a, STATIC,   SINGULAR, INT32,    thermal_shutdown_deci_celsius,   2) \
+X(a, STATIC,   SINGULAR, UINT32,   cell_imbalance_threshold_mv,   3)
 #define star_v1_SafetyThresholds_CALLBACK NULL
-#define star_v1_SafetyThresholds_DEFAULT  NULL
+#define star_v1_SafetyThresholds_DEFAULT NULL
 
-#define star_v1_EncoderConfiguration_FIELDLIST(X, a)                                               \
-  X(a, STATIC, SINGULAR, UINT32, edges_per_revolution, 1)                                          \
-  X(a, STATIC, SINGULAR, DOUBLE, wheel_diameter_m, 2)                                              \
-  X(a, STATIC, SINGULAR, DOUBLE, gear_ratio, 3)
+#define star_v1_EncoderConfiguration_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   edges_per_revolution,   1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   wheel_diameter_m,   2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   gear_ratio,        3)
 #define star_v1_EncoderConfiguration_CALLBACK NULL
-#define star_v1_EncoderConfiguration_DEFAULT  NULL
+#define star_v1_EncoderConfiguration_DEFAULT NULL
 
-#define star_v1_TimingConfiguration_FIELDLIST(X, a)                                                \
-  X(a, STATIC, SINGULAR, UINT32, motor_control_period_ms, 1)                                       \
-  X(a, STATIC, SINGULAR, UINT32, telemetry_period_ms, 2)                                           \
-  X(a, STATIC, SINGULAR, UINT32, communication_timeout_ms, 3)
+#define star_v1_TimingConfiguration_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   motor_control_period_ms,   1) \
+X(a, STATIC,   SINGULAR, UINT32,   telemetry_period_ms,   2) \
+X(a, STATIC,   SINGULAR, UINT32,   communication_timeout_ms,   3)
 #define star_v1_TimingConfiguration_CALLBACK NULL
-#define star_v1_TimingConfiguration_DEFAULT  NULL
+#define star_v1_TimingConfiguration_DEFAULT NULL
 
-#define star_v1_ConfigValidationResult_FIELDLIST(X, a)                                             \
-  X(a, STATIC, SINGULAR, UENUM, status, 1)                                                         \
-  X(a, STATIC, REPEATED, MESSAGE, errors, 2)
-#define star_v1_ConfigValidationResult_CALLBACK       NULL
-#define star_v1_ConfigValidationResult_DEFAULT        NULL
+#define star_v1_ConfigValidationResult_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UENUM,    status,            1) \
+X(a, STATIC,   REPEATED, MESSAGE,  errors,            2)
+#define star_v1_ConfigValidationResult_CALLBACK NULL
+#define star_v1_ConfigValidationResult_DEFAULT NULL
 #define star_v1_ConfigValidationResult_errors_MSGTYPE star_v1_ConfigValidationError
 
-#define star_v1_ConfigValidationError_FIELDLIST(X, a)                                              \
-  X(a, STATIC, SINGULAR, STRING, field_path, 1)                                                    \
-  X(a, STATIC, SINGULAR, UENUM, error_code, 2)                                                     \
-  X(a, STATIC, SINGULAR, STRING, message, 3)                                                       \
-  X(a, STATIC, SINGULAR, STRING, actual_value, 4)                                                  \
-  X(a, STATIC, SINGULAR, STRING, expected_constraint, 5)
+#define star_v1_ConfigValidationError_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, STRING,   field_path,        1) \
+X(a, STATIC,   SINGULAR, UENUM,    error_code,        2) \
+X(a, STATIC,   SINGULAR, STRING,   message,           3) \
+X(a, STATIC,   SINGULAR, STRING,   actual_value,      4) \
+X(a, STATIC,   SINGULAR, STRING,   expected_constraint,   5)
 #define star_v1_ConfigValidationError_CALLBACK NULL
-#define star_v1_ConfigValidationError_DEFAULT  NULL
+#define star_v1_ConfigValidationError_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_GetConfigurationRequest_msg;
 extern const pb_msgdesc_t star_v1_GetConfigurationResponse_msg;
@@ -922,32 +754,32 @@ extern const pb_msgdesc_t star_v1_ConfigValidationResult_msg;
 extern const pb_msgdesc_t star_v1_ConfigValidationError_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_GetConfigurationRequest_fields       &star_v1_GetConfigurationRequest_msg
-#define star_v1_GetConfigurationResponse_fields      &star_v1_GetConfigurationResponse_msg
-#define star_v1_SetConfigurationRequest_fields       &star_v1_SetConfigurationRequest_msg
-#define star_v1_SetConfigurationResponse_fields      &star_v1_SetConfigurationResponse_msg
-#define star_v1_ResetToDefaultsRequest_fields        &star_v1_ResetToDefaultsRequest_msg
-#define star_v1_ResetToDefaultsResponse_fields       &star_v1_ResetToDefaultsResponse_msg
-#define star_v1_ValidateConfigurationRequest_fields  &star_v1_ValidateConfigurationRequest_msg
+#define star_v1_GetConfigurationRequest_fields &star_v1_GetConfigurationRequest_msg
+#define star_v1_GetConfigurationResponse_fields &star_v1_GetConfigurationResponse_msg
+#define star_v1_SetConfigurationRequest_fields &star_v1_SetConfigurationRequest_msg
+#define star_v1_SetConfigurationResponse_fields &star_v1_SetConfigurationResponse_msg
+#define star_v1_ResetToDefaultsRequest_fields &star_v1_ResetToDefaultsRequest_msg
+#define star_v1_ResetToDefaultsResponse_fields &star_v1_ResetToDefaultsResponse_msg
+#define star_v1_ValidateConfigurationRequest_fields &star_v1_ValidateConfigurationRequest_msg
 #define star_v1_ValidateConfigurationResponse_fields &star_v1_ValidateConfigurationResponse_msg
-#define star_v1_SaveConfigurationRequest_fields      &star_v1_SaveConfigurationRequest_msg
-#define star_v1_SaveConfigurationResponse_fields     &star_v1_SaveConfigurationResponse_msg
-#define star_v1_GetMotorPidConfigRequest_fields      &star_v1_GetMotorPidConfigRequest_msg
-#define star_v1_GetMotorPidConfigResponse_fields     &star_v1_GetMotorPidConfigResponse_msg
-#define star_v1_SetMotorPidConfigRequest_fields      &star_v1_SetMotorPidConfigRequest_msg
-#define star_v1_SetMotorPidConfigResponse_fields     &star_v1_SetMotorPidConfigResponse_msg
-#define star_v1_RetransmitConfig_fields              &star_v1_RetransmitConfig_msg
-#define star_v1_SetRetransmitConfigRequest_fields    &star_v1_SetRetransmitConfigRequest_msg
-#define star_v1_SetRetransmitConfigResponse_fields   &star_v1_SetRetransmitConfigResponse_msg
-#define star_v1_SystemConfiguration_fields           &star_v1_SystemConfiguration_msg
-#define star_v1_MotorPidConfiguration_fields         &star_v1_MotorPidConfiguration_msg
-#define star_v1_CurrentSensorCalibration_fields      &star_v1_CurrentSensorCalibration_msg
-#define star_v1_TemperatureCalibration_fields        &star_v1_TemperatureCalibration_msg
-#define star_v1_SafetyThresholds_fields              &star_v1_SafetyThresholds_msg
-#define star_v1_EncoderConfiguration_fields          &star_v1_EncoderConfiguration_msg
-#define star_v1_TimingConfiguration_fields           &star_v1_TimingConfiguration_msg
-#define star_v1_ConfigValidationResult_fields        &star_v1_ConfigValidationResult_msg
-#define star_v1_ConfigValidationError_fields         &star_v1_ConfigValidationError_msg
+#define star_v1_SaveConfigurationRequest_fields &star_v1_SaveConfigurationRequest_msg
+#define star_v1_SaveConfigurationResponse_fields &star_v1_SaveConfigurationResponse_msg
+#define star_v1_GetMotorPidConfigRequest_fields &star_v1_GetMotorPidConfigRequest_msg
+#define star_v1_GetMotorPidConfigResponse_fields &star_v1_GetMotorPidConfigResponse_msg
+#define star_v1_SetMotorPidConfigRequest_fields &star_v1_SetMotorPidConfigRequest_msg
+#define star_v1_SetMotorPidConfigResponse_fields &star_v1_SetMotorPidConfigResponse_msg
+#define star_v1_RetransmitConfig_fields &star_v1_RetransmitConfig_msg
+#define star_v1_SetRetransmitConfigRequest_fields &star_v1_SetRetransmitConfigRequest_msg
+#define star_v1_SetRetransmitConfigResponse_fields &star_v1_SetRetransmitConfigResponse_msg
+#define star_v1_SystemConfiguration_fields &star_v1_SystemConfiguration_msg
+#define star_v1_MotorPidConfiguration_fields &star_v1_MotorPidConfiguration_msg
+#define star_v1_CurrentSensorCalibration_fields &star_v1_CurrentSensorCalibration_msg
+#define star_v1_TemperatureCalibration_fields &star_v1_TemperatureCalibration_msg
+#define star_v1_SafetyThresholds_fields &star_v1_SafetyThresholds_msg
+#define star_v1_EncoderConfiguration_fields &star_v1_EncoderConfiguration_msg
+#define star_v1_TimingConfiguration_fields &star_v1_TimingConfiguration_msg
+#define star_v1_ConfigValidationResult_fields &star_v1_ConfigValidationResult_msg
+#define star_v1_ConfigValidationError_fields &star_v1_ConfigValidationError_msg
 
 /* Maximum encoded size of messages (where known) */
 /* star_v1_GetConfigurationResponse_size depends on runtime parameters */
@@ -957,26 +789,26 @@ extern const pb_msgdesc_t star_v1_ConfigValidationError_msg;
 /* star_v1_SystemConfiguration_size depends on runtime parameters */
 /* star_v1_CurrentSensorCalibration_size depends on runtime parameters */
 #define STAR_V1_STAR_V1_CONFIGURATION_PB_H_MAX_SIZE star_v1_SetConfigurationResponse_size
-#define star_v1_ConfigValidationError_size          585
-#define star_v1_ConfigValidationResult_size         4706
-#define star_v1_EncoderConfiguration_size           24
-#define star_v1_GetConfigurationRequest_size        149
-#define star_v1_GetMotorPidConfigRequest_size       160
-#define star_v1_GetMotorPidConfigResponse_size      439
-#define star_v1_MotorPidConfiguration_size          76
-#define star_v1_ResetToDefaultsRequest_size         151
-#define star_v1_RetransmitConfig_size               20
-#define star_v1_SafetyThresholds_size               23
-#define star_v1_SaveConfigurationRequest_size       149
-#define star_v1_SaveConfigurationResponse_size      371
-#define star_v1_SetConfigurationResponse_size       5072
-#define star_v1_SetMotorPidConfigRequest_size       227
-#define star_v1_SetMotorPidConfigResponse_size      5072
-#define star_v1_SetRetransmitConfigRequest_size     171
-#define star_v1_SetRetransmitConfigResponse_size    363
-#define star_v1_TemperatureCalibration_size         9
-#define star_v1_TimingConfiguration_size            18
-#define star_v1_ValidateConfigurationResponse_size  5072
+#define star_v1_ConfigValidationError_size       585
+#define star_v1_ConfigValidationResult_size      4706
+#define star_v1_EncoderConfiguration_size        24
+#define star_v1_GetConfigurationRequest_size     149
+#define star_v1_GetMotorPidConfigRequest_size    160
+#define star_v1_GetMotorPidConfigResponse_size   439
+#define star_v1_MotorPidConfiguration_size       76
+#define star_v1_ResetToDefaultsRequest_size      151
+#define star_v1_RetransmitConfig_size            20
+#define star_v1_SafetyThresholds_size            23
+#define star_v1_SaveConfigurationRequest_size    149
+#define star_v1_SaveConfigurationResponse_size   371
+#define star_v1_SetConfigurationResponse_size    5072
+#define star_v1_SetMotorPidConfigRequest_size    227
+#define star_v1_SetMotorPidConfigResponse_size   5072
+#define star_v1_SetRetransmitConfigRequest_size  171
+#define star_v1_SetRetransmitConfigResponse_size 363
+#define star_v1_TemperatureCalibration_size      9
+#define star_v1_TimingConfiguration_size         18
+#define star_v1_ValidateConfigurationResponse_size 5072
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/controller.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/controller.pb.c
@@ -7,3 +7,6 @@
 #endif
 
 PB_BIND(star_v1_ControllerState, star_v1_ControllerState, AUTO)
+
+
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/controller.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/controller.pb.h
@@ -12,45 +12,40 @@
 /* Struct definitions */
 /* ControllerState represents the state of a gamepad controller for direct robot control. */
 typedef struct _star_v1_ControllerState {
-  /* Linear velocity (v) from Left Stick Y-axis. Range: [-1.0, 1.0] */
-  float linear_vel;
-  /* Angular velocity (omega) from Left Stick X-axis. Range: [-1.0, 1.0] */
-  float angular_vel;
-  /* Timestamp in milliseconds (e.g., since epoch or monotonic boot time)
+    /* Linear velocity (v) from Left Stick Y-axis. Range: [-1.0, 1.0] */
+    float linear_vel;
+    /* Angular velocity (omega) from Left Stick X-axis. Range: [-1.0, 1.0] */
+    float angular_vel;
+    /* Timestamp in milliseconds (e.g., since epoch or monotonic boot time)
  Used for jitter buffer and out-of-order packet handling. */
-  int64_t timestamp;
-  /* Enable verbose debug logging on the gateway */
-  bool debug;
+    int64_t timestamp;
+    /* Enable verbose debug logging on the gateway */
+    bool debug;
 } star_v1_ControllerState;
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define star_v1_ControllerState_init_default                                                       \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_ControllerState_init_zero                                                          \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
+#define star_v1_ControllerState_init_default     {0, 0, 0, 0}
+#define star_v1_ControllerState_init_zero        {0, 0, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_ControllerState_linear_vel_tag  1
-#define star_v1_ControllerState_angular_vel_tag 2
-#define star_v1_ControllerState_timestamp_tag   3
-#define star_v1_ControllerState_debug_tag       4
+#define star_v1_ControllerState_linear_vel_tag   1
+#define star_v1_ControllerState_angular_vel_tag  2
+#define star_v1_ControllerState_timestamp_tag    3
+#define star_v1_ControllerState_debug_tag        4
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_ControllerState_FIELDLIST(X, a)                                                    \
-  X(a, STATIC, SINGULAR, FLOAT, linear_vel, 1)                                                     \
-  X(a, STATIC, SINGULAR, FLOAT, angular_vel, 2)                                                    \
-  X(a, STATIC, SINGULAR, INT64, timestamp, 3)                                                      \
-  X(a, STATIC, SINGULAR, BOOL, debug, 4)
+#define star_v1_ControllerState_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, FLOAT,    linear_vel,        1) \
+X(a, STATIC,   SINGULAR, FLOAT,    angular_vel,       2) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp,         3) \
+X(a, STATIC,   SINGULAR, BOOL,     debug,             4)
 #define star_v1_ControllerState_CALLBACK NULL
-#define star_v1_ControllerState_DEFAULT  NULL
+#define star_v1_ControllerState_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_ControllerState_msg;
 

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/diagnostics.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/diagnostics.pb.c
@@ -8,4 +8,10 @@
 
 PB_BIND(star_v1_TransportHealthReport, star_v1_TransportHealthReport, AUTO)
 
+
 PB_BIND(star_v1_TransportDiagnostics, star_v1_TransportDiagnostics, 2)
+
+
+
+
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/diagnostics.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/diagnostics.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_DIAGNOSTICS_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_DIAGNOSTICS_PB_H_INCLUDED
 #include <pb.h>
-
 #include "google/protobuf/duration.pb.h"
 #include "google/protobuf/timestamp.pb.h"
 
@@ -15,64 +14,65 @@
 /* Enum definitions */
 /* TransportType identifies the physical transport. */
 typedef enum _star_v1_TransportType {
-  /* Unknown or unspecified transport. */
-  star_v1_TransportType_TRANSPORT_TYPE_UNKNOWN = 0,
-  /* USB CDC (ACM) serial transport. */
-  star_v1_TransportType_TRANSPORT_TYPE_USB_CDC = 1,
-  /* SPI full-duplex transport. */
-  star_v1_TransportType_TRANSPORT_TYPE_SPI = 2
+    /* Unknown or unspecified transport. */
+    star_v1_TransportType_TRANSPORT_TYPE_UNKNOWN = 0,
+    /* USB CDC (ACM) serial transport. */
+    star_v1_TransportType_TRANSPORT_TYPE_USB_CDC = 1,
+    /* SPI full-duplex transport. */
+    star_v1_TransportType_TRANSPORT_TYPE_SPI = 2
 } star_v1_TransportType;
 
 /* Struct definitions */
 /* TransportHealthReport contains health metrics for a single transport.
  Sent periodically by the gateway or on-demand for diagnostics. */
 typedef struct _star_v1_TransportHealthReport {
-  /* Transport identifier (e.g., "usb", "spi"). */
-  char transport_name[16];
-  /* Physical transport type. */
-  star_v1_TransportType transport_type;
-  /* Whether this transport is currently the active (selected) transport. */
-  bool is_active;
-  /* Whether this transport is considered healthy. */
-  bool is_healthy;
-  /* Total frames sent since last reset. */
-  uint64_t total_sent;
-  /* Total frames received since last reset. */
-  uint64_t total_received;
-  /* Total errors encountered since last reset. */
-  uint64_t total_errors;
-  /* Current consecutive failure count (resets on success). */
-  uint32_t consecutive_failures;
-  /* Average round-trip latency. */
-  bool                     has_avg_latency;
-  google_protobuf_Duration avg_latency;
-  /* Packet loss rate (0.0 to 1.0) over sliding window. */
-  float packet_loss_rate;
-  /* Timestamp of last successful operation. */
-  bool                      has_last_success;
-  google_protobuf_Timestamp last_success;
-  /* Timestamp of last failure. */
-  bool                      has_last_failure;
-  google_protobuf_Timestamp last_failure;
-  /* Timestamp of last recovery (unhealthy -> healthy transition). */
-  bool                      has_last_recovery;
-  google_protobuf_Timestamp last_recovery;
+    /* Transport identifier (e.g., "usb", "spi"). */
+    char transport_name[16];
+    /* Physical transport type. */
+    star_v1_TransportType transport_type;
+    /* Whether this transport is currently the active (selected) transport. */
+    bool is_active;
+    /* Whether this transport is considered healthy. */
+    bool is_healthy;
+    /* Total frames sent since last reset. */
+    uint64_t total_sent;
+    /* Total frames received since last reset. */
+    uint64_t total_received;
+    /* Total errors encountered since last reset. */
+    uint64_t total_errors;
+    /* Current consecutive failure count (resets on success). */
+    uint32_t consecutive_failures;
+    /* Average round-trip latency. */
+    bool has_avg_latency;
+    google_protobuf_Duration avg_latency;
+    /* Packet loss rate (0.0 to 1.0) over sliding window. */
+    float packet_loss_rate;
+    /* Timestamp of last successful operation. */
+    bool has_last_success;
+    google_protobuf_Timestamp last_success;
+    /* Timestamp of last failure. */
+    bool has_last_failure;
+    google_protobuf_Timestamp last_failure;
+    /* Timestamp of last recovery (unhealthy -> healthy transition). */
+    bool has_last_recovery;
+    google_protobuf_Timestamp last_recovery;
 } star_v1_TransportHealthReport;
 
 /* TransportDiagnostics contains health reports for all transports.
  This is the top-level diagnostics message sent over the wire. */
 typedef struct _star_v1_TransportDiagnostics {
-  /* Health reports for each registered transport. */
-  pb_size_t                     transports_count;
-  star_v1_TransportHealthReport transports[8];
-  /* Name of the currently active transport. */
-  char active_transport[16];
-  /* Total number of transport switches since startup. */
-  uint32_t switch_count;
-  /* Timestamp when diagnostics were collected. */
-  bool                      has_collected_at;
-  google_protobuf_Timestamp collected_at;
+    /* Health reports for each registered transport. */
+    pb_size_t transports_count;
+    star_v1_TransportHealthReport transports[8];
+    /* Name of the currently active transport. */
+    char active_transport[16];
+    /* Total number of transport switches since startup. */
+    uint32_t switch_count;
+    /* Timestamp when diagnostics were collected. */
+    bool has_collected_at;
+    google_protobuf_Timestamp collected_at;
 } star_v1_TransportDiagnostics;
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,100 +81,67 @@ extern "C" {
 /* Helper constants for enums */
 #define _star_v1_TransportType_MIN star_v1_TransportType_TRANSPORT_TYPE_UNKNOWN
 #define _star_v1_TransportType_MAX star_v1_TransportType_TRANSPORT_TYPE_SPI
-#define _star_v1_TransportType_ARRAYSIZE                                                           \
-  ((star_v1_TransportType)(star_v1_TransportType_TRANSPORT_TYPE_SPI + 1))
+#define _star_v1_TransportType_ARRAYSIZE ((star_v1_TransportType)(star_v1_TransportType_TRANSPORT_TYPE_SPI+1))
 
 #define star_v1_TransportHealthReport_transport_type_ENUMTYPE star_v1_TransportType
 
+
+
 /* Initializer values for message structs */
-#define star_v1_TransportHealthReport_init_default                                                 \
-  {                                                                                                \
-    "", _star_v1_TransportType_MIN, 0, 0, 0, 0, 0, 0, false,                                       \
-      google_protobuf_Duration_init_default, 0, false, google_protobuf_Timestamp_init_default,     \
-      false, google_protobuf_Timestamp_init_default, false, google_protobuf_Timestamp_init_default \
-  }
-#define star_v1_TransportDiagnostics_init_default                                                  \
-  {                                                                                                \
-    0,                                                                                             \
-      {star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default,                                                 \
-       star_v1_TransportHealthReport_init_default},                                                \
-      "", 0, false, google_protobuf_Timestamp_init_default                                         \
-  }
-#define star_v1_TransportHealthReport_init_zero                                                    \
-  {                                                                                                \
-    "", _star_v1_TransportType_MIN, 0, 0, 0, 0, 0, 0, false, google_protobuf_Duration_init_zero,   \
-      0, false, google_protobuf_Timestamp_init_zero, false, google_protobuf_Timestamp_init_zero,   \
-      false, google_protobuf_Timestamp_init_zero                                                   \
-  }
-#define star_v1_TransportDiagnostics_init_zero                                                     \
-  {                                                                                                \
-    0,                                                                                             \
-      {star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero,                                                    \
-       star_v1_TransportHealthReport_init_zero},                                                   \
-      "", 0, false, google_protobuf_Timestamp_init_zero                                            \
-  }
+#define star_v1_TransportHealthReport_init_default {"", _star_v1_TransportType_MIN, 0, 0, 0, 0, 0, 0, false, google_protobuf_Duration_init_default, 0, false, google_protobuf_Timestamp_init_default, false, google_protobuf_Timestamp_init_default, false, google_protobuf_Timestamp_init_default}
+#define star_v1_TransportDiagnostics_init_default {0, {star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default, star_v1_TransportHealthReport_init_default}, "", 0, false, google_protobuf_Timestamp_init_default}
+#define star_v1_TransportHealthReport_init_zero  {"", _star_v1_TransportType_MIN, 0, 0, 0, 0, 0, 0, false, google_protobuf_Duration_init_zero, 0, false, google_protobuf_Timestamp_init_zero, false, google_protobuf_Timestamp_init_zero, false, google_protobuf_Timestamp_init_zero}
+#define star_v1_TransportDiagnostics_init_zero   {0, {star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero, star_v1_TransportHealthReport_init_zero}, "", 0, false, google_protobuf_Timestamp_init_zero}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_TransportHealthReport_transport_name_tag       1
-#define star_v1_TransportHealthReport_transport_type_tag       2
-#define star_v1_TransportHealthReport_is_active_tag            3
-#define star_v1_TransportHealthReport_is_healthy_tag           4
-#define star_v1_TransportHealthReport_total_sent_tag           10
-#define star_v1_TransportHealthReport_total_received_tag       11
-#define star_v1_TransportHealthReport_total_errors_tag         12
+#define star_v1_TransportHealthReport_transport_name_tag 1
+#define star_v1_TransportHealthReport_transport_type_tag 2
+#define star_v1_TransportHealthReport_is_active_tag 3
+#define star_v1_TransportHealthReport_is_healthy_tag 4
+#define star_v1_TransportHealthReport_total_sent_tag 10
+#define star_v1_TransportHealthReport_total_received_tag 11
+#define star_v1_TransportHealthReport_total_errors_tag 12
 #define star_v1_TransportHealthReport_consecutive_failures_tag 13
-#define star_v1_TransportHealthReport_avg_latency_tag          14
-#define star_v1_TransportHealthReport_packet_loss_rate_tag     15
-#define star_v1_TransportHealthReport_last_success_tag         20
-#define star_v1_TransportHealthReport_last_failure_tag         21
-#define star_v1_TransportHealthReport_last_recovery_tag        22
-#define star_v1_TransportDiagnostics_transports_tag            1
-#define star_v1_TransportDiagnostics_active_transport_tag      2
-#define star_v1_TransportDiagnostics_switch_count_tag          3
-#define star_v1_TransportDiagnostics_collected_at_tag          4
+#define star_v1_TransportHealthReport_avg_latency_tag 14
+#define star_v1_TransportHealthReport_packet_loss_rate_tag 15
+#define star_v1_TransportHealthReport_last_success_tag 20
+#define star_v1_TransportHealthReport_last_failure_tag 21
+#define star_v1_TransportHealthReport_last_recovery_tag 22
+#define star_v1_TransportDiagnostics_transports_tag 1
+#define star_v1_TransportDiagnostics_active_transport_tag 2
+#define star_v1_TransportDiagnostics_switch_count_tag 3
+#define star_v1_TransportDiagnostics_collected_at_tag 4
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_TransportHealthReport_FIELDLIST(X, a)                                              \
-  X(a, STATIC, SINGULAR, STRING, transport_name, 1)                                                \
-  X(a, STATIC, SINGULAR, UENUM, transport_type, 2)                                                 \
-  X(a, STATIC, SINGULAR, BOOL, is_active, 3)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, is_healthy, 4)                                                      \
-  X(a, STATIC, SINGULAR, UINT64, total_sent, 10)                                                   \
-  X(a, STATIC, SINGULAR, UINT64, total_received, 11)                                               \
-  X(a, STATIC, SINGULAR, UINT64, total_errors, 12)                                                 \
-  X(a, STATIC, SINGULAR, UINT32, consecutive_failures, 13)                                         \
-  X(a, STATIC, OPTIONAL, MESSAGE, avg_latency, 14)                                                 \
-  X(a, STATIC, SINGULAR, FLOAT, packet_loss_rate, 15)                                              \
-  X(a, STATIC, OPTIONAL, MESSAGE, last_success, 20)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, last_failure, 21)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, last_recovery, 22)
-#define star_v1_TransportHealthReport_CALLBACK              NULL
-#define star_v1_TransportHealthReport_DEFAULT               NULL
-#define star_v1_TransportHealthReport_avg_latency_MSGTYPE   google_protobuf_Duration
-#define star_v1_TransportHealthReport_last_success_MSGTYPE  google_protobuf_Timestamp
-#define star_v1_TransportHealthReport_last_failure_MSGTYPE  google_protobuf_Timestamp
+#define star_v1_TransportHealthReport_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, STRING,   transport_name,    1) \
+X(a, STATIC,   SINGULAR, UENUM,    transport_type,    2) \
+X(a, STATIC,   SINGULAR, BOOL,     is_active,         3) \
+X(a, STATIC,   SINGULAR, BOOL,     is_healthy,        4) \
+X(a, STATIC,   SINGULAR, UINT64,   total_sent,       10) \
+X(a, STATIC,   SINGULAR, UINT64,   total_received,   11) \
+X(a, STATIC,   SINGULAR, UINT64,   total_errors,     12) \
+X(a, STATIC,   SINGULAR, UINT32,   consecutive_failures,  13) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  avg_latency,      14) \
+X(a, STATIC,   SINGULAR, FLOAT,    packet_loss_rate,  15) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  last_success,     20) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  last_failure,     21) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  last_recovery,    22)
+#define star_v1_TransportHealthReport_CALLBACK NULL
+#define star_v1_TransportHealthReport_DEFAULT NULL
+#define star_v1_TransportHealthReport_avg_latency_MSGTYPE google_protobuf_Duration
+#define star_v1_TransportHealthReport_last_success_MSGTYPE google_protobuf_Timestamp
+#define star_v1_TransportHealthReport_last_failure_MSGTYPE google_protobuf_Timestamp
 #define star_v1_TransportHealthReport_last_recovery_MSGTYPE google_protobuf_Timestamp
 
-#define star_v1_TransportDiagnostics_FIELDLIST(X, a)                                               \
-  X(a, STATIC, REPEATED, MESSAGE, transports, 1)                                                   \
-  X(a, STATIC, SINGULAR, STRING, active_transport, 2)                                              \
-  X(a, STATIC, SINGULAR, UINT32, switch_count, 3)                                                  \
-  X(a, STATIC, OPTIONAL, MESSAGE, collected_at, 4)
-#define star_v1_TransportDiagnostics_CALLBACK             NULL
-#define star_v1_TransportDiagnostics_DEFAULT              NULL
-#define star_v1_TransportDiagnostics_transports_MSGTYPE   star_v1_TransportHealthReport
+#define star_v1_TransportDiagnostics_FIELDLIST(X, a) \
+X(a, STATIC,   REPEATED, MESSAGE,  transports,        1) \
+X(a, STATIC,   SINGULAR, STRING,   active_transport,   2) \
+X(a, STATIC,   SINGULAR, UINT32,   switch_count,      3) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  collected_at,      4)
+#define star_v1_TransportDiagnostics_CALLBACK NULL
+#define star_v1_TransportDiagnostics_DEFAULT NULL
+#define star_v1_TransportDiagnostics_transports_MSGTYPE star_v1_TransportHealthReport
 #define star_v1_TransportDiagnostics_collected_at_MSGTYPE google_protobuf_Timestamp
 
 extern const pb_msgdesc_t star_v1_TransportHealthReport_msg;
@@ -182,12 +149,12 @@ extern const pb_msgdesc_t star_v1_TransportDiagnostics_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
 #define star_v1_TransportHealthReport_fields &star_v1_TransportHealthReport_msg
-#define star_v1_TransportDiagnostics_fields  &star_v1_TransportDiagnostics_msg
+#define star_v1_TransportDiagnostics_fields &star_v1_TransportDiagnostics_msg
 
 /* Maximum encoded size of messages (where known) */
 #define STAR_V1_STAR_V1_DIAGNOSTICS_PB_H_MAX_SIZE star_v1_TransportDiagnostics_size
-#define star_v1_TransportDiagnostics_size         1399
-#define star_v1_TransportHealthReport_size        166
+#define star_v1_TransportDiagnostics_size        1399
+#define star_v1_TransportHealthReport_size       166
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/firmware_update.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/firmware_update.pb.c
@@ -8,48 +8,78 @@
 
 PB_BIND(star_v1_BeginUpdateRequest, star_v1_BeginUpdateRequest, AUTO)
 
+
 PB_BIND(star_v1_BeginUpdateResponse, star_v1_BeginUpdateResponse, 2)
+
 
 PB_BIND(star_v1_WriteChunkRequest, star_v1_WriteChunkRequest, AUTO)
 
+
 PB_BIND(star_v1_WriteChunkResponse, star_v1_WriteChunkResponse, 2)
+
 
 PB_BIND(star_v1_FirmwareChunk, star_v1_FirmwareChunk, AUTO)
 
+
 PB_BIND(star_v1_StreamChunksResponse, star_v1_StreamChunksResponse, 2)
+
 
 PB_BIND(star_v1_FinalizeUpdateRequest, star_v1_FinalizeUpdateRequest, AUTO)
 
+
 PB_BIND(star_v1_FinalizeUpdateResponse, star_v1_FinalizeUpdateResponse, 2)
+
 
 PB_BIND(star_v1_AbortUpdateRequest, star_v1_AbortUpdateRequest, AUTO)
 
+
 PB_BIND(star_v1_AbortUpdateResponse, star_v1_AbortUpdateResponse, 2)
+
 
 PB_BIND(star_v1_GetUpdateProgressRequest, star_v1_GetUpdateProgressRequest, AUTO)
 
+
 PB_BIND(star_v1_GetUpdateProgressResponse, star_v1_GetUpdateProgressResponse, 2)
+
 
 PB_BIND(star_v1_StreamUpdateProgressRequest, star_v1_StreamUpdateProgressRequest, AUTO)
 
+
 PB_BIND(star_v1_FirmwareUpdateProgress, star_v1_FirmwareUpdateProgress, AUTO)
+
 
 PB_BIND(star_v1_RebootRequest, star_v1_RebootRequest, AUTO)
 
+
 PB_BIND(star_v1_RebootResponse, star_v1_RebootResponse, 2)
+
 
 PB_BIND(star_v1_RollbackRequest, star_v1_RollbackRequest, AUTO)
 
+
 PB_BIND(star_v1_RollbackResponse, star_v1_RollbackResponse, 2)
+
 
 PB_BIND(star_v1_MarkValidRequest, star_v1_MarkValidRequest, AUTO)
 
+
 PB_BIND(star_v1_MarkValidResponse, star_v1_MarkValidResponse, 2)
+
 
 PB_BIND(star_v1_GetFirmwareInfoRequest, star_v1_GetFirmwareInfoRequest, AUTO)
 
+
 PB_BIND(star_v1_GetFirmwareInfoResponse, star_v1_GetFirmwareInfoResponse, 2)
+
 
 PB_BIND(star_v1_FirmwareInfo, star_v1_FirmwareInfo, AUTO)
 
+
 PB_BIND(star_v1_FirmwareUpdateError, star_v1_FirmwareUpdateError, AUTO)
+
+
+
+
+
+
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/firmware_update.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/firmware_update.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_FIRMWARE_UPDATE_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_FIRMWARE_UPDATE_PB_H_INCLUDED
 #include <pb.h>
-
 #include "star/v1/common.pb.h"
 
 #if PB_PROTO_HEADER_VERSION != 40
@@ -15,331 +14,332 @@
 /* Firmware update state.
  Maps to star_ota_state_t. */
 typedef enum _star_v1_FirmwareUpdateState {
-  /* Unknown state. */
-  star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_UNKNOWN = 0,
-  /* No OTA in progress. */
-  star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_IDLE = 1,
-  /* Receiving firmware data. */
-  star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_RECEIVING = 2,
-  /* Validating received firmware. */
-  star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_VALIDATING = 3,
-  /* OTA complete, ready to reboot. */
-  star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_COMPLETE = 4,
-  /* Error occurred during OTA. */
-  star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_ERROR = 5
+    /* Unknown state. */
+    star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_UNKNOWN = 0,
+    /* No OTA in progress. */
+    star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_IDLE = 1,
+    /* Receiving firmware data. */
+    star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_RECEIVING = 2,
+    /* Validating received firmware. */
+    star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_VALIDATING = 3,
+    /* OTA complete, ready to reboot. */
+    star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_COMPLETE = 4,
+    /* Error occurred during OTA. */
+    star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_ERROR = 5
 } star_v1_FirmwareUpdateState;
 
 /* Firmware update error codes. */
 typedef enum _star_v1_FirmwareUpdateErrorCode {
-  /* Unknown error. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_UNKNOWN = 0,
-  /* Invalid firmware size. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_INVALID_SIZE = 1,
-  /* OTA already in progress. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_ALREADY_IN_PROGRESS = 2,
-  /* OTA partition not found. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_PARTITION = 3,
-  /* OTA not started. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NOT_STARTED = 4,
-  /* Size exceeds expected. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_SIZE_EXCEEDED = 5,
-  /* Incomplete transfer. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_INCOMPLETE = 6,
-  /* CRC validation failed. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_CRC_FAILED = 7,
-  /* Firmware validation failed. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_VALIDATION_FAILED = 8,
-  /* Flash write failed. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_WRITE_FAILED = 9,
-  /* Chunk sequence error. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_SEQUENCE_ERROR = 10,
-  /* Timeout during transfer. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_TIMEOUT = 11,
-  /* Insufficient storage space. */
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_SPACE = 12
+    /* Unknown error. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_UNKNOWN = 0,
+    /* Invalid firmware size. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_INVALID_SIZE = 1,
+    /* OTA already in progress. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_ALREADY_IN_PROGRESS = 2,
+    /* OTA partition not found. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_PARTITION = 3,
+    /* OTA not started. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NOT_STARTED = 4,
+    /* Size exceeds expected. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_SIZE_EXCEEDED = 5,
+    /* Incomplete transfer. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_INCOMPLETE = 6,
+    /* CRC validation failed. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_CRC_FAILED = 7,
+    /* Firmware validation failed. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_VALIDATION_FAILED = 8,
+    /* Flash write failed. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_WRITE_FAILED = 9,
+    /* Chunk sequence error. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_SEQUENCE_ERROR = 10,
+    /* Timeout during transfer. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_TIMEOUT = 11,
+    /* Insufficient storage space. */
+    star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_SPACE = 12
 } star_v1_FirmwareUpdateErrorCode;
 
 /* Struct definitions */
 /* Request to begin OTA update. */
 typedef struct _star_v1_BeginUpdateRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Expected firmware size in bytes. */
-  uint32_t firmware_size;
-  /* Expected firmware version (for validation). */
-  pb_callback_t expected_version;
-  /* Expected CRC-32 checksum of complete firmware. */
-  uint32_t expected_crc32;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Expected firmware size in bytes. */
+    uint32_t firmware_size;
+    /* Expected firmware version (for validation). */
+    pb_callback_t expected_version;
+    /* Expected CRC-32 checksum of complete firmware. */
+    uint32_t expected_crc32;
 } star_v1_BeginUpdateRequest;
 
 /* Firmware data chunk. */
 typedef struct _star_v1_FirmwareChunk {
-  /* Raw firmware data bytes.
+    /* Raw firmware data bytes.
  Recommended size: 1024 bytes (1KB). */
-  pb_callback_t data;
-  /* Chunk sequence number (0-indexed).
+    pb_callback_t data;
+    /* Chunk sequence number (0-indexed).
  Used for ordering and deduplication. */
-  uint32_t sequence;
-  /* Byte offset in firmware image. */
-  uint32_t offset;
-  /* CRC-32 of this chunk (optional, for validation). */
-  uint32_t chunk_crc32;
+    uint32_t sequence;
+    /* Byte offset in firmware image. */
+    uint32_t offset;
+    /* CRC-32 of this chunk (optional, for validation). */
+    uint32_t chunk_crc32;
 } star_v1_FirmwareChunk;
 
 /* Request to write a firmware chunk. */
 typedef struct _star_v1_WriteChunkRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Firmware chunk data. */
-  bool                  has_chunk;
-  star_v1_FirmwareChunk chunk;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Firmware chunk data. */
+    bool has_chunk;
+    star_v1_FirmwareChunk chunk;
 } star_v1_WriteChunkRequest;
 
 /* Request to finalize update. */
 typedef struct _star_v1_FinalizeUpdateRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_FinalizeUpdateRequest;
 
 /* Request to abort update. */
 typedef struct _star_v1_AbortUpdateRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Reason for abort (for logging). */
-  pb_callback_t reason;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Reason for abort (for logging). */
+    pb_callback_t reason;
 } star_v1_AbortUpdateRequest;
 
 /* Response to abort request. */
 typedef struct _star_v1_AbortUpdateResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if abort was successful. */
-  bool aborted;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if abort was successful. */
+    bool aborted;
 } star_v1_AbortUpdateResponse;
 
 /* Request to get update progress. */
 typedef struct _star_v1_GetUpdateProgressRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_GetUpdateProgressRequest;
 
 /* Request to stream update progress. */
 typedef struct _star_v1_StreamUpdateProgressRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Update interval in milliseconds.
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Update interval in milliseconds.
  Valid range: 100-5000 ms. */
-  uint32_t update_interval_ms;
+    uint32_t update_interval_ms;
 } star_v1_StreamUpdateProgressRequest;
 
 /* Firmware update progress information.
  Maps to star_ota_stats_t. */
 typedef struct _star_v1_FirmwareUpdateProgress {
-  /* Total firmware size in bytes. */
-  uint32_t total_size;
-  /* Bytes received so far. */
-  uint32_t bytes_received;
-  /* Progress percentage (0-100). */
-  int32_t progress_percent;
-  /* Running CRC-32 checksum of received data. */
-  uint32_t running_crc32;
-  /* Current update state. */
-  star_v1_FirmwareUpdateState state;
-  /* Estimated time remaining in seconds.
+    /* Total firmware size in bytes. */
+    uint32_t total_size;
+    /* Bytes received so far. */
+    uint32_t bytes_received;
+    /* Progress percentage (0-100). */
+    int32_t progress_percent;
+    /* Running CRC-32 checksum of received data. */
+    uint32_t running_crc32;
+    /* Current update state. */
+    star_v1_FirmwareUpdateState state;
+    /* Estimated time remaining in seconds.
  -1 if cannot be calculated. */
-  int32_t estimated_seconds_remaining;
-  /* Transfer speed in bytes per second. */
-  uint32_t transfer_speed_bps;
-  /* Last chunk sequence number received. */
-  uint32_t last_sequence;
+    int32_t estimated_seconds_remaining;
+    /* Transfer speed in bytes per second. */
+    uint32_t transfer_speed_bps;
+    /* Last chunk sequence number received. */
+    uint32_t last_sequence;
 } star_v1_FirmwareUpdateProgress;
 
 /* Response to write chunk request. */
 typedef struct _star_v1_WriteChunkResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if chunk was written successfully. */
-  bool success;
-  /* Current progress after this chunk. */
-  bool                           has_progress;
-  star_v1_FirmwareUpdateProgress progress;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if chunk was written successfully. */
+    bool success;
+    /* Current progress after this chunk. */
+    bool has_progress;
+    star_v1_FirmwareUpdateProgress progress;
 } star_v1_WriteChunkResponse;
 
 /* Response with update progress. */
 typedef struct _star_v1_GetUpdateProgressResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Current update progress. */
-  bool                           has_progress;
-  star_v1_FirmwareUpdateProgress progress;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Current update progress. */
+    bool has_progress;
+    star_v1_FirmwareUpdateProgress progress;
 } star_v1_GetUpdateProgressResponse;
 
 /* Request to reboot. */
 typedef struct _star_v1_RebootRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Delay before reboot in milliseconds.
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Delay before reboot in milliseconds.
  Allows time for response to be sent.
  Valid range: 0-5000 ms. Default: 1000 ms. */
-  uint32_t delay_ms;
+    uint32_t delay_ms;
 } star_v1_RebootRequest;
 
 /* Response to reboot request. */
 typedef struct _star_v1_RebootResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if reboot will occur. */
-  bool rebooting;
-  /* Delay before reboot in milliseconds. */
-  uint32_t reboot_delay_ms;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if reboot will occur. */
+    bool rebooting;
+    /* Delay before reboot in milliseconds. */
+    uint32_t reboot_delay_ms;
 } star_v1_RebootResponse;
 
 /* Request to rollback firmware. */
 typedef struct _star_v1_RollbackRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_RollbackRequest;
 
 /* Response to rollback request. */
 typedef struct _star_v1_RollbackResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if rollback will occur. */
-  bool rolling_back;
-  /* Previous firmware version being restored. */
-  pb_callback_t previous_version;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if rollback will occur. */
+    bool rolling_back;
+    /* Previous firmware version being restored. */
+    pb_callback_t previous_version;
 } star_v1_RollbackResponse;
 
 /* Request to mark firmware valid. */
 typedef struct _star_v1_MarkValidRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_MarkValidRequest;
 
 /* Response to mark valid request. */
 typedef struct _star_v1_MarkValidResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if firmware marked as valid. */
-  bool marked_valid;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if firmware marked as valid. */
+    bool marked_valid;
 } star_v1_MarkValidResponse;
 
 /* Request for firmware information. */
 typedef struct _star_v1_GetFirmwareInfoRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_GetFirmwareInfoRequest;
 
 /* Firmware version and metadata. */
 typedef struct _star_v1_FirmwareInfo {
-  /* Firmware version string (e.g., "1.0.0"). */
-  pb_callback_t version;
-  /* Git commit hash (short form). */
-  pb_callback_t git_hash;
-  /* Build date in ISO 8601 format. */
-  pb_callback_t build_date;
-  /* Firmware size in bytes. */
-  uint32_t size;
-  /* Firmware CRC-32 checksum. */
-  uint32_t crc32;
-  /* IDF version used to build. */
-  pb_callback_t idf_version;
-  /* Target chip (e.g., "esp32s3"). */
-  pb_callback_t chip_target;
+    /* Firmware version string (e.g., "1.0.0"). */
+    pb_callback_t version;
+    /* Git commit hash (short form). */
+    pb_callback_t git_hash;
+    /* Build date in ISO 8601 format. */
+    pb_callback_t build_date;
+    /* Firmware size in bytes. */
+    uint32_t size;
+    /* Firmware CRC-32 checksum. */
+    uint32_t crc32;
+    /* IDF version used to build. */
+    pb_callback_t idf_version;
+    /* Target chip (e.g., "esp32s3"). */
+    pb_callback_t chip_target;
 } star_v1_FirmwareInfo;
 
 /* Response with firmware information. */
 typedef struct _star_v1_GetFirmwareInfoResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Current running firmware info. */
-  bool                 has_current_firmware;
-  star_v1_FirmwareInfo current_firmware;
-  /* Previous firmware info (for rollback), if available.
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Current running firmware info. */
+    bool has_current_firmware;
+    star_v1_FirmwareInfo current_firmware;
+    /* Previous firmware info (for rollback), if available.
  May be absent on devices that have never been updated. */
-  bool                 has_previous_firmware;
-  star_v1_FirmwareInfo previous_firmware;
-  /* True if running from OTA partition. */
-  bool is_ota_boot;
-  /* True if firmware is marked valid. */
-  bool is_valid;
+    bool has_previous_firmware;
+    star_v1_FirmwareInfo previous_firmware;
+    /* True if running from OTA partition. */
+    bool is_ota_boot;
+    /* True if firmware is marked valid. */
+    bool is_valid;
 } star_v1_GetFirmwareInfoResponse;
 
 /* Detailed firmware update error. */
 typedef struct _star_v1_FirmwareUpdateError {
-  /* Error code for programmatic handling. */
-  star_v1_FirmwareUpdateErrorCode code;
-  /* Human-readable error message. */
-  pb_callback_t message;
-  /* Additional error details (ESP error code, etc.). */
-  pb_callback_t details;
-  /* Chunk sequence number where error occurred (if applicable). */
-  uint32_t error_at_sequence;
-  /* Byte offset where error occurred (if applicable). */
-  uint32_t error_at_offset;
+    /* Error code for programmatic handling. */
+    star_v1_FirmwareUpdateErrorCode code;
+    /* Human-readable error message. */
+    pb_callback_t message;
+    /* Additional error details (ESP error code, etc.). */
+    pb_callback_t details;
+    /* Chunk sequence number where error occurred (if applicable). */
+    uint32_t error_at_sequence;
+    /* Byte offset where error occurred (if applicable). */
+    uint32_t error_at_offset;
 } star_v1_FirmwareUpdateError;
 
 /* Response to begin update request. */
 typedef struct _star_v1_BeginUpdateResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if update can begin. */
-  bool accepted;
-  /* Maximum chunk size supported (in bytes). */
-  uint32_t max_chunk_size;
-  /* Update session ID for tracking. */
-  pb_callback_t session_id;
-  /* Detailed error if not accepted. */
-  bool                        has_error;
-  star_v1_FirmwareUpdateError error;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if update can begin. */
+    bool accepted;
+    /* Maximum chunk size supported (in bytes). */
+    uint32_t max_chunk_size;
+    /* Update session ID for tracking. */
+    pb_callback_t session_id;
+    /* Detailed error if not accepted. */
+    bool has_error;
+    star_v1_FirmwareUpdateError error;
 } star_v1_BeginUpdateResponse;
 
 /* Response to streaming chunks. */
 typedef struct _star_v1_StreamChunksResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Total chunks received. */
-  uint32_t chunks_received;
-  /* Final progress after streaming. */
-  bool                           has_progress;
-  star_v1_FirmwareUpdateProgress progress;
-  /* Error if streaming failed. */
-  bool                        has_error;
-  star_v1_FirmwareUpdateError error;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Total chunks received. */
+    uint32_t chunks_received;
+    /* Final progress after streaming. */
+    bool has_progress;
+    star_v1_FirmwareUpdateProgress progress;
+    /* Error if streaming failed. */
+    bool has_error;
+    star_v1_FirmwareUpdateError error;
 } star_v1_StreamChunksResponse;
 
 /* Response to finalize request. */
 typedef struct _star_v1_FinalizeUpdateResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if firmware validation passed. */
-  bool validated;
-  /* True if ready to reboot. */
-  bool ready_to_reboot;
-  /* Validation error if failed. */
-  bool                        has_error;
-  star_v1_FirmwareUpdateError error;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if firmware validation passed. */
+    bool validated;
+    /* True if ready to reboot. */
+    bool ready_to_reboot;
+    /* Validation error if failed. */
+    bool has_error;
+    star_v1_FirmwareUpdateError error;
 } star_v1_FinalizeUpdateResponse;
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -348,511 +348,364 @@ extern "C" {
 /* Helper constants for enums */
 #define _star_v1_FirmwareUpdateState_MIN star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_UNKNOWN
 #define _star_v1_FirmwareUpdateState_MAX star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_ERROR
-#define _star_v1_FirmwareUpdateState_ARRAYSIZE                                                     \
-  ((star_v1_FirmwareUpdateState)(star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_ERROR + 1))
+#define _star_v1_FirmwareUpdateState_ARRAYSIZE ((star_v1_FirmwareUpdateState)(star_v1_FirmwareUpdateState_FIRMWARE_UPDATE_STATE_ERROR+1))
 
-#define _star_v1_FirmwareUpdateErrorCode_MIN                                                       \
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_UNKNOWN
-#define _star_v1_FirmwareUpdateErrorCode_MAX                                                       \
-  star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_SPACE
-#define _star_v1_FirmwareUpdateErrorCode_ARRAYSIZE                                                         \
-  ((star_v1_FirmwareUpdateErrorCode)(star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_SPACE + \
-                                     1))
+#define _star_v1_FirmwareUpdateErrorCode_MIN star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_UNKNOWN
+#define _star_v1_FirmwareUpdateErrorCode_MAX star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_SPACE
+#define _star_v1_FirmwareUpdateErrorCode_ARRAYSIZE ((star_v1_FirmwareUpdateErrorCode)(star_v1_FirmwareUpdateErrorCode_FIRMWARE_UPDATE_ERROR_CODE_NO_SPACE+1))
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 #define star_v1_FirmwareUpdateProgress_state_ENUMTYPE star_v1_FirmwareUpdateState
 
+
+
+
+
+
+
+
+
+
 #define star_v1_FirmwareUpdateError_code_ENUMTYPE star_v1_FirmwareUpdateErrorCode
 
+
 /* Initializer values for message structs */
-#define star_v1_BeginUpdateRequest_init_default                                                    \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0, {{NULL}, NULL}, 0                                \
-  }
-#define star_v1_BeginUpdateResponse_init_default                                                   \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, 0, {{NULL}, NULL}, false,                       \
-      star_v1_FirmwareUpdateError_init_default                                                     \
-  }
-#define star_v1_WriteChunkRequest_init_default                                                     \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_FirmwareChunk_init_default           \
-  }
-#define star_v1_WriteChunkResponse_init_default                                                    \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, false,                                          \
-      star_v1_FirmwareUpdateProgress_init_default                                                  \
-  }
-#define star_v1_FirmwareChunk_init_default                                                         \
-  {                                                                                                \
-    {{NULL}, NULL}, 0, 0, 0                                                                        \
-  }
-#define star_v1_StreamChunksResponse_init_default                                                  \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, false,                                          \
-      star_v1_FirmwareUpdateProgress_init_default, false, star_v1_FirmwareUpdateError_init_default \
-  }
-#define star_v1_FinalizeUpdateRequest_init_default                                                 \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_FinalizeUpdateResponse_init_default                                                \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, 0, false,                                       \
-      star_v1_FirmwareUpdateError_init_default                                                     \
-  }
-#define star_v1_AbortUpdateRequest_init_default                                                    \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default,                                                     \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_AbortUpdateResponse_init_default                                                   \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0                                                  \
-  }
-#define star_v1_GetUpdateProgressRequest_init_default                                              \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_GetUpdateProgressResponse_init_default                                             \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_FirmwareUpdateProgress_init_default \
-  }
-#define star_v1_StreamUpdateProgressRequest_init_default                                           \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0                                                   \
-  }
-#define star_v1_FirmwareUpdateProgress_init_default                                                \
-  {                                                                                                \
-    0, 0, 0, 0, _star_v1_FirmwareUpdateState_MIN, 0, 0, 0                                          \
-  }
-#define star_v1_RebootRequest_init_default                                                         \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0                                                   \
-  }
-#define star_v1_RebootResponse_init_default                                                        \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, 0                                               \
-  }
-#define star_v1_RollbackRequest_init_default                                                       \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_RollbackResponse_init_default                                                      \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0,                                                 \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_MarkValidRequest_init_default                                                      \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_MarkValidResponse_init_default                                                     \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0                                                  \
-  }
-#define star_v1_GetFirmwareInfoRequest_init_default                                                \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_GetFirmwareInfoResponse_init_default                                               \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_FirmwareInfo_init_default, false,   \
-      star_v1_FirmwareInfo_init_default, 0, 0                                                      \
-  }
-#define star_v1_FirmwareInfo_init_default                                                          \
-  {                                                                                                \
-    {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, {{NULL}, NULL},                          \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_FirmwareUpdateError_init_default                                                   \
-  {                                                                                                \
-    _star_v1_FirmwareUpdateErrorCode_MIN, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0                     \
-  }
-#define star_v1_BeginUpdateRequest_init_zero                                                       \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0, {{NULL}, NULL}, 0                                   \
-  }
-#define star_v1_BeginUpdateResponse_init_zero                                                      \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, 0, {{NULL}, NULL}, false,                          \
-      star_v1_FirmwareUpdateError_init_zero                                                        \
-  }
-#define star_v1_WriteChunkRequest_init_zero                                                        \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_FirmwareChunk_init_zero                 \
-  }
-#define star_v1_WriteChunkResponse_init_zero                                                       \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, false, star_v1_FirmwareUpdateProgress_init_zero    \
-  }
-#define star_v1_FirmwareChunk_init_zero                                                            \
-  {                                                                                                \
-    {{NULL}, NULL}, 0, 0, 0                                                                        \
-  }
-#define star_v1_StreamChunksResponse_init_zero                                                     \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, false, star_v1_FirmwareUpdateProgress_init_zero,   \
-      false, star_v1_FirmwareUpdateError_init_zero                                                 \
-  }
-#define star_v1_FinalizeUpdateRequest_init_zero                                                    \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_FinalizeUpdateResponse_init_zero                                                   \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, 0, false, star_v1_FirmwareUpdateError_init_zero    \
-  }
-#define star_v1_AbortUpdateRequest_init_zero                                                       \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero,                                                        \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_AbortUpdateResponse_init_zero                                                      \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0                                                     \
-  }
-#define star_v1_GetUpdateProgressRequest_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_GetUpdateProgressResponse_init_zero                                                \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_FirmwareUpdateProgress_init_zero       \
-  }
-#define star_v1_StreamUpdateProgressRequest_init_zero                                              \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0                                                      \
-  }
-#define star_v1_FirmwareUpdateProgress_init_zero                                                   \
-  {                                                                                                \
-    0, 0, 0, 0, _star_v1_FirmwareUpdateState_MIN, 0, 0, 0                                          \
-  }
-#define star_v1_RebootRequest_init_zero                                                            \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0                                                      \
-  }
-#define star_v1_RebootResponse_init_zero                                                           \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, 0                                                  \
-  }
-#define star_v1_RollbackRequest_init_zero                                                          \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_RollbackResponse_init_zero                                                         \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0,                                                    \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_MarkValidRequest_init_zero                                                         \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_MarkValidResponse_init_zero                                                        \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0                                                     \
-  }
-#define star_v1_GetFirmwareInfoRequest_init_zero                                                   \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_GetFirmwareInfoResponse_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_FirmwareInfo_init_zero, false,         \
-      star_v1_FirmwareInfo_init_zero, 0, 0                                                         \
-  }
-#define star_v1_FirmwareInfo_init_zero                                                             \
-  {                                                                                                \
-    {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, {{NULL}, NULL},                          \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_FirmwareUpdateError_init_zero                                                      \
-  {                                                                                                \
-    _star_v1_FirmwareUpdateErrorCode_MIN, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0                     \
-  }
+#define star_v1_BeginUpdateRequest_init_default  {false, star_v1_RequestHeader_init_default, 0, {{NULL}, NULL}, 0}
+#define star_v1_BeginUpdateResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, 0, {{NULL}, NULL}, false, star_v1_FirmwareUpdateError_init_default}
+#define star_v1_WriteChunkRequest_init_default   {false, star_v1_RequestHeader_init_default, false, star_v1_FirmwareChunk_init_default}
+#define star_v1_WriteChunkResponse_init_default  {false, star_v1_ResponseHeader_init_default, 0, false, star_v1_FirmwareUpdateProgress_init_default}
+#define star_v1_FirmwareChunk_init_default       {{{NULL}, NULL}, 0, 0, 0}
+#define star_v1_StreamChunksResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, false, star_v1_FirmwareUpdateProgress_init_default, false, star_v1_FirmwareUpdateError_init_default}
+#define star_v1_FinalizeUpdateRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_FinalizeUpdateResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, 0, false, star_v1_FirmwareUpdateError_init_default}
+#define star_v1_AbortUpdateRequest_init_default  {false, star_v1_RequestHeader_init_default, {{NULL}, NULL}}
+#define star_v1_AbortUpdateResponse_init_default {false, star_v1_ResponseHeader_init_default, 0}
+#define star_v1_GetUpdateProgressRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_GetUpdateProgressResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_FirmwareUpdateProgress_init_default}
+#define star_v1_StreamUpdateProgressRequest_init_default {false, star_v1_RequestHeader_init_default, 0}
+#define star_v1_FirmwareUpdateProgress_init_default {0, 0, 0, 0, _star_v1_FirmwareUpdateState_MIN, 0, 0, 0}
+#define star_v1_RebootRequest_init_default       {false, star_v1_RequestHeader_init_default, 0}
+#define star_v1_RebootResponse_init_default      {false, star_v1_ResponseHeader_init_default, 0, 0}
+#define star_v1_RollbackRequest_init_default     {false, star_v1_RequestHeader_init_default}
+#define star_v1_RollbackResponse_init_default    {false, star_v1_ResponseHeader_init_default, 0, {{NULL}, NULL}}
+#define star_v1_MarkValidRequest_init_default    {false, star_v1_RequestHeader_init_default}
+#define star_v1_MarkValidResponse_init_default   {false, star_v1_ResponseHeader_init_default, 0}
+#define star_v1_GetFirmwareInfoRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_GetFirmwareInfoResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_FirmwareInfo_init_default, false, star_v1_FirmwareInfo_init_default, 0, 0}
+#define star_v1_FirmwareInfo_init_default        {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, {{NULL}, NULL}, {{NULL}, NULL}}
+#define star_v1_FirmwareUpdateError_init_default {_star_v1_FirmwareUpdateErrorCode_MIN, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0}
+#define star_v1_BeginUpdateRequest_init_zero     {false, star_v1_RequestHeader_init_zero, 0, {{NULL}, NULL}, 0}
+#define star_v1_BeginUpdateResponse_init_zero    {false, star_v1_ResponseHeader_init_zero, 0, 0, {{NULL}, NULL}, false, star_v1_FirmwareUpdateError_init_zero}
+#define star_v1_WriteChunkRequest_init_zero      {false, star_v1_RequestHeader_init_zero, false, star_v1_FirmwareChunk_init_zero}
+#define star_v1_WriteChunkResponse_init_zero     {false, star_v1_ResponseHeader_init_zero, 0, false, star_v1_FirmwareUpdateProgress_init_zero}
+#define star_v1_FirmwareChunk_init_zero          {{{NULL}, NULL}, 0, 0, 0}
+#define star_v1_StreamChunksResponse_init_zero   {false, star_v1_ResponseHeader_init_zero, 0, false, star_v1_FirmwareUpdateProgress_init_zero, false, star_v1_FirmwareUpdateError_init_zero}
+#define star_v1_FinalizeUpdateRequest_init_zero  {false, star_v1_RequestHeader_init_zero}
+#define star_v1_FinalizeUpdateResponse_init_zero {false, star_v1_ResponseHeader_init_zero, 0, 0, false, star_v1_FirmwareUpdateError_init_zero}
+#define star_v1_AbortUpdateRequest_init_zero     {false, star_v1_RequestHeader_init_zero, {{NULL}, NULL}}
+#define star_v1_AbortUpdateResponse_init_zero    {false, star_v1_ResponseHeader_init_zero, 0}
+#define star_v1_GetUpdateProgressRequest_init_zero {false, star_v1_RequestHeader_init_zero}
+#define star_v1_GetUpdateProgressResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_FirmwareUpdateProgress_init_zero}
+#define star_v1_StreamUpdateProgressRequest_init_zero {false, star_v1_RequestHeader_init_zero, 0}
+#define star_v1_FirmwareUpdateProgress_init_zero {0, 0, 0, 0, _star_v1_FirmwareUpdateState_MIN, 0, 0, 0}
+#define star_v1_RebootRequest_init_zero          {false, star_v1_RequestHeader_init_zero, 0}
+#define star_v1_RebootResponse_init_zero         {false, star_v1_ResponseHeader_init_zero, 0, 0}
+#define star_v1_RollbackRequest_init_zero        {false, star_v1_RequestHeader_init_zero}
+#define star_v1_RollbackResponse_init_zero       {false, star_v1_ResponseHeader_init_zero, 0, {{NULL}, NULL}}
+#define star_v1_MarkValidRequest_init_zero       {false, star_v1_RequestHeader_init_zero}
+#define star_v1_MarkValidResponse_init_zero      {false, star_v1_ResponseHeader_init_zero, 0}
+#define star_v1_GetFirmwareInfoRequest_init_zero {false, star_v1_RequestHeader_init_zero}
+#define star_v1_GetFirmwareInfoResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_FirmwareInfo_init_zero, false, star_v1_FirmwareInfo_init_zero, 0, 0}
+#define star_v1_FirmwareInfo_init_zero           {{{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, {{NULL}, NULL}, {{NULL}, NULL}}
+#define star_v1_FirmwareUpdateError_init_zero    {_star_v1_FirmwareUpdateErrorCode_MIN, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_BeginUpdateRequest_header_tag                          1
-#define star_v1_BeginUpdateRequest_firmware_size_tag                   2
-#define star_v1_BeginUpdateRequest_expected_version_tag                3
-#define star_v1_BeginUpdateRequest_expected_crc32_tag                  4
-#define star_v1_FirmwareChunk_data_tag                                 1
-#define star_v1_FirmwareChunk_sequence_tag                             2
-#define star_v1_FirmwareChunk_offset_tag                               3
-#define star_v1_FirmwareChunk_chunk_crc32_tag                          4
-#define star_v1_WriteChunkRequest_header_tag                           1
-#define star_v1_WriteChunkRequest_chunk_tag                            2
-#define star_v1_FinalizeUpdateRequest_header_tag                       1
-#define star_v1_AbortUpdateRequest_header_tag                          1
-#define star_v1_AbortUpdateRequest_reason_tag                          2
-#define star_v1_AbortUpdateResponse_header_tag                         1
-#define star_v1_AbortUpdateResponse_aborted_tag                        2
-#define star_v1_GetUpdateProgressRequest_header_tag                    1
-#define star_v1_StreamUpdateProgressRequest_header_tag                 1
-#define star_v1_StreamUpdateProgressRequest_update_interval_ms_tag     2
-#define star_v1_FirmwareUpdateProgress_total_size_tag                  1
-#define star_v1_FirmwareUpdateProgress_bytes_received_tag              2
-#define star_v1_FirmwareUpdateProgress_progress_percent_tag            3
-#define star_v1_FirmwareUpdateProgress_running_crc32_tag               4
-#define star_v1_FirmwareUpdateProgress_state_tag                       5
+#define star_v1_BeginUpdateRequest_header_tag    1
+#define star_v1_BeginUpdateRequest_firmware_size_tag 2
+#define star_v1_BeginUpdateRequest_expected_version_tag 3
+#define star_v1_BeginUpdateRequest_expected_crc32_tag 4
+#define star_v1_FirmwareChunk_data_tag           1
+#define star_v1_FirmwareChunk_sequence_tag       2
+#define star_v1_FirmwareChunk_offset_tag         3
+#define star_v1_FirmwareChunk_chunk_crc32_tag    4
+#define star_v1_WriteChunkRequest_header_tag     1
+#define star_v1_WriteChunkRequest_chunk_tag      2
+#define star_v1_FinalizeUpdateRequest_header_tag 1
+#define star_v1_AbortUpdateRequest_header_tag    1
+#define star_v1_AbortUpdateRequest_reason_tag    2
+#define star_v1_AbortUpdateResponse_header_tag   1
+#define star_v1_AbortUpdateResponse_aborted_tag  2
+#define star_v1_GetUpdateProgressRequest_header_tag 1
+#define star_v1_StreamUpdateProgressRequest_header_tag 1
+#define star_v1_StreamUpdateProgressRequest_update_interval_ms_tag 2
+#define star_v1_FirmwareUpdateProgress_total_size_tag 1
+#define star_v1_FirmwareUpdateProgress_bytes_received_tag 2
+#define star_v1_FirmwareUpdateProgress_progress_percent_tag 3
+#define star_v1_FirmwareUpdateProgress_running_crc32_tag 4
+#define star_v1_FirmwareUpdateProgress_state_tag 5
 #define star_v1_FirmwareUpdateProgress_estimated_seconds_remaining_tag 6
-#define star_v1_FirmwareUpdateProgress_transfer_speed_bps_tag          7
-#define star_v1_FirmwareUpdateProgress_last_sequence_tag               8
-#define star_v1_WriteChunkResponse_header_tag                          1
-#define star_v1_WriteChunkResponse_success_tag                         2
-#define star_v1_WriteChunkResponse_progress_tag                        3
-#define star_v1_GetUpdateProgressResponse_header_tag                   1
-#define star_v1_GetUpdateProgressResponse_progress_tag                 2
-#define star_v1_RebootRequest_header_tag                               1
-#define star_v1_RebootRequest_delay_ms_tag                             2
-#define star_v1_RebootResponse_header_tag                              1
-#define star_v1_RebootResponse_rebooting_tag                           2
-#define star_v1_RebootResponse_reboot_delay_ms_tag                     3
-#define star_v1_RollbackRequest_header_tag                             1
-#define star_v1_RollbackResponse_header_tag                            1
-#define star_v1_RollbackResponse_rolling_back_tag                      2
-#define star_v1_RollbackResponse_previous_version_tag                  3
-#define star_v1_MarkValidRequest_header_tag                            1
-#define star_v1_MarkValidResponse_header_tag                           1
-#define star_v1_MarkValidResponse_marked_valid_tag                     2
-#define star_v1_GetFirmwareInfoRequest_header_tag                      1
-#define star_v1_FirmwareInfo_version_tag                               1
-#define star_v1_FirmwareInfo_git_hash_tag                              2
-#define star_v1_FirmwareInfo_build_date_tag                            3
-#define star_v1_FirmwareInfo_size_tag                                  4
-#define star_v1_FirmwareInfo_crc32_tag                                 5
-#define star_v1_FirmwareInfo_idf_version_tag                           6
-#define star_v1_FirmwareInfo_chip_target_tag                           7
-#define star_v1_GetFirmwareInfoResponse_header_tag                     1
-#define star_v1_GetFirmwareInfoResponse_current_firmware_tag           2
-#define star_v1_GetFirmwareInfoResponse_previous_firmware_tag          3
-#define star_v1_GetFirmwareInfoResponse_is_ota_boot_tag                4
-#define star_v1_GetFirmwareInfoResponse_is_valid_tag                   5
-#define star_v1_FirmwareUpdateError_code_tag                           1
-#define star_v1_FirmwareUpdateError_message_tag                        2
-#define star_v1_FirmwareUpdateError_details_tag                        3
-#define star_v1_FirmwareUpdateError_error_at_sequence_tag              4
-#define star_v1_FirmwareUpdateError_error_at_offset_tag                5
-#define star_v1_BeginUpdateResponse_header_tag                         1
-#define star_v1_BeginUpdateResponse_accepted_tag                       2
-#define star_v1_BeginUpdateResponse_max_chunk_size_tag                 3
-#define star_v1_BeginUpdateResponse_session_id_tag                     4
-#define star_v1_BeginUpdateResponse_error_tag                          5
-#define star_v1_StreamChunksResponse_header_tag                        1
-#define star_v1_StreamChunksResponse_chunks_received_tag               2
-#define star_v1_StreamChunksResponse_progress_tag                      3
-#define star_v1_StreamChunksResponse_error_tag                         4
-#define star_v1_FinalizeUpdateResponse_header_tag                      1
-#define star_v1_FinalizeUpdateResponse_validated_tag                   2
-#define star_v1_FinalizeUpdateResponse_ready_to_reboot_tag             3
-#define star_v1_FinalizeUpdateResponse_error_tag                       4
+#define star_v1_FirmwareUpdateProgress_transfer_speed_bps_tag 7
+#define star_v1_FirmwareUpdateProgress_last_sequence_tag 8
+#define star_v1_WriteChunkResponse_header_tag    1
+#define star_v1_WriteChunkResponse_success_tag   2
+#define star_v1_WriteChunkResponse_progress_tag  3
+#define star_v1_GetUpdateProgressResponse_header_tag 1
+#define star_v1_GetUpdateProgressResponse_progress_tag 2
+#define star_v1_RebootRequest_header_tag         1
+#define star_v1_RebootRequest_delay_ms_tag       2
+#define star_v1_RebootResponse_header_tag        1
+#define star_v1_RebootResponse_rebooting_tag     2
+#define star_v1_RebootResponse_reboot_delay_ms_tag 3
+#define star_v1_RollbackRequest_header_tag       1
+#define star_v1_RollbackResponse_header_tag      1
+#define star_v1_RollbackResponse_rolling_back_tag 2
+#define star_v1_RollbackResponse_previous_version_tag 3
+#define star_v1_MarkValidRequest_header_tag      1
+#define star_v1_MarkValidResponse_header_tag     1
+#define star_v1_MarkValidResponse_marked_valid_tag 2
+#define star_v1_GetFirmwareInfoRequest_header_tag 1
+#define star_v1_FirmwareInfo_version_tag         1
+#define star_v1_FirmwareInfo_git_hash_tag        2
+#define star_v1_FirmwareInfo_build_date_tag      3
+#define star_v1_FirmwareInfo_size_tag            4
+#define star_v1_FirmwareInfo_crc32_tag           5
+#define star_v1_FirmwareInfo_idf_version_tag     6
+#define star_v1_FirmwareInfo_chip_target_tag     7
+#define star_v1_GetFirmwareInfoResponse_header_tag 1
+#define star_v1_GetFirmwareInfoResponse_current_firmware_tag 2
+#define star_v1_GetFirmwareInfoResponse_previous_firmware_tag 3
+#define star_v1_GetFirmwareInfoResponse_is_ota_boot_tag 4
+#define star_v1_GetFirmwareInfoResponse_is_valid_tag 5
+#define star_v1_FirmwareUpdateError_code_tag     1
+#define star_v1_FirmwareUpdateError_message_tag  2
+#define star_v1_FirmwareUpdateError_details_tag  3
+#define star_v1_FirmwareUpdateError_error_at_sequence_tag 4
+#define star_v1_FirmwareUpdateError_error_at_offset_tag 5
+#define star_v1_BeginUpdateResponse_header_tag   1
+#define star_v1_BeginUpdateResponse_accepted_tag 2
+#define star_v1_BeginUpdateResponse_max_chunk_size_tag 3
+#define star_v1_BeginUpdateResponse_session_id_tag 4
+#define star_v1_BeginUpdateResponse_error_tag    5
+#define star_v1_StreamChunksResponse_header_tag  1
+#define star_v1_StreamChunksResponse_chunks_received_tag 2
+#define star_v1_StreamChunksResponse_progress_tag 3
+#define star_v1_StreamChunksResponse_error_tag   4
+#define star_v1_FinalizeUpdateResponse_header_tag 1
+#define star_v1_FinalizeUpdateResponse_validated_tag 2
+#define star_v1_FinalizeUpdateResponse_ready_to_reboot_tag 3
+#define star_v1_FinalizeUpdateResponse_error_tag 4
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_BeginUpdateRequest_FIELDLIST(X, a)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, UINT32, firmware_size, 2)                                                 \
-  X(a, CALLBACK, SINGULAR, STRING, expected_version, 3)                                            \
-  X(a, STATIC, SINGULAR, UINT32, expected_crc32, 4)
-#define star_v1_BeginUpdateRequest_CALLBACK       pb_default_field_callback
-#define star_v1_BeginUpdateRequest_DEFAULT        NULL
+#define star_v1_BeginUpdateRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, UINT32,   firmware_size,     2) \
+X(a, CALLBACK, SINGULAR, STRING,   expected_version,   3) \
+X(a, STATIC,   SINGULAR, UINT32,   expected_crc32,    4)
+#define star_v1_BeginUpdateRequest_CALLBACK pb_default_field_callback
+#define star_v1_BeginUpdateRequest_DEFAULT NULL
 #define star_v1_BeginUpdateRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_BeginUpdateResponse_FIELDLIST(X, a)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, accepted, 2)                                                        \
-  X(a, STATIC, SINGULAR, UINT32, max_chunk_size, 3)                                                \
-  X(a, CALLBACK, SINGULAR, STRING, session_id, 4)                                                  \
-  X(a, STATIC, OPTIONAL, MESSAGE, error, 5)
-#define star_v1_BeginUpdateResponse_CALLBACK       pb_default_field_callback
-#define star_v1_BeginUpdateResponse_DEFAULT        NULL
+#define star_v1_BeginUpdateResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     accepted,          2) \
+X(a, STATIC,   SINGULAR, UINT32,   max_chunk_size,    3) \
+X(a, CALLBACK, SINGULAR, STRING,   session_id,        4) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  error,             5)
+#define star_v1_BeginUpdateResponse_CALLBACK pb_default_field_callback
+#define star_v1_BeginUpdateResponse_DEFAULT NULL
 #define star_v1_BeginUpdateResponse_header_MSGTYPE star_v1_ResponseHeader
-#define star_v1_BeginUpdateResponse_error_MSGTYPE  star_v1_FirmwareUpdateError
+#define star_v1_BeginUpdateResponse_error_MSGTYPE star_v1_FirmwareUpdateError
 
-#define star_v1_WriteChunkRequest_FIELDLIST(X, a)                                                  \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, chunk, 2)
-#define star_v1_WriteChunkRequest_CALLBACK       NULL
-#define star_v1_WriteChunkRequest_DEFAULT        NULL
+#define star_v1_WriteChunkRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  chunk,             2)
+#define star_v1_WriteChunkRequest_CALLBACK NULL
+#define star_v1_WriteChunkRequest_DEFAULT NULL
 #define star_v1_WriteChunkRequest_header_MSGTYPE star_v1_RequestHeader
-#define star_v1_WriteChunkRequest_chunk_MSGTYPE  star_v1_FirmwareChunk
+#define star_v1_WriteChunkRequest_chunk_MSGTYPE star_v1_FirmwareChunk
 
-#define star_v1_WriteChunkResponse_FIELDLIST(X, a)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, success, 2)                                                         \
-  X(a, STATIC, OPTIONAL, MESSAGE, progress, 3)
-#define star_v1_WriteChunkResponse_CALLBACK         NULL
-#define star_v1_WriteChunkResponse_DEFAULT          NULL
-#define star_v1_WriteChunkResponse_header_MSGTYPE   star_v1_ResponseHeader
+#define star_v1_WriteChunkResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     success,           2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  progress,          3)
+#define star_v1_WriteChunkResponse_CALLBACK NULL
+#define star_v1_WriteChunkResponse_DEFAULT NULL
+#define star_v1_WriteChunkResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_WriteChunkResponse_progress_MSGTYPE star_v1_FirmwareUpdateProgress
 
-#define star_v1_FirmwareChunk_FIELDLIST(X, a)                                                      \
-  X(a, CALLBACK, SINGULAR, BYTES, data, 1)                                                         \
-  X(a, STATIC, SINGULAR, UINT32, sequence, 2)                                                      \
-  X(a, STATIC, SINGULAR, UINT32, offset, 3)                                                        \
-  X(a, STATIC, SINGULAR, UINT32, chunk_crc32, 4)
+#define star_v1_FirmwareChunk_FIELDLIST(X, a) \
+X(a, CALLBACK, SINGULAR, BYTES,    data,              1) \
+X(a, STATIC,   SINGULAR, UINT32,   sequence,          2) \
+X(a, STATIC,   SINGULAR, UINT32,   offset,            3) \
+X(a, STATIC,   SINGULAR, UINT32,   chunk_crc32,       4)
 #define star_v1_FirmwareChunk_CALLBACK pb_default_field_callback
-#define star_v1_FirmwareChunk_DEFAULT  NULL
+#define star_v1_FirmwareChunk_DEFAULT NULL
 
-#define star_v1_StreamChunksResponse_FIELDLIST(X, a)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, UINT32, chunks_received, 2)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, progress, 3)                                                     \
-  X(a, STATIC, OPTIONAL, MESSAGE, error, 4)
-#define star_v1_StreamChunksResponse_CALLBACK         NULL
-#define star_v1_StreamChunksResponse_DEFAULT          NULL
-#define star_v1_StreamChunksResponse_header_MSGTYPE   star_v1_ResponseHeader
+#define star_v1_StreamChunksResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, UINT32,   chunks_received,   2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  progress,          3) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  error,             4)
+#define star_v1_StreamChunksResponse_CALLBACK NULL
+#define star_v1_StreamChunksResponse_DEFAULT NULL
+#define star_v1_StreamChunksResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_StreamChunksResponse_progress_MSGTYPE star_v1_FirmwareUpdateProgress
-#define star_v1_StreamChunksResponse_error_MSGTYPE    star_v1_FirmwareUpdateError
+#define star_v1_StreamChunksResponse_error_MSGTYPE star_v1_FirmwareUpdateError
 
-#define star_v1_FinalizeUpdateRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_FinalizeUpdateRequest_CALLBACK        NULL
-#define star_v1_FinalizeUpdateRequest_DEFAULT         NULL
-#define star_v1_FinalizeUpdateRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_FinalizeUpdateRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_FinalizeUpdateRequest_CALLBACK NULL
+#define star_v1_FinalizeUpdateRequest_DEFAULT NULL
+#define star_v1_FinalizeUpdateRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_FinalizeUpdateResponse_FIELDLIST(X, a)                                             \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, validated, 2)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, ready_to_reboot, 3)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, error, 4)
-#define star_v1_FinalizeUpdateResponse_CALLBACK       NULL
-#define star_v1_FinalizeUpdateResponse_DEFAULT        NULL
+#define star_v1_FinalizeUpdateResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     validated,         2) \
+X(a, STATIC,   SINGULAR, BOOL,     ready_to_reboot,   3) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  error,             4)
+#define star_v1_FinalizeUpdateResponse_CALLBACK NULL
+#define star_v1_FinalizeUpdateResponse_DEFAULT NULL
 #define star_v1_FinalizeUpdateResponse_header_MSGTYPE star_v1_ResponseHeader
-#define star_v1_FinalizeUpdateResponse_error_MSGTYPE  star_v1_FirmwareUpdateError
+#define star_v1_FinalizeUpdateResponse_error_MSGTYPE star_v1_FirmwareUpdateError
 
-#define star_v1_AbortUpdateRequest_FIELDLIST(X, a)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, CALLBACK, SINGULAR, STRING, reason, 2)
-#define star_v1_AbortUpdateRequest_CALLBACK       pb_default_field_callback
-#define star_v1_AbortUpdateRequest_DEFAULT        NULL
+#define star_v1_AbortUpdateRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, CALLBACK, SINGULAR, STRING,   reason,            2)
+#define star_v1_AbortUpdateRequest_CALLBACK pb_default_field_callback
+#define star_v1_AbortUpdateRequest_DEFAULT NULL
 #define star_v1_AbortUpdateRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_AbortUpdateResponse_FIELDLIST(X, a)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, aborted, 2)
-#define star_v1_AbortUpdateResponse_CALLBACK       NULL
-#define star_v1_AbortUpdateResponse_DEFAULT        NULL
+#define star_v1_AbortUpdateResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     aborted,           2)
+#define star_v1_AbortUpdateResponse_CALLBACK NULL
+#define star_v1_AbortUpdateResponse_DEFAULT NULL
 #define star_v1_AbortUpdateResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_GetUpdateProgressRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetUpdateProgressRequest_CALLBACK        NULL
-#define star_v1_GetUpdateProgressRequest_DEFAULT         NULL
-#define star_v1_GetUpdateProgressRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_GetUpdateProgressRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_GetUpdateProgressRequest_CALLBACK NULL
+#define star_v1_GetUpdateProgressRequest_DEFAULT NULL
+#define star_v1_GetUpdateProgressRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetUpdateProgressResponse_FIELDLIST(X, a)                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, progress, 2)
-#define star_v1_GetUpdateProgressResponse_CALLBACK         NULL
-#define star_v1_GetUpdateProgressResponse_DEFAULT          NULL
-#define star_v1_GetUpdateProgressResponse_header_MSGTYPE   star_v1_ResponseHeader
+#define star_v1_GetUpdateProgressResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  progress,          2)
+#define star_v1_GetUpdateProgressResponse_CALLBACK NULL
+#define star_v1_GetUpdateProgressResponse_DEFAULT NULL
+#define star_v1_GetUpdateProgressResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetUpdateProgressResponse_progress_MSGTYPE star_v1_FirmwareUpdateProgress
 
-#define star_v1_StreamUpdateProgressRequest_FIELDLIST(X, a)                                        \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, UINT32, update_interval_ms, 2)
-#define star_v1_StreamUpdateProgressRequest_CALLBACK       NULL
-#define star_v1_StreamUpdateProgressRequest_DEFAULT        NULL
+#define star_v1_StreamUpdateProgressRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, UINT32,   update_interval_ms,   2)
+#define star_v1_StreamUpdateProgressRequest_CALLBACK NULL
+#define star_v1_StreamUpdateProgressRequest_DEFAULT NULL
 #define star_v1_StreamUpdateProgressRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_FirmwareUpdateProgress_FIELDLIST(X, a)                                             \
-  X(a, STATIC, SINGULAR, UINT32, total_size, 1)                                                    \
-  X(a, STATIC, SINGULAR, UINT32, bytes_received, 2)                                                \
-  X(a, STATIC, SINGULAR, INT32, progress_percent, 3)                                               \
-  X(a, STATIC, SINGULAR, UINT32, running_crc32, 4)                                                 \
-  X(a, STATIC, SINGULAR, UENUM, state, 5)                                                          \
-  X(a, STATIC, SINGULAR, INT32, estimated_seconds_remaining, 6)                                    \
-  X(a, STATIC, SINGULAR, UINT32, transfer_speed_bps, 7)                                            \
-  X(a, STATIC, SINGULAR, UINT32, last_sequence, 8)
+#define star_v1_FirmwareUpdateProgress_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UINT32,   total_size,        1) \
+X(a, STATIC,   SINGULAR, UINT32,   bytes_received,    2) \
+X(a, STATIC,   SINGULAR, INT32,    progress_percent,   3) \
+X(a, STATIC,   SINGULAR, UINT32,   running_crc32,     4) \
+X(a, STATIC,   SINGULAR, UENUM,    state,             5) \
+X(a, STATIC,   SINGULAR, INT32,    estimated_seconds_remaining,   6) \
+X(a, STATIC,   SINGULAR, UINT32,   transfer_speed_bps,   7) \
+X(a, STATIC,   SINGULAR, UINT32,   last_sequence,     8)
 #define star_v1_FirmwareUpdateProgress_CALLBACK NULL
-#define star_v1_FirmwareUpdateProgress_DEFAULT  NULL
+#define star_v1_FirmwareUpdateProgress_DEFAULT NULL
 
-#define star_v1_RebootRequest_FIELDLIST(X, a)                                                      \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, UINT32, delay_ms, 2)
-#define star_v1_RebootRequest_CALLBACK       NULL
-#define star_v1_RebootRequest_DEFAULT        NULL
+#define star_v1_RebootRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, UINT32,   delay_ms,          2)
+#define star_v1_RebootRequest_CALLBACK NULL
+#define star_v1_RebootRequest_DEFAULT NULL
 #define star_v1_RebootRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_RebootResponse_FIELDLIST(X, a)                                                     \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, rebooting, 2)                                                       \
-  X(a, STATIC, SINGULAR, UINT32, reboot_delay_ms, 3)
-#define star_v1_RebootResponse_CALLBACK       NULL
-#define star_v1_RebootResponse_DEFAULT        NULL
+#define star_v1_RebootResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     rebooting,         2) \
+X(a, STATIC,   SINGULAR, UINT32,   reboot_delay_ms,   3)
+#define star_v1_RebootResponse_CALLBACK NULL
+#define star_v1_RebootResponse_DEFAULT NULL
 #define star_v1_RebootResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_RollbackRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_RollbackRequest_CALLBACK        NULL
-#define star_v1_RollbackRequest_DEFAULT         NULL
-#define star_v1_RollbackRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_RollbackRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_RollbackRequest_CALLBACK NULL
+#define star_v1_RollbackRequest_DEFAULT NULL
+#define star_v1_RollbackRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_RollbackResponse_FIELDLIST(X, a)                                                   \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, rolling_back, 2)                                                    \
-  X(a, CALLBACK, SINGULAR, STRING, previous_version, 3)
-#define star_v1_RollbackResponse_CALLBACK       pb_default_field_callback
-#define star_v1_RollbackResponse_DEFAULT        NULL
+#define star_v1_RollbackResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     rolling_back,      2) \
+X(a, CALLBACK, SINGULAR, STRING,   previous_version,   3)
+#define star_v1_RollbackResponse_CALLBACK pb_default_field_callback
+#define star_v1_RollbackResponse_DEFAULT NULL
 #define star_v1_RollbackResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_MarkValidRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_MarkValidRequest_CALLBACK        NULL
-#define star_v1_MarkValidRequest_DEFAULT         NULL
-#define star_v1_MarkValidRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_MarkValidRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_MarkValidRequest_CALLBACK NULL
+#define star_v1_MarkValidRequest_DEFAULT NULL
+#define star_v1_MarkValidRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_MarkValidResponse_FIELDLIST(X, a)                                                  \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, marked_valid, 2)
-#define star_v1_MarkValidResponse_CALLBACK       NULL
-#define star_v1_MarkValidResponse_DEFAULT        NULL
+#define star_v1_MarkValidResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     marked_valid,      2)
+#define star_v1_MarkValidResponse_CALLBACK NULL
+#define star_v1_MarkValidResponse_DEFAULT NULL
 #define star_v1_MarkValidResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_GetFirmwareInfoRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetFirmwareInfoRequest_CALLBACK        NULL
-#define star_v1_GetFirmwareInfoRequest_DEFAULT         NULL
-#define star_v1_GetFirmwareInfoRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_GetFirmwareInfoRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_GetFirmwareInfoRequest_CALLBACK NULL
+#define star_v1_GetFirmwareInfoRequest_DEFAULT NULL
+#define star_v1_GetFirmwareInfoRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetFirmwareInfoResponse_FIELDLIST(X, a)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, current_firmware, 2)                                             \
-  X(a, STATIC, OPTIONAL, MESSAGE, previous_firmware, 3)                                            \
-  X(a, STATIC, SINGULAR, BOOL, is_ota_boot, 4)                                                     \
-  X(a, STATIC, SINGULAR, BOOL, is_valid, 5)
-#define star_v1_GetFirmwareInfoResponse_CALLBACK                  NULL
-#define star_v1_GetFirmwareInfoResponse_DEFAULT                   NULL
-#define star_v1_GetFirmwareInfoResponse_header_MSGTYPE            star_v1_ResponseHeader
-#define star_v1_GetFirmwareInfoResponse_current_firmware_MSGTYPE  star_v1_FirmwareInfo
+#define star_v1_GetFirmwareInfoResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  current_firmware,   2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  previous_firmware,   3) \
+X(a, STATIC,   SINGULAR, BOOL,     is_ota_boot,       4) \
+X(a, STATIC,   SINGULAR, BOOL,     is_valid,          5)
+#define star_v1_GetFirmwareInfoResponse_CALLBACK NULL
+#define star_v1_GetFirmwareInfoResponse_DEFAULT NULL
+#define star_v1_GetFirmwareInfoResponse_header_MSGTYPE star_v1_ResponseHeader
+#define star_v1_GetFirmwareInfoResponse_current_firmware_MSGTYPE star_v1_FirmwareInfo
 #define star_v1_GetFirmwareInfoResponse_previous_firmware_MSGTYPE star_v1_FirmwareInfo
 
-#define star_v1_FirmwareInfo_FIELDLIST(X, a)                                                       \
-  X(a, CALLBACK, SINGULAR, STRING, version, 1)                                                     \
-  X(a, CALLBACK, SINGULAR, STRING, git_hash, 2)                                                    \
-  X(a, CALLBACK, SINGULAR, STRING, build_date, 3)                                                  \
-  X(a, STATIC, SINGULAR, UINT32, size, 4)                                                          \
-  X(a, STATIC, SINGULAR, UINT32, crc32, 5)                                                         \
-  X(a, CALLBACK, SINGULAR, STRING, idf_version, 6)                                                 \
-  X(a, CALLBACK, SINGULAR, STRING, chip_target, 7)
+#define star_v1_FirmwareInfo_FIELDLIST(X, a) \
+X(a, CALLBACK, SINGULAR, STRING,   version,           1) \
+X(a, CALLBACK, SINGULAR, STRING,   git_hash,          2) \
+X(a, CALLBACK, SINGULAR, STRING,   build_date,        3) \
+X(a, STATIC,   SINGULAR, UINT32,   size,              4) \
+X(a, STATIC,   SINGULAR, UINT32,   crc32,             5) \
+X(a, CALLBACK, SINGULAR, STRING,   idf_version,       6) \
+X(a, CALLBACK, SINGULAR, STRING,   chip_target,       7)
 #define star_v1_FirmwareInfo_CALLBACK pb_default_field_callback
-#define star_v1_FirmwareInfo_DEFAULT  NULL
+#define star_v1_FirmwareInfo_DEFAULT NULL
 
-#define star_v1_FirmwareUpdateError_FIELDLIST(X, a)                                                \
-  X(a, STATIC, SINGULAR, UENUM, code, 1)                                                           \
-  X(a, CALLBACK, SINGULAR, STRING, message, 2)                                                     \
-  X(a, CALLBACK, SINGULAR, STRING, details, 3)                                                     \
-  X(a, STATIC, SINGULAR, UINT32, error_at_sequence, 4)                                             \
-  X(a, STATIC, SINGULAR, UINT32, error_at_offset, 5)
+#define star_v1_FirmwareUpdateError_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UENUM,    code,              1) \
+X(a, CALLBACK, SINGULAR, STRING,   message,           2) \
+X(a, CALLBACK, SINGULAR, STRING,   details,           3) \
+X(a, STATIC,   SINGULAR, UINT32,   error_at_sequence,   4) \
+X(a, STATIC,   SINGULAR, UINT32,   error_at_offset,   5)
 #define star_v1_FirmwareUpdateError_CALLBACK pb_default_field_callback
-#define star_v1_FirmwareUpdateError_DEFAULT  NULL
+#define star_v1_FirmwareUpdateError_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_BeginUpdateRequest_msg;
 extern const pb_msgdesc_t star_v1_BeginUpdateResponse_msg;
@@ -880,30 +733,30 @@ extern const pb_msgdesc_t star_v1_FirmwareInfo_msg;
 extern const pb_msgdesc_t star_v1_FirmwareUpdateError_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_BeginUpdateRequest_fields          &star_v1_BeginUpdateRequest_msg
-#define star_v1_BeginUpdateResponse_fields         &star_v1_BeginUpdateResponse_msg
-#define star_v1_WriteChunkRequest_fields           &star_v1_WriteChunkRequest_msg
-#define star_v1_WriteChunkResponse_fields          &star_v1_WriteChunkResponse_msg
-#define star_v1_FirmwareChunk_fields               &star_v1_FirmwareChunk_msg
-#define star_v1_StreamChunksResponse_fields        &star_v1_StreamChunksResponse_msg
-#define star_v1_FinalizeUpdateRequest_fields       &star_v1_FinalizeUpdateRequest_msg
-#define star_v1_FinalizeUpdateResponse_fields      &star_v1_FinalizeUpdateResponse_msg
-#define star_v1_AbortUpdateRequest_fields          &star_v1_AbortUpdateRequest_msg
-#define star_v1_AbortUpdateResponse_fields         &star_v1_AbortUpdateResponse_msg
-#define star_v1_GetUpdateProgressRequest_fields    &star_v1_GetUpdateProgressRequest_msg
-#define star_v1_GetUpdateProgressResponse_fields   &star_v1_GetUpdateProgressResponse_msg
+#define star_v1_BeginUpdateRequest_fields &star_v1_BeginUpdateRequest_msg
+#define star_v1_BeginUpdateResponse_fields &star_v1_BeginUpdateResponse_msg
+#define star_v1_WriteChunkRequest_fields &star_v1_WriteChunkRequest_msg
+#define star_v1_WriteChunkResponse_fields &star_v1_WriteChunkResponse_msg
+#define star_v1_FirmwareChunk_fields &star_v1_FirmwareChunk_msg
+#define star_v1_StreamChunksResponse_fields &star_v1_StreamChunksResponse_msg
+#define star_v1_FinalizeUpdateRequest_fields &star_v1_FinalizeUpdateRequest_msg
+#define star_v1_FinalizeUpdateResponse_fields &star_v1_FinalizeUpdateResponse_msg
+#define star_v1_AbortUpdateRequest_fields &star_v1_AbortUpdateRequest_msg
+#define star_v1_AbortUpdateResponse_fields &star_v1_AbortUpdateResponse_msg
+#define star_v1_GetUpdateProgressRequest_fields &star_v1_GetUpdateProgressRequest_msg
+#define star_v1_GetUpdateProgressResponse_fields &star_v1_GetUpdateProgressResponse_msg
 #define star_v1_StreamUpdateProgressRequest_fields &star_v1_StreamUpdateProgressRequest_msg
-#define star_v1_FirmwareUpdateProgress_fields      &star_v1_FirmwareUpdateProgress_msg
-#define star_v1_RebootRequest_fields               &star_v1_RebootRequest_msg
-#define star_v1_RebootResponse_fields              &star_v1_RebootResponse_msg
-#define star_v1_RollbackRequest_fields             &star_v1_RollbackRequest_msg
-#define star_v1_RollbackResponse_fields            &star_v1_RollbackResponse_msg
-#define star_v1_MarkValidRequest_fields            &star_v1_MarkValidRequest_msg
-#define star_v1_MarkValidResponse_fields           &star_v1_MarkValidResponse_msg
-#define star_v1_GetFirmwareInfoRequest_fields      &star_v1_GetFirmwareInfoRequest_msg
-#define star_v1_GetFirmwareInfoResponse_fields     &star_v1_GetFirmwareInfoResponse_msg
-#define star_v1_FirmwareInfo_fields                &star_v1_FirmwareInfo_msg
-#define star_v1_FirmwareUpdateError_fields         &star_v1_FirmwareUpdateError_msg
+#define star_v1_FirmwareUpdateProgress_fields &star_v1_FirmwareUpdateProgress_msg
+#define star_v1_RebootRequest_fields &star_v1_RebootRequest_msg
+#define star_v1_RebootResponse_fields &star_v1_RebootResponse_msg
+#define star_v1_RollbackRequest_fields &star_v1_RollbackRequest_msg
+#define star_v1_RollbackResponse_fields &star_v1_RollbackResponse_msg
+#define star_v1_MarkValidRequest_fields &star_v1_MarkValidRequest_msg
+#define star_v1_MarkValidResponse_fields &star_v1_MarkValidResponse_msg
+#define star_v1_GetFirmwareInfoRequest_fields &star_v1_GetFirmwareInfoRequest_msg
+#define star_v1_GetFirmwareInfoResponse_fields &star_v1_GetFirmwareInfoResponse_msg
+#define star_v1_FirmwareInfo_fields &star_v1_FirmwareInfo_msg
+#define star_v1_FirmwareUpdateError_fields &star_v1_FirmwareUpdateError_msg
 
 /* Maximum encoded size of messages (where known) */
 /* star_v1_BeginUpdateRequest_size depends on runtime parameters */
@@ -918,19 +771,19 @@ extern const pb_msgdesc_t star_v1_FirmwareUpdateError_msg;
 /* star_v1_FirmwareInfo_size depends on runtime parameters */
 /* star_v1_FirmwareUpdateError_size depends on runtime parameters */
 #define STAR_V1_STAR_V1_FIRMWARE_UPDATE_PB_H_MAX_SIZE star_v1_WriteChunkResponse_size
-#define star_v1_AbortUpdateResponse_size              365
-#define star_v1_FinalizeUpdateRequest_size            149
-#define star_v1_FirmwareUpdateProgress_size           54
-#define star_v1_GetFirmwareInfoRequest_size           149
-#define star_v1_GetUpdateProgressRequest_size         149
-#define star_v1_GetUpdateProgressResponse_size        419
-#define star_v1_MarkValidRequest_size                 149
-#define star_v1_MarkValidResponse_size                365
-#define star_v1_RebootRequest_size                    155
-#define star_v1_RebootResponse_size                   371
-#define star_v1_RollbackRequest_size                  149
-#define star_v1_StreamUpdateProgressRequest_size      155
-#define star_v1_WriteChunkResponse_size               421
+#define star_v1_AbortUpdateResponse_size         365
+#define star_v1_FinalizeUpdateRequest_size       149
+#define star_v1_FirmwareUpdateProgress_size      54
+#define star_v1_GetFirmwareInfoRequest_size      149
+#define star_v1_GetUpdateProgressRequest_size    149
+#define star_v1_GetUpdateProgressResponse_size   419
+#define star_v1_MarkValidRequest_size            149
+#define star_v1_MarkValidResponse_size           365
+#define star_v1_RebootRequest_size               155
+#define star_v1_RebootResponse_size              371
+#define star_v1_RollbackRequest_size             149
+#define star_v1_StreamUpdateProgressRequest_size 155
+#define star_v1_WriteChunkResponse_size          421
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.c
@@ -8,12 +8,20 @@
 
 PB_BIND(star_v1_ForwardTelemetryRequest, star_v1_ForwardTelemetryRequest, 4)
 
+
 PB_BIND(star_v1_ForwardTelemetryResponse, star_v1_ForwardTelemetryResponse, 2)
+
 
 PB_BIND(star_v1_GetTeleopCommandRequest, star_v1_GetTeleopCommandRequest, AUTO)
 
+
 PB_BIND(star_v1_GetTeleopCommandResponse, star_v1_GetTeleopCommandResponse, 2)
+
 
 PB_BIND(star_v1_SetPIDGainsRequest, star_v1_SetPIDGainsRequest, AUTO)
 
+
 PB_BIND(star_v1_SetPIDGainsResponse, star_v1_SetPIDGainsResponse, 2)
+
+
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_GATEWAY_SERVICE_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_GATEWAY_SERVICE_PB_H_INCLUDED
 #include <pb.h>
-
 #include "star/v1/common.pb.h"
 #include "star/v1/motor_control.pb.h"
 #include "star/v1/telemetry.pb.h"
@@ -17,243 +16,191 @@
 /* Struct definitions */
 /* Request to forward telemetry from ROS2 to Gateway. */
 typedef struct _star_v1_ForwardTelemetryRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Robot system status (mode, connections, uptime).
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Robot system status (mode, connections, uptime).
  Forwarded from /robot_status ROS2 topic. */
-  bool                 has_system_status;
-  star_v1_SystemStatus system_status;
-  /* Optional: Additional telemetry data (IMU, GPS, etc.). */
-  bool                  has_telemetry;
-  star_v1_TelemetryData telemetry;
-  /* Per-motor status for all drive motors.
+    bool has_system_status;
+    star_v1_SystemStatus system_status;
+    /* Optional: Additional telemetry data (IMU, GPS, etc.). */
+    bool has_telemetry;
+    star_v1_TelemetryData telemetry;
+    /* Per-motor status for all drive motors.
  Forwarded from /motor_status ROS2 topic.
  nanopb: max_count:4 (4-motor drive configuration; defined in gateway_service.options). */
-  pb_size_t           motor_status_count;
-  star_v1_MotorStatus motor_status[4];
-  /* Robot pose and velocity from wheel odometry.
+    pb_size_t motor_status_count;
+    star_v1_MotorStatus motor_status[4];
+    /* Robot pose and velocity from wheel odometry.
  Forwarded from /odometry ROS2 topic.
  nanopb: OdometryData contains only fixed-width scalar fields (double, int64);
    no repeated fields or variable-length strings, so no max_size/max_count
    constraints are needed beyond those enforced by the message field types. */
-  bool                 has_odometry;
-  star_v1_OdometryData odometry;
-  /* Latest LiDAR scan from RPLiDAR C1.
+    bool has_odometry;
+    star_v1_OdometryData odometry;
+    /* Latest LiDAR scan from RPLiDAR C1.
  Forwarded from /scan ROS2 topic.
  nanopb: LidarScan.angle_rad, LidarScan.range_m, and LidarScan.intensity are
    bounded by max_count:800 (RPLiDAR C1 maximum samples per revolution at
    10 Hz scan mode). Defined in ui.options and duplicated in gateway_service.options. */
-  bool              has_lidar_scan;
-  star_v1_LidarScan lidar_scan;
+    bool has_lidar_scan;
+    star_v1_LidarScan lidar_scan;
 } star_v1_ForwardTelemetryRequest;
 
 /* Response to telemetry forwarding. */
 typedef struct _star_v1_ForwardTelemetryResponse {
-  /* Standard response header. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if telemetry was successfully cached for UI streaming. */
-  bool cached;
-  /* Number of active UI WebSocket clients receiving this telemetry. */
-  int32_t active_clients;
+    /* Standard response header. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if telemetry was successfully cached for UI streaming. */
+    bool cached;
+    /* Number of active UI WebSocket clients receiving this telemetry. */
+    int32_t active_clients;
 } star_v1_ForwardTelemetryResponse;
 
 /* Request for latest teleop command from Gateway. */
 typedef struct _star_v1_GetTeleopCommandRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_GetTeleopCommandRequest;
 
 /* Response with latest teleop command. */
 typedef struct _star_v1_GetTeleopCommandResponse {
-  /* Standard response header. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Latest velocity command from UI.
+    /* Standard response header. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Latest velocity command from UI.
  If no command received yet, contains zero velocities. */
-  bool                    has_command;
-  star_v1_VelocityCommand command;
-  /* True if a valid command is available (not just zeros). */
-  bool command_available;
-  /* Age of command in milliseconds (for staleness checking).
+    bool has_command;
+    star_v1_VelocityCommand command;
+    /* True if a valid command is available (not just zeros). */
+    bool command_available;
+    /* Age of command in milliseconds (for staleness checking).
  ROS2 should reject commands older than 500ms. */
-  int64_t command_age_ms;
+    int64_t command_age_ms;
 } star_v1_GetTeleopCommandResponse;
 
 /* Request to set PID gains for motor velocity control. */
 typedef struct _star_v1_SetPIDGainsRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* PID configuration to apply. */
-  bool              has_pid_config;
-  star_v1_PidConfig pid_config;
-  /* Motor ID to configure (0 = left, 1 = right, -1 = both). */
-  int32_t motor_id;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* PID configuration to apply. */
+    bool has_pid_config;
+    star_v1_PidConfig pid_config;
+    /* Motor ID to configure (0 = left, 1 = right, -1 = both). */
+    int32_t motor_id;
 } star_v1_SetPIDGainsRequest;
 
 /* Response to PID gains update. */
 typedef struct _star_v1_SetPIDGainsResponse {
-  /* Standard response header. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if gains were successfully applied to motor controller. */
-  bool success;
-  /* Human-readable message (e.g., "PID gains updated for both motors"). */
-  pb_callback_t message;
+    /* Standard response header. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if gains were successfully applied to motor controller. */
+    bool success;
+    /* Human-readable message (e.g., "PID gains updated for both motors"). */
+    pb_callback_t message;
 } star_v1_SetPIDGainsResponse;
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define star_v1_ForwardTelemetryRequest_init_default                                               \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_SystemStatus_init_default, false,    \
-      star_v1_TelemetryData_init_default, 0,                                                       \
-      {star_v1_MotorStatus_init_default,                                                           \
-       star_v1_MotorStatus_init_default,                                                           \
-       star_v1_MotorStatus_init_default,                                                           \
-       star_v1_MotorStatus_init_default},                                                          \
-      false, star_v1_OdometryData_init_default, false, star_v1_LidarScan_init_default              \
-  }
-#define star_v1_ForwardTelemetryResponse_init_default                                              \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0, 0                                               \
-  }
-#define star_v1_GetTeleopCommandRequest_init_default                                               \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_GetTeleopCommandResponse_init_default                                              \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_VelocityCommand_init_default, 0, 0  \
-  }
-#define star_v1_SetPIDGainsRequest_init_default                                                    \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_PidConfig_init_default, 0            \
-  }
-#define star_v1_SetPIDGainsResponse_init_default                                                   \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0,                                                 \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
-#define star_v1_ForwardTelemetryRequest_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_SystemStatus_init_zero, false,          \
-      star_v1_TelemetryData_init_zero, 0,                                                          \
-      {star_v1_MotorStatus_init_zero,                                                              \
-       star_v1_MotorStatus_init_zero,                                                              \
-       star_v1_MotorStatus_init_zero,                                                              \
-       star_v1_MotorStatus_init_zero},                                                             \
-      false, star_v1_OdometryData_init_zero, false, star_v1_LidarScan_init_zero                    \
-  }
-#define star_v1_ForwardTelemetryResponse_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0, 0                                                  \
-  }
-#define star_v1_GetTeleopCommandRequest_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_GetTeleopCommandResponse_init_zero                                                 \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_VelocityCommand_init_zero, 0, 0        \
-  }
-#define star_v1_SetPIDGainsRequest_init_zero                                                       \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_PidConfig_init_zero, 0                  \
-  }
-#define star_v1_SetPIDGainsResponse_init_zero                                                      \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0,                                                    \
-    {                                                                                              \
-      {NULL}, NULL                                                                                 \
-    }                                                                                              \
-  }
+#define star_v1_ForwardTelemetryRequest_init_default {false, star_v1_RequestHeader_init_default, false, star_v1_SystemStatus_init_default, false, star_v1_TelemetryData_init_default, 0, {star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default}, false, star_v1_OdometryData_init_default, false, star_v1_LidarScan_init_default}
+#define star_v1_ForwardTelemetryResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, 0}
+#define star_v1_GetTeleopCommandRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_GetTeleopCommandResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_VelocityCommand_init_default, 0, 0}
+#define star_v1_SetPIDGainsRequest_init_default  {false, star_v1_RequestHeader_init_default, false, star_v1_PidConfig_init_default, 0}
+#define star_v1_SetPIDGainsResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, {{NULL}, NULL}}
+#define star_v1_ForwardTelemetryRequest_init_zero {false, star_v1_RequestHeader_init_zero, false, star_v1_SystemStatus_init_zero, false, star_v1_TelemetryData_init_zero, 0, {star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero}, false, star_v1_OdometryData_init_zero, false, star_v1_LidarScan_init_zero}
+#define star_v1_ForwardTelemetryResponse_init_zero {false, star_v1_ResponseHeader_init_zero, 0, 0}
+#define star_v1_GetTeleopCommandRequest_init_zero {false, star_v1_RequestHeader_init_zero}
+#define star_v1_GetTeleopCommandResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_VelocityCommand_init_zero, 0, 0}
+#define star_v1_SetPIDGainsRequest_init_zero     {false, star_v1_RequestHeader_init_zero, false, star_v1_PidConfig_init_zero, 0}
+#define star_v1_SetPIDGainsResponse_init_zero    {false, star_v1_ResponseHeader_init_zero, 0, {{NULL}, NULL}}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_ForwardTelemetryRequest_header_tag             1
-#define star_v1_ForwardTelemetryRequest_system_status_tag      2
-#define star_v1_ForwardTelemetryRequest_telemetry_tag          4
-#define star_v1_ForwardTelemetryRequest_motor_status_tag       5
-#define star_v1_ForwardTelemetryRequest_odometry_tag           6
-#define star_v1_ForwardTelemetryRequest_lidar_scan_tag         7
-#define star_v1_ForwardTelemetryResponse_header_tag            1
-#define star_v1_ForwardTelemetryResponse_cached_tag            2
-#define star_v1_ForwardTelemetryResponse_active_clients_tag    3
-#define star_v1_GetTeleopCommandRequest_header_tag             1
-#define star_v1_GetTeleopCommandResponse_header_tag            1
-#define star_v1_GetTeleopCommandResponse_command_tag           2
+#define star_v1_ForwardTelemetryRequest_header_tag 1
+#define star_v1_ForwardTelemetryRequest_system_status_tag 2
+#define star_v1_ForwardTelemetryRequest_telemetry_tag 4
+#define star_v1_ForwardTelemetryRequest_motor_status_tag 5
+#define star_v1_ForwardTelemetryRequest_odometry_tag 6
+#define star_v1_ForwardTelemetryRequest_lidar_scan_tag 7
+#define star_v1_ForwardTelemetryResponse_header_tag 1
+#define star_v1_ForwardTelemetryResponse_cached_tag 2
+#define star_v1_ForwardTelemetryResponse_active_clients_tag 3
+#define star_v1_GetTeleopCommandRequest_header_tag 1
+#define star_v1_GetTeleopCommandResponse_header_tag 1
+#define star_v1_GetTeleopCommandResponse_command_tag 2
 #define star_v1_GetTeleopCommandResponse_command_available_tag 3
-#define star_v1_GetTeleopCommandResponse_command_age_ms_tag    4
-#define star_v1_SetPIDGainsRequest_header_tag                  1
-#define star_v1_SetPIDGainsRequest_pid_config_tag              2
-#define star_v1_SetPIDGainsRequest_motor_id_tag                3
-#define star_v1_SetPIDGainsResponse_header_tag                 1
-#define star_v1_SetPIDGainsResponse_success_tag                2
-#define star_v1_SetPIDGainsResponse_message_tag                3
+#define star_v1_GetTeleopCommandResponse_command_age_ms_tag 4
+#define star_v1_SetPIDGainsRequest_header_tag    1
+#define star_v1_SetPIDGainsRequest_pid_config_tag 2
+#define star_v1_SetPIDGainsRequest_motor_id_tag  3
+#define star_v1_SetPIDGainsResponse_header_tag   1
+#define star_v1_SetPIDGainsResponse_success_tag  2
+#define star_v1_SetPIDGainsResponse_message_tag  3
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_ForwardTelemetryRequest_FIELDLIST(X, a)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, system_status, 2)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, telemetry, 4)                                                    \
-  X(a, STATIC, REPEATED, MESSAGE, motor_status, 5)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, odometry, 6)                                                     \
-  X(a, STATIC, OPTIONAL, MESSAGE, lidar_scan, 7)
-#define star_v1_ForwardTelemetryRequest_CALLBACK              NULL
-#define star_v1_ForwardTelemetryRequest_DEFAULT               NULL
-#define star_v1_ForwardTelemetryRequest_header_MSGTYPE        star_v1_RequestHeader
+#define star_v1_ForwardTelemetryRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  system_status,     2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  telemetry,         4) \
+X(a, STATIC,   REPEATED, MESSAGE,  motor_status,      5) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  odometry,          6) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  lidar_scan,        7)
+#define star_v1_ForwardTelemetryRequest_CALLBACK NULL
+#define star_v1_ForwardTelemetryRequest_DEFAULT NULL
+#define star_v1_ForwardTelemetryRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_ForwardTelemetryRequest_system_status_MSGTYPE star_v1_SystemStatus
-#define star_v1_ForwardTelemetryRequest_telemetry_MSGTYPE     star_v1_TelemetryData
-#define star_v1_ForwardTelemetryRequest_motor_status_MSGTYPE  star_v1_MotorStatus
-#define star_v1_ForwardTelemetryRequest_odometry_MSGTYPE      star_v1_OdometryData
-#define star_v1_ForwardTelemetryRequest_lidar_scan_MSGTYPE    star_v1_LidarScan
+#define star_v1_ForwardTelemetryRequest_telemetry_MSGTYPE star_v1_TelemetryData
+#define star_v1_ForwardTelemetryRequest_motor_status_MSGTYPE star_v1_MotorStatus
+#define star_v1_ForwardTelemetryRequest_odometry_MSGTYPE star_v1_OdometryData
+#define star_v1_ForwardTelemetryRequest_lidar_scan_MSGTYPE star_v1_LidarScan
 
-#define star_v1_ForwardTelemetryResponse_FIELDLIST(X, a)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, cached, 2)                                                          \
-  X(a, STATIC, SINGULAR, INT32, active_clients, 3)
-#define star_v1_ForwardTelemetryResponse_CALLBACK       NULL
-#define star_v1_ForwardTelemetryResponse_DEFAULT        NULL
+#define star_v1_ForwardTelemetryResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     cached,            2) \
+X(a, STATIC,   SINGULAR, INT32,    active_clients,    3)
+#define star_v1_ForwardTelemetryResponse_CALLBACK NULL
+#define star_v1_ForwardTelemetryResponse_DEFAULT NULL
 #define star_v1_ForwardTelemetryResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_GetTeleopCommandRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetTeleopCommandRequest_CALLBACK        NULL
-#define star_v1_GetTeleopCommandRequest_DEFAULT         NULL
-#define star_v1_GetTeleopCommandRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_GetTeleopCommandRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_GetTeleopCommandRequest_CALLBACK NULL
+#define star_v1_GetTeleopCommandRequest_DEFAULT NULL
+#define star_v1_GetTeleopCommandRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetTeleopCommandResponse_FIELDLIST(X, a)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, command, 2)                                                      \
-  X(a, STATIC, SINGULAR, BOOL, command_available, 3)                                               \
-  X(a, STATIC, SINGULAR, INT64, command_age_ms, 4)
-#define star_v1_GetTeleopCommandResponse_CALLBACK        NULL
-#define star_v1_GetTeleopCommandResponse_DEFAULT         NULL
-#define star_v1_GetTeleopCommandResponse_header_MSGTYPE  star_v1_ResponseHeader
+#define star_v1_GetTeleopCommandResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  command,           2) \
+X(a, STATIC,   SINGULAR, BOOL,     command_available,   3) \
+X(a, STATIC,   SINGULAR, INT64,    command_age_ms,    4)
+#define star_v1_GetTeleopCommandResponse_CALLBACK NULL
+#define star_v1_GetTeleopCommandResponse_DEFAULT NULL
+#define star_v1_GetTeleopCommandResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetTeleopCommandResponse_command_MSGTYPE star_v1_VelocityCommand
 
-#define star_v1_SetPIDGainsRequest_FIELDLIST(X, a)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, pid_config, 2)                                                   \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 3)
-#define star_v1_SetPIDGainsRequest_CALLBACK           NULL
-#define star_v1_SetPIDGainsRequest_DEFAULT            NULL
-#define star_v1_SetPIDGainsRequest_header_MSGTYPE     star_v1_RequestHeader
+#define star_v1_SetPIDGainsRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  pid_config,        2) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          3)
+#define star_v1_SetPIDGainsRequest_CALLBACK NULL
+#define star_v1_SetPIDGainsRequest_DEFAULT NULL
+#define star_v1_SetPIDGainsRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_SetPIDGainsRequest_pid_config_MSGTYPE star_v1_PidConfig
 
-#define star_v1_SetPIDGainsResponse_FIELDLIST(X, a)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, success, 2)                                                         \
-  X(a, CALLBACK, SINGULAR, STRING, message, 3)
-#define star_v1_SetPIDGainsResponse_CALLBACK       pb_default_field_callback
-#define star_v1_SetPIDGainsResponse_DEFAULT        NULL
+#define star_v1_SetPIDGainsResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     success,           2) \
+X(a, CALLBACK, SINGULAR, STRING,   message,           3)
+#define star_v1_SetPIDGainsResponse_CALLBACK pb_default_field_callback
+#define star_v1_SetPIDGainsResponse_DEFAULT NULL
 #define star_v1_SetPIDGainsResponse_header_MSGTYPE star_v1_ResponseHeader
 
 extern const pb_msgdesc_t star_v1_ForwardTelemetryRequest_msg;
@@ -264,21 +211,21 @@ extern const pb_msgdesc_t star_v1_SetPIDGainsRequest_msg;
 extern const pb_msgdesc_t star_v1_SetPIDGainsResponse_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_ForwardTelemetryRequest_fields  &star_v1_ForwardTelemetryRequest_msg
+#define star_v1_ForwardTelemetryRequest_fields &star_v1_ForwardTelemetryRequest_msg
 #define star_v1_ForwardTelemetryResponse_fields &star_v1_ForwardTelemetryResponse_msg
-#define star_v1_GetTeleopCommandRequest_fields  &star_v1_GetTeleopCommandRequest_msg
+#define star_v1_GetTeleopCommandRequest_fields &star_v1_GetTeleopCommandRequest_msg
 #define star_v1_GetTeleopCommandResponse_fields &star_v1_GetTeleopCommandResponse_msg
-#define star_v1_SetPIDGainsRequest_fields       &star_v1_SetPIDGainsRequest_msg
-#define star_v1_SetPIDGainsResponse_fields      &star_v1_SetPIDGainsResponse_msg
+#define star_v1_SetPIDGainsRequest_fields &star_v1_SetPIDGainsRequest_msg
+#define star_v1_SetPIDGainsResponse_fields &star_v1_SetPIDGainsResponse_msg
 
 /* Maximum encoded size of messages (where known) */
 /* star_v1_SetPIDGainsResponse_size depends on runtime parameters */
 #define STAR_V1_STAR_V1_GATEWAY_SERVICE_PB_H_MAX_SIZE star_v1_ForwardTelemetryRequest_size
-#define star_v1_ForwardTelemetryRequest_size          8451
-#define star_v1_ForwardTelemetryResponse_size         376
-#define star_v1_GetTeleopCommandRequest_size          149
-#define star_v1_GetTeleopCommandResponse_size         431
-#define star_v1_SetPIDGainsRequest_size               225
+#define star_v1_ForwardTelemetryRequest_size     8481
+#define star_v1_ForwardTelemetryResponse_size    376
+#define star_v1_GetTeleopCommandRequest_size     149
+#define star_v1_GetTeleopCommandResponse_size    431
+#define star_v1_SetPIDGainsRequest_size          225
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.c
@@ -8,27 +8,42 @@
 
 PB_BIND(star_v1_SetVelocityRequest, star_v1_SetVelocityRequest, AUTO)
 
+
 PB_BIND(star_v1_SetVelocityResponse, star_v1_SetVelocityResponse, 2)
+
 
 PB_BIND(star_v1_VelocityCommand, star_v1_VelocityCommand, AUTO)
 
+
 PB_BIND(star_v1_EmergencyStopRequest, star_v1_EmergencyStopRequest, 2)
+
 
 PB_BIND(star_v1_EmergencyStopResponse, star_v1_EmergencyStopResponse, 2)
 
+
 PB_BIND(star_v1_SetMotorPowerRequest, star_v1_SetMotorPowerRequest, AUTO)
+
 
 PB_BIND(star_v1_SetMotorPowerResponse, star_v1_SetMotorPowerResponse, 2)
 
+
 PB_BIND(star_v1_MotorPowerCommand, star_v1_MotorPowerCommand, AUTO)
+
 
 PB_BIND(star_v1_StreamEncodersRequest, star_v1_StreamEncodersRequest, AUTO)
 
+
 PB_BIND(star_v1_EncoderData, star_v1_EncoderData, AUTO)
+
 
 PB_BIND(star_v1_MotorStatus, star_v1_MotorStatus, AUTO)
 
+
 PB_BIND(star_v1_PidConfig, star_v1_PidConfig, AUTO)
+
+
+
+
 
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
@@ -37,3 +52,4 @@ PB_BIND(star_v1_PidConfig, star_v1_PidConfig, AUTO)
  */
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 #endif
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/motor_control.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_MOTOR_CONTROL_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_MOTOR_CONTROL_PB_H_INCLUDED
 #include <pb.h>
-
 #include "star/v1/common.pb.h"
 
 #if PB_PROTO_HEADER_VERSION != 40
@@ -14,16 +13,16 @@
 /* Enum definitions */
 /* Motor operating state. */
 typedef enum _star_v1_MotorState {
-  /* Unknown state. */
-  star_v1_MotorState_MOTOR_STATE_UNKNOWN = 0,
-  /* Motor is idle (not commanded). */
-  star_v1_MotorState_MOTOR_STATE_IDLE = 1,
-  /* Motor is running under PID control. */
-  star_v1_MotorState_MOTOR_STATE_RUNNING = 2,
-  /* Motor is in fault condition. */
-  star_v1_MotorState_MOTOR_STATE_FAULT = 3,
-  /* Motor is in emergency stop. */
-  star_v1_MotorState_MOTOR_STATE_ESTOP = 4
+    /* Unknown state. */
+    star_v1_MotorState_MOTOR_STATE_UNKNOWN = 0,
+    /* Motor is idle (not commanded). */
+    star_v1_MotorState_MOTOR_STATE_IDLE = 1,
+    /* Motor is running under PID control. */
+    star_v1_MotorState_MOTOR_STATE_RUNNING = 2,
+    /* Motor is in fault condition. */
+    star_v1_MotorState_MOTOR_STATE_FAULT = 3,
+    /* Motor is in emergency stop. */
+    star_v1_MotorState_MOTOR_STATE_ESTOP = 4
 } star_v1_MotorState;
 
 /* Struct definitions */
@@ -44,158 +43,159 @@ typedef enum _star_v1_MotorState {
    back_left   (5) -> velocity_mps[2]
    back_right  (6) -> velocity_mps[3] */
 typedef struct _star_v1_VelocityCommand {
-  /* Front left motor velocity in meters per second.
+    /* Front left motor velocity in meters per second.
  Valid range: -2.0 to 2.0 m/s.
  Positive = forward, negative = reverse. */
-  double front_left_velocity_mps;
-  /* Front right motor velocity in meters per second.
+    double front_left_velocity_mps;
+    /* Front right motor velocity in meters per second.
  Valid range: -2.0 to 2.0 m/s.
  Positive = forward, negative = reverse. */
-  double front_right_velocity_mps;
-  /* Command sequence number for ordering and deduplication. */
-  uint32_t sequence;
-  /* Client timestamp in microseconds for latency tracking. */
-  int64_t timestamp_us;
-  /* Back left motor velocity in meters per second.
+    double front_right_velocity_mps;
+    /* Command sequence number for ordering and deduplication. */
+    uint32_t sequence;
+    /* Client timestamp in microseconds for latency tracking. */
+    int64_t timestamp_us;
+    /* Back left motor velocity in meters per second.
  Valid range: -2.0 to 2.0 m/s.
  Positive = forward, negative = reverse. */
-  double back_left_velocity_mps;
-  /* Back right motor velocity in meters per second.
+    double back_left_velocity_mps;
+    /* Back right motor velocity in meters per second.
  Valid range: -2.0 to 2.0 m/s.
  Positive = forward, negative = reverse. */
-  double back_right_velocity_mps;
+    double back_right_velocity_mps;
 } star_v1_VelocityCommand;
 
 /* Request to set wheel velocities. */
 typedef struct _star_v1_SetVelocityRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Velocity command to execute. */
-  bool                    has_command;
-  star_v1_VelocityCommand command;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Velocity command to execute. */
+    bool has_command;
+    star_v1_VelocityCommand command;
 } star_v1_SetVelocityRequest;
 
 /* Emergency stop request. */
 typedef struct _star_v1_EmergencyStopRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Reason for emergency stop (for logging). */
-  char reason[128];
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Reason for emergency stop (for logging). */
+    char reason[128];
 } star_v1_EmergencyStopRequest;
 
 /* Emergency stop response. */
 typedef struct _star_v1_EmergencyStopResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* True if emergency stop was successfully engaged. */
-  bool estop_engaged;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* True if emergency stop was successfully engaged. */
+    bool estop_engaged;
 } star_v1_EmergencyStopResponse;
 
 /* Response to motor power command. */
 typedef struct _star_v1_SetMotorPowerResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
 } star_v1_SetMotorPowerResponse;
 
 /* Direct motor power control for individual motors.
  Bypasses PID controller - use for testing only. */
 typedef struct _star_v1_MotorPowerCommand {
-  /* Motor index: 0-3 for 4 independent motors. */
-  int32_t motor_id;
-  /* Power level as duty cycle percentage.
+    /* Motor index: 0-3 for 4 independent motors. */
+    int32_t motor_id;
+    /* Power level as duty cycle percentage.
  Valid range: -100.0 to 100.0 percent.
  Positive = forward, negative = reverse. */
-  double duty_cycle_percent;
+    double duty_cycle_percent;
 } star_v1_MotorPowerCommand;
 
 /* Request to set individual motor power. */
 typedef struct _star_v1_SetMotorPowerRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Motor power command. */
-  bool                      has_command;
-  star_v1_MotorPowerCommand command;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Motor power command. */
+    bool has_command;
+    star_v1_MotorPowerCommand command;
 } star_v1_SetMotorPowerRequest;
 
 /* Request to stream encoder data. */
 typedef struct _star_v1_StreamEncodersRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Desired update rate in Hz.
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Desired update rate in Hz.
  Valid range: 1 to 100 Hz. */
-  int32_t rate_hz;
+    int32_t rate_hz;
 } star_v1_StreamEncodersRequest;
 
 /* Real-time encoder feedback from motor controller.
  Streamed at configured rate. */
 typedef struct _star_v1_EncoderData {
-  /* Motor index: 0-3 for 4 independent motors. */
-  int32_t motor_id;
-  /* Absolute encoder position in ticks.
+    /* Motor index: 0-3 for 4 independent motors. */
+    int32_t motor_id;
+    /* Absolute encoder position in ticks.
  341 PPR Hall encoder * 34.02:1 gear ratio = 1364 ticks per revolution. */
-  int64_t ticks;
-  /* Current velocity in meters per second. */
-  double velocity_mps;
-  /* Timestamp in microseconds since boot. */
-  int64_t timestamp_us;
+    int64_t ticks;
+    /* Current velocity in meters per second. */
+    double velocity_mps;
+    /* Timestamp in microseconds since boot. */
+    int64_t timestamp_us;
 } star_v1_EncoderData;
 
 /* Motor status information. */
 typedef struct _star_v1_MotorStatus {
-  /* Motor index: 0-3 for 4 independent motors. */
-  int32_t motor_id;
-  /* Current duty cycle percentage.
+    /* Motor index: 0-3 for 4 independent motors. */
+    int32_t motor_id;
+    /* Current duty cycle percentage.
  Range: -100.0 to 100.0 percent. */
-  double duty_cycle_percent;
-  /* Current velocity in meters per second. */
-  double velocity_mps;
-  /* Target velocity in meters per second. */
-  double target_velocity_mps;
-  /* Motor temperature in Celsius (if available). */
-  double temperature_celsius;
-  /* Current draw in milliamps (if current sensing available). */
-  double current_ma;
-  /* Fault flags (bitfield).
+    double duty_cycle_percent;
+    /* Current velocity in meters per second. */
+    double velocity_mps;
+    /* Target velocity in meters per second. */
+    double target_velocity_mps;
+    /* Motor temperature in Celsius (if available). */
+    double temperature_celsius;
+    /* Current draw in milliamps (if current sensing available). */
+    double current_ma;
+    /* Fault flags (bitfield).
  Bit 0: overcurrent, Bit 1: overtemperature, Bit 2: encoder fault. */
-  uint32_t fault_flags;
-  /* Current motor state. */
-  star_v1_MotorState state;
+    uint32_t fault_flags;
+    /* Current motor state. */
+    star_v1_MotorState state;
 } star_v1_MotorStatus;
 
 /* Response to velocity command. */
 typedef struct _star_v1_SetVelocityResponse {
-  /* Standard response header with status. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Current motor status after command. */
-  pb_size_t           motor_status_count;
-  star_v1_MotorStatus motor_status[2];
+    /* Standard response header with status. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Current motor status after command. */
+    pb_size_t motor_status_count;
+    star_v1_MotorStatus motor_status[2];
 } star_v1_SetVelocityResponse;
 
 /* PID gains for motor velocity control.
  Matches ESP32 star_pid_config_t structure. */
 typedef struct _star_v1_PidConfig {
-  /* Proportional gain. */
-  double kp;
-  /* Integral gain. */
-  double ki;
-  /* Derivative gain. */
-  double kd;
-  /* Output saturation minimum (duty cycle percent). */
-  double output_min_percent;
-  /* Output saturation maximum (duty cycle percent). */
-  double output_max_percent;
-  /* Anti-windup integral minimum. */
-  double integral_min;
-  /* Anti-windup integral maximum. */
-  double integral_max;
+    /* Proportional gain. */
+    double kp;
+    /* Integral gain. */
+    double ki;
+    /* Derivative gain. */
+    double kd;
+    /* Output saturation minimum (duty cycle percent). */
+    double output_min_percent;
+    /* Output saturation maximum (duty cycle percent). */
+    double output_max_percent;
+    /* Anti-windup integral minimum. */
+    double integral_min;
+    /* Anti-windup integral maximum. */
+    double integral_max;
 } star_v1_PidConfig;
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -204,254 +204,188 @@ extern "C" {
 /* Helper constants for enums */
 #define _star_v1_MotorState_MIN star_v1_MotorState_MOTOR_STATE_UNKNOWN
 #define _star_v1_MotorState_MAX star_v1_MotorState_MOTOR_STATE_ESTOP
-#define _star_v1_MotorState_ARRAYSIZE                                                              \
-  ((star_v1_MotorState)(star_v1_MotorState_MOTOR_STATE_ESTOP + 1))
+#define _star_v1_MotorState_ARRAYSIZE ((star_v1_MotorState)(star_v1_MotorState_MOTOR_STATE_ESTOP+1))
+
+
+
+
+
+
+
+
+
+
 
 #define star_v1_MotorStatus_state_ENUMTYPE star_v1_MotorState
 
+
+
 /* Initializer values for message structs */
-#define star_v1_SetVelocityRequest_init_default                                                    \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_VelocityCommand_init_default         \
-  }
-#define star_v1_SetVelocityResponse_init_default                                                   \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0,                                                 \
-    {                                                                                              \
-      star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default                           \
-    }                                                                                              \
-  }
-#define star_v1_VelocityCommand_init_default                                                       \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0                                                                               \
-  }
-#define star_v1_EmergencyStopRequest_init_default                                                  \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, ""                                                  \
-  }
-#define star_v1_EmergencyStopResponse_init_default                                                 \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, 0                                                  \
-  }
-#define star_v1_SetMotorPowerRequest_init_default                                                  \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, false, star_v1_MotorPowerCommand_init_default       \
-  }
-#define star_v1_SetMotorPowerResponse_init_default                                                 \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default                                                     \
-  }
-#define star_v1_MotorPowerCommand_init_default                                                     \
-  {                                                                                                \
-    0, 0                                                                                           \
-  }
-#define star_v1_StreamEncodersRequest_init_default                                                 \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0                                                   \
-  }
-#define star_v1_EncoderData_init_default                                                           \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_MotorStatus_init_default                                                           \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0, 0, _star_v1_MotorState_MIN                                                   \
-  }
-#define star_v1_PidConfig_init_default                                                             \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0, 0                                                                            \
-  }
-#define star_v1_SetVelocityRequest_init_zero                                                       \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_VelocityCommand_init_zero               \
-  }
-#define star_v1_SetVelocityResponse_init_zero                                                      \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0,                                                    \
-    {                                                                                              \
-      star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero                                 \
-    }                                                                                              \
-  }
-#define star_v1_VelocityCommand_init_zero                                                          \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0                                                                               \
-  }
-#define star_v1_EmergencyStopRequest_init_zero                                                     \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, ""                                                     \
-  }
-#define star_v1_EmergencyStopResponse_init_zero                                                    \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, 0                                                     \
-  }
-#define star_v1_SetMotorPowerRequest_init_zero                                                     \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, false, star_v1_MotorPowerCommand_init_zero             \
-  }
-#define star_v1_SetMotorPowerResponse_init_zero                                                    \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero                                                        \
-  }
-#define star_v1_MotorPowerCommand_init_zero                                                        \
-  {                                                                                                \
-    0, 0                                                                                           \
-  }
-#define star_v1_StreamEncodersRequest_init_zero                                                    \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0                                                      \
-  }
-#define star_v1_EncoderData_init_zero                                                              \
-  {                                                                                                \
-    0, 0, 0, 0                                                                                     \
-  }
-#define star_v1_MotorStatus_init_zero                                                              \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0, 0, _star_v1_MotorState_MIN                                                   \
-  }
-#define star_v1_PidConfig_init_zero                                                                \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0, 0                                                                            \
-  }
+#define star_v1_SetVelocityRequest_init_default  {false, star_v1_RequestHeader_init_default, false, star_v1_VelocityCommand_init_default}
+#define star_v1_SetVelocityResponse_init_default {false, star_v1_ResponseHeader_init_default, 0, {star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default}}
+#define star_v1_VelocityCommand_init_default     {0, 0, 0, 0, 0, 0}
+#define star_v1_EmergencyStopRequest_init_default {false, star_v1_RequestHeader_init_default, ""}
+#define star_v1_EmergencyStopResponse_init_default {false, star_v1_ResponseHeader_init_default, 0}
+#define star_v1_SetMotorPowerRequest_init_default {false, star_v1_RequestHeader_init_default, false, star_v1_MotorPowerCommand_init_default}
+#define star_v1_SetMotorPowerResponse_init_default {false, star_v1_ResponseHeader_init_default}
+#define star_v1_MotorPowerCommand_init_default   {0, 0}
+#define star_v1_StreamEncodersRequest_init_default {false, star_v1_RequestHeader_init_default, 0}
+#define star_v1_EncoderData_init_default         {0, 0, 0, 0}
+#define star_v1_MotorStatus_init_default         {0, 0, 0, 0, 0, 0, 0, _star_v1_MotorState_MIN}
+#define star_v1_PidConfig_init_default           {0, 0, 0, 0, 0, 0, 0}
+#define star_v1_SetVelocityRequest_init_zero     {false, star_v1_RequestHeader_init_zero, false, star_v1_VelocityCommand_init_zero}
+#define star_v1_SetVelocityResponse_init_zero    {false, star_v1_ResponseHeader_init_zero, 0, {star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero}}
+#define star_v1_VelocityCommand_init_zero        {0, 0, 0, 0, 0, 0}
+#define star_v1_EmergencyStopRequest_init_zero   {false, star_v1_RequestHeader_init_zero, ""}
+#define star_v1_EmergencyStopResponse_init_zero  {false, star_v1_ResponseHeader_init_zero, 0}
+#define star_v1_SetMotorPowerRequest_init_zero   {false, star_v1_RequestHeader_init_zero, false, star_v1_MotorPowerCommand_init_zero}
+#define star_v1_SetMotorPowerResponse_init_zero  {false, star_v1_ResponseHeader_init_zero}
+#define star_v1_MotorPowerCommand_init_zero      {0, 0}
+#define star_v1_StreamEncodersRequest_init_zero  {false, star_v1_RequestHeader_init_zero, 0}
+#define star_v1_EncoderData_init_zero            {0, 0, 0, 0}
+#define star_v1_MotorStatus_init_zero            {0, 0, 0, 0, 0, 0, 0, _star_v1_MotorState_MIN}
+#define star_v1_PidConfig_init_zero              {0, 0, 0, 0, 0, 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_VelocityCommand_front_left_velocity_mps_tag  1
+#define star_v1_VelocityCommand_front_left_velocity_mps_tag 1
 #define star_v1_VelocityCommand_front_right_velocity_mps_tag 2
-#define star_v1_VelocityCommand_sequence_tag                 3
-#define star_v1_VelocityCommand_timestamp_us_tag             4
-#define star_v1_VelocityCommand_back_left_velocity_mps_tag   5
-#define star_v1_VelocityCommand_back_right_velocity_mps_tag  6
-#define star_v1_SetVelocityRequest_header_tag                1
-#define star_v1_SetVelocityRequest_command_tag               2
-#define star_v1_EmergencyStopRequest_header_tag              1
-#define star_v1_EmergencyStopRequest_reason_tag              2
-#define star_v1_EmergencyStopResponse_header_tag             1
-#define star_v1_EmergencyStopResponse_estop_engaged_tag      2
-#define star_v1_SetMotorPowerResponse_header_tag             1
-#define star_v1_MotorPowerCommand_motor_id_tag               1
-#define star_v1_MotorPowerCommand_duty_cycle_percent_tag     2
-#define star_v1_SetMotorPowerRequest_header_tag              1
-#define star_v1_SetMotorPowerRequest_command_tag             2
-#define star_v1_StreamEncodersRequest_header_tag             1
-#define star_v1_StreamEncodersRequest_rate_hz_tag            2
-#define star_v1_EncoderData_motor_id_tag                     1
-#define star_v1_EncoderData_ticks_tag                        2
-#define star_v1_EncoderData_velocity_mps_tag                 3
-#define star_v1_EncoderData_timestamp_us_tag                 4
-#define star_v1_MotorStatus_motor_id_tag                     1
-#define star_v1_MotorStatus_duty_cycle_percent_tag           2
-#define star_v1_MotorStatus_velocity_mps_tag                 3
-#define star_v1_MotorStatus_target_velocity_mps_tag          4
-#define star_v1_MotorStatus_temperature_celsius_tag          5
-#define star_v1_MotorStatus_current_ma_tag                   6
-#define star_v1_MotorStatus_fault_flags_tag                  7
-#define star_v1_MotorStatus_state_tag                        8
-#define star_v1_SetVelocityResponse_header_tag               1
-#define star_v1_SetVelocityResponse_motor_status_tag         2
-#define star_v1_PidConfig_kp_tag                             1
-#define star_v1_PidConfig_ki_tag                             2
-#define star_v1_PidConfig_kd_tag                             3
-#define star_v1_PidConfig_output_min_percent_tag             4
-#define star_v1_PidConfig_output_max_percent_tag             5
-#define star_v1_PidConfig_integral_min_tag                   6
-#define star_v1_PidConfig_integral_max_tag                   7
+#define star_v1_VelocityCommand_sequence_tag     3
+#define star_v1_VelocityCommand_timestamp_us_tag 4
+#define star_v1_VelocityCommand_back_left_velocity_mps_tag 5
+#define star_v1_VelocityCommand_back_right_velocity_mps_tag 6
+#define star_v1_SetVelocityRequest_header_tag    1
+#define star_v1_SetVelocityRequest_command_tag   2
+#define star_v1_EmergencyStopRequest_header_tag  1
+#define star_v1_EmergencyStopRequest_reason_tag  2
+#define star_v1_EmergencyStopResponse_header_tag 1
+#define star_v1_EmergencyStopResponse_estop_engaged_tag 2
+#define star_v1_SetMotorPowerResponse_header_tag 1
+#define star_v1_MotorPowerCommand_motor_id_tag   1
+#define star_v1_MotorPowerCommand_duty_cycle_percent_tag 2
+#define star_v1_SetMotorPowerRequest_header_tag  1
+#define star_v1_SetMotorPowerRequest_command_tag 2
+#define star_v1_StreamEncodersRequest_header_tag 1
+#define star_v1_StreamEncodersRequest_rate_hz_tag 2
+#define star_v1_EncoderData_motor_id_tag         1
+#define star_v1_EncoderData_ticks_tag            2
+#define star_v1_EncoderData_velocity_mps_tag     3
+#define star_v1_EncoderData_timestamp_us_tag     4
+#define star_v1_MotorStatus_motor_id_tag         1
+#define star_v1_MotorStatus_duty_cycle_percent_tag 2
+#define star_v1_MotorStatus_velocity_mps_tag     3
+#define star_v1_MotorStatus_target_velocity_mps_tag 4
+#define star_v1_MotorStatus_temperature_celsius_tag 5
+#define star_v1_MotorStatus_current_ma_tag       6
+#define star_v1_MotorStatus_fault_flags_tag      7
+#define star_v1_MotorStatus_state_tag            8
+#define star_v1_SetVelocityResponse_header_tag   1
+#define star_v1_SetVelocityResponse_motor_status_tag 2
+#define star_v1_PidConfig_kp_tag                 1
+#define star_v1_PidConfig_ki_tag                 2
+#define star_v1_PidConfig_kd_tag                 3
+#define star_v1_PidConfig_output_min_percent_tag 4
+#define star_v1_PidConfig_output_max_percent_tag 5
+#define star_v1_PidConfig_integral_min_tag       6
+#define star_v1_PidConfig_integral_max_tag       7
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_SetVelocityRequest_FIELDLIST(X, a)                                                 \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, command, 2)
-#define star_v1_SetVelocityRequest_CALLBACK        NULL
-#define star_v1_SetVelocityRequest_DEFAULT         NULL
-#define star_v1_SetVelocityRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_SetVelocityRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  command,           2)
+#define star_v1_SetVelocityRequest_CALLBACK NULL
+#define star_v1_SetVelocityRequest_DEFAULT NULL
+#define star_v1_SetVelocityRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_SetVelocityRequest_command_MSGTYPE star_v1_VelocityCommand
 
-#define star_v1_SetVelocityResponse_FIELDLIST(X, a)                                                \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, REPEATED, MESSAGE, motor_status, 2)
-#define star_v1_SetVelocityResponse_CALLBACK             NULL
-#define star_v1_SetVelocityResponse_DEFAULT              NULL
-#define star_v1_SetVelocityResponse_header_MSGTYPE       star_v1_ResponseHeader
+#define star_v1_SetVelocityResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   REPEATED, MESSAGE,  motor_status,      2)
+#define star_v1_SetVelocityResponse_CALLBACK NULL
+#define star_v1_SetVelocityResponse_DEFAULT NULL
+#define star_v1_SetVelocityResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_SetVelocityResponse_motor_status_MSGTYPE star_v1_MotorStatus
 
-#define star_v1_VelocityCommand_FIELDLIST(X, a)                                                    \
-  X(a, STATIC, SINGULAR, DOUBLE, front_left_velocity_mps, 1)                                       \
-  X(a, STATIC, SINGULAR, DOUBLE, front_right_velocity_mps, 2)                                      \
-  X(a, STATIC, SINGULAR, UINT32, sequence, 3)                                                      \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 4)                                                   \
-  X(a, STATIC, SINGULAR, DOUBLE, back_left_velocity_mps, 5)                                        \
-  X(a, STATIC, SINGULAR, DOUBLE, back_right_velocity_mps, 6)
+#define star_v1_VelocityCommand_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   front_left_velocity_mps,   1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   front_right_velocity_mps,   2) \
+X(a, STATIC,   SINGULAR, UINT32,   sequence,          3) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      4) \
+X(a, STATIC,   SINGULAR, DOUBLE,   back_left_velocity_mps,   5) \
+X(a, STATIC,   SINGULAR, DOUBLE,   back_right_velocity_mps,   6)
 #define star_v1_VelocityCommand_CALLBACK NULL
-#define star_v1_VelocityCommand_DEFAULT  NULL
+#define star_v1_VelocityCommand_DEFAULT NULL
 
-#define star_v1_EmergencyStopRequest_FIELDLIST(X, a)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, STRING, reason, 2)
-#define star_v1_EmergencyStopRequest_CALLBACK       NULL
-#define star_v1_EmergencyStopRequest_DEFAULT        NULL
+#define star_v1_EmergencyStopRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, STRING,   reason,            2)
+#define star_v1_EmergencyStopRequest_CALLBACK NULL
+#define star_v1_EmergencyStopRequest_DEFAULT NULL
 #define star_v1_EmergencyStopRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_EmergencyStopResponse_FIELDLIST(X, a)                                              \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, estop_engaged, 2)
-#define star_v1_EmergencyStopResponse_CALLBACK       NULL
-#define star_v1_EmergencyStopResponse_DEFAULT        NULL
+#define star_v1_EmergencyStopResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     estop_engaged,     2)
+#define star_v1_EmergencyStopResponse_CALLBACK NULL
+#define star_v1_EmergencyStopResponse_DEFAULT NULL
 #define star_v1_EmergencyStopResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_SetMotorPowerRequest_FIELDLIST(X, a)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, command, 2)
-#define star_v1_SetMotorPowerRequest_CALLBACK        NULL
-#define star_v1_SetMotorPowerRequest_DEFAULT         NULL
-#define star_v1_SetMotorPowerRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_SetMotorPowerRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  command,           2)
+#define star_v1_SetMotorPowerRequest_CALLBACK NULL
+#define star_v1_SetMotorPowerRequest_DEFAULT NULL
+#define star_v1_SetMotorPowerRequest_header_MSGTYPE star_v1_RequestHeader
 #define star_v1_SetMotorPowerRequest_command_MSGTYPE star_v1_MotorPowerCommand
 
-#define star_v1_SetMotorPowerResponse_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_SetMotorPowerResponse_CALLBACK        NULL
-#define star_v1_SetMotorPowerResponse_DEFAULT         NULL
-#define star_v1_SetMotorPowerResponse_header_MSGTYPE  star_v1_ResponseHeader
+#define star_v1_SetMotorPowerResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_SetMotorPowerResponse_CALLBACK NULL
+#define star_v1_SetMotorPowerResponse_DEFAULT NULL
+#define star_v1_SetMotorPowerResponse_header_MSGTYPE star_v1_ResponseHeader
 
-#define star_v1_MotorPowerCommand_FIELDLIST(X, a)                                                  \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
-  X(a, STATIC, SINGULAR, DOUBLE, duty_cycle_percent, 2)
+#define star_v1_MotorPowerCommand_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   duty_cycle_percent,   2)
 #define star_v1_MotorPowerCommand_CALLBACK NULL
-#define star_v1_MotorPowerCommand_DEFAULT  NULL
+#define star_v1_MotorPowerCommand_DEFAULT NULL
 
-#define star_v1_StreamEncodersRequest_FIELDLIST(X, a)                                              \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, INT32, rate_hz, 2)
-#define star_v1_StreamEncodersRequest_CALLBACK       NULL
-#define star_v1_StreamEncodersRequest_DEFAULT        NULL
+#define star_v1_StreamEncodersRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, INT32,    rate_hz,           2)
+#define star_v1_StreamEncodersRequest_CALLBACK NULL
+#define star_v1_StreamEncodersRequest_DEFAULT NULL
 #define star_v1_StreamEncodersRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_EncoderData_FIELDLIST(X, a)                                                        \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
-  X(a, STATIC, SINGULAR, INT64, ticks, 2)                                                          \
-  X(a, STATIC, SINGULAR, DOUBLE, velocity_mps, 3)                                                  \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 4)
+#define star_v1_EncoderData_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          1) \
+X(a, STATIC,   SINGULAR, INT64,    ticks,             2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   velocity_mps,      3) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      4)
 #define star_v1_EncoderData_CALLBACK NULL
-#define star_v1_EncoderData_DEFAULT  NULL
+#define star_v1_EncoderData_DEFAULT NULL
 
-#define star_v1_MotorStatus_FIELDLIST(X, a)                                                        \
-  X(a, STATIC, SINGULAR, INT32, motor_id, 1)                                                       \
-  X(a, STATIC, SINGULAR, DOUBLE, duty_cycle_percent, 2)                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, velocity_mps, 3)                                                  \
-  X(a, STATIC, SINGULAR, DOUBLE, target_velocity_mps, 4)                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, temperature_celsius, 5)                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, current_ma, 6)                                                    \
-  X(a, STATIC, SINGULAR, UINT32, fault_flags, 7)                                                   \
-  X(a, STATIC, SINGULAR, UENUM, state, 8)
+#define star_v1_MotorStatus_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, INT32,    motor_id,          1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   duty_cycle_percent,   2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   velocity_mps,      3) \
+X(a, STATIC,   SINGULAR, DOUBLE,   target_velocity_mps,   4) \
+X(a, STATIC,   SINGULAR, DOUBLE,   temperature_celsius,   5) \
+X(a, STATIC,   SINGULAR, DOUBLE,   current_ma,        6) \
+X(a, STATIC,   SINGULAR, UINT32,   fault_flags,       7) \
+X(a, STATIC,   SINGULAR, UENUM,    state,             8)
 #define star_v1_MotorStatus_CALLBACK NULL
-#define star_v1_MotorStatus_DEFAULT  NULL
+#define star_v1_MotorStatus_DEFAULT NULL
 
-#define star_v1_PidConfig_FIELDLIST(X, a)                                                          \
-  X(a, STATIC, SINGULAR, DOUBLE, kp, 1)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, ki, 2)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, kd, 3)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, output_min_percent, 4)                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, output_max_percent, 5)                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, integral_min, 6)                                                  \
-  X(a, STATIC, SINGULAR, DOUBLE, integral_max, 7)
+#define star_v1_PidConfig_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   kp,                1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   ki,                2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   kd,                3) \
+X(a, STATIC,   SINGULAR, DOUBLE,   output_min_percent,   4) \
+X(a, STATIC,   SINGULAR, DOUBLE,   output_max_percent,   5) \
+X(a, STATIC,   SINGULAR, DOUBLE,   integral_min,      6) \
+X(a, STATIC,   SINGULAR, DOUBLE,   integral_max,      7)
 #define star_v1_PidConfig_CALLBACK NULL
-#define star_v1_PidConfig_DEFAULT  NULL
+#define star_v1_PidConfig_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_SetVelocityRequest_msg;
 extern const pb_msgdesc_t star_v1_SetVelocityResponse_msg;
@@ -467,33 +401,33 @@ extern const pb_msgdesc_t star_v1_MotorStatus_msg;
 extern const pb_msgdesc_t star_v1_PidConfig_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_SetVelocityRequest_fields    &star_v1_SetVelocityRequest_msg
-#define star_v1_SetVelocityResponse_fields   &star_v1_SetVelocityResponse_msg
-#define star_v1_VelocityCommand_fields       &star_v1_VelocityCommand_msg
-#define star_v1_EmergencyStopRequest_fields  &star_v1_EmergencyStopRequest_msg
+#define star_v1_SetVelocityRequest_fields &star_v1_SetVelocityRequest_msg
+#define star_v1_SetVelocityResponse_fields &star_v1_SetVelocityResponse_msg
+#define star_v1_VelocityCommand_fields &star_v1_VelocityCommand_msg
+#define star_v1_EmergencyStopRequest_fields &star_v1_EmergencyStopRequest_msg
 #define star_v1_EmergencyStopResponse_fields &star_v1_EmergencyStopResponse_msg
-#define star_v1_SetMotorPowerRequest_fields  &star_v1_SetMotorPowerRequest_msg
+#define star_v1_SetMotorPowerRequest_fields &star_v1_SetMotorPowerRequest_msg
 #define star_v1_SetMotorPowerResponse_fields &star_v1_SetMotorPowerResponse_msg
-#define star_v1_MotorPowerCommand_fields     &star_v1_MotorPowerCommand_msg
+#define star_v1_MotorPowerCommand_fields &star_v1_MotorPowerCommand_msg
 #define star_v1_StreamEncodersRequest_fields &star_v1_StreamEncodersRequest_msg
-#define star_v1_EncoderData_fields           &star_v1_EncoderData_msg
-#define star_v1_MotorStatus_fields           &star_v1_MotorStatus_msg
-#define star_v1_PidConfig_fields             &star_v1_PidConfig_msg
+#define star_v1_EncoderData_fields &star_v1_EncoderData_msg
+#define star_v1_MotorStatus_fields &star_v1_MotorStatus_msg
+#define star_v1_PidConfig_fields &star_v1_PidConfig_msg
 
 /* Maximum encoded size of messages (where known) */
 #define STAR_V1_STAR_V1_MOTOR_CONTROL_PB_H_MAX_SIZE star_v1_SetVelocityResponse_size
-#define star_v1_EmergencyStopRequest_size           279
-#define star_v1_EmergencyStopResponse_size          365
-#define star_v1_EncoderData_size                    42
-#define star_v1_MotorPowerCommand_size              20
-#define star_v1_MotorStatus_size                    64
-#define star_v1_PidConfig_size                      63
-#define star_v1_SetMotorPowerRequest_size           171
-#define star_v1_SetMotorPowerResponse_size          363
-#define star_v1_SetVelocityRequest_size             204
-#define star_v1_SetVelocityResponse_size            495
-#define star_v1_StreamEncodersRequest_size          160
-#define star_v1_VelocityCommand_size                53
+#define star_v1_EmergencyStopRequest_size        279
+#define star_v1_EmergencyStopResponse_size       365
+#define star_v1_EncoderData_size                 42
+#define star_v1_MotorPowerCommand_size           20
+#define star_v1_MotorStatus_size                 64
+#define star_v1_PidConfig_size                   63
+#define star_v1_SetMotorPowerRequest_size        171
+#define star_v1_SetMotorPowerResponse_size       363
+#define star_v1_SetVelocityRequest_size          204
+#define star_v1_SetVelocityResponse_size         495
+#define star_v1_StreamEncodersRequest_size       160
+#define star_v1_VelocityCommand_size             53
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
@@ -8,23 +8,40 @@
 
 PB_BIND(star_v1_GetTelemetryRequest, star_v1_GetTelemetryRequest, AUTO)
 
+
 PB_BIND(star_v1_GetTelemetryResponse, star_v1_GetTelemetryResponse, 2)
+
 
 PB_BIND(star_v1_StreamTelemetryRequest, star_v1_StreamTelemetryRequest, 2)
 
+
 PB_BIND(star_v1_GetSystemStatusRequest, star_v1_GetSystemStatusRequest, AUTO)
+
 
 PB_BIND(star_v1_GetSystemStatusResponse, star_v1_GetSystemStatusResponse, 2)
 
+
 PB_BIND(star_v1_TelemetryData, star_v1_TelemetryData, 2)
+
 
 PB_BIND(star_v1_ImuData, star_v1_ImuData, AUTO)
 
+
 PB_BIND(star_v1_ObstacleData, star_v1_ObstacleData, AUTO)
+
 
 PB_BIND(star_v1_GpsData, star_v1_GpsData, AUTO)
 
+
 PB_BIND(star_v1_SystemStatus, star_v1_SystemStatus, AUTO)
+
+
+
+
+
+
+
+
 
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
@@ -33,3 +50,4 @@ PB_BIND(star_v1_SystemStatus, star_v1_SystemStatus, AUTO)
  */
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 #endif
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
@@ -20,6 +20,8 @@ PB_BIND(star_v1_TelemetryData, star_v1_TelemetryData, 2)
 
 PB_BIND(star_v1_ImuData, star_v1_ImuData, AUTO)
 
+PB_BIND(star_v1_ObstacleData, star_v1_ObstacleData, AUTO)
+
 PB_BIND(star_v1_GpsData, star_v1_GpsData, AUTO)
 
 PB_BIND(star_v1_SystemStatus, star_v1_SystemStatus, AUTO)

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
@@ -117,6 +117,24 @@ typedef struct _star_v1_ImuData {
   double gyro_z_rad_per_s;
 } star_v1_ImuData;
 
+/* Obstacle detection data from ultrasonic sensors (RX72N specific).
+ Reports distance and detection state from 4 HC-SR04 sensors. */
+typedef struct _star_v1_ObstacleData {
+  /* Distance from sensor 0 in meters. 0.0 if sensor invalid. */
+  float distance_0_m;
+  /* Distance from sensor 1 in meters. 0.0 if sensor invalid. */
+  float distance_1_m;
+  /* Distance from sensor 2 in meters. 0.0 if sensor invalid. */
+  float distance_2_m;
+  /* Distance from sensor 3 in meters. 0.0 if sensor invalid. */
+  float distance_3_m;
+  /* Any sensor has detected an obstacle within threshold distance. */
+  bool any_obstacle;
+  /* Per-sensor detection bitmask. Bit N set = sensor N detected obstacle.
+ Bit 0: sensor 0, Bit 1: sensor 1, Bit 2: sensor 2, Bit 3: sensor 3. */
+  uint32_t detected_mask;
+} star_v1_ObstacleData;
+
 /* GPS position data. */
 typedef struct _star_v1_GpsData {
   /* WGS84 latitude in degrees.
@@ -181,6 +199,9 @@ typedef struct _star_v1_TelemetryData {
  Increments with each transmitted frame. Used by diagnostics to detect
  missing frames in the telemetry stream. */
   uint32_t frame_sequence;
+  /* Obstacle detection data from ultrasonic sensors (RX72N specific). */
+  bool                 has_obstacle;
+  star_v1_ObstacleData obstacle;
 } star_v1_TelemetryData;
 
 /* Response with telemetry snapshot. */
@@ -276,7 +297,7 @@ extern "C" {
     false, star_v1_ImuData_init_default, false, star_v1_GpsData_init_default, 0, 0, 0, 0, false,   \
       google_protobuf_Timestamp_init_default, 0, 0, 0, false, star_v1_EncoderData_init_default,    \
       false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false,     \
-      star_v1_EncoderData_init_default, 0                                                          \
+      star_v1_EncoderData_init_default, 0, false, star_v1_ObstacleData_init_default                \
   }
 #define star_v1_ImuData_init_default                                                               \
   {                                                                                                \
@@ -285,6 +306,10 @@ extern "C" {
 #define star_v1_GpsData_init_default                                                               \
   {                                                                                                \
     0, 0, 0, 0, 0, _star_v1_GpsFix_MIN                                                             \
+  }
+#define star_v1_ObstacleData_init_default                                                          \
+  {                                                                                                \
+    0, 0, 0, 0, 0, 0                                                                               \
   }
 #define star_v1_SystemStatus_init_default                                                          \
   {                                                                                                \
@@ -318,7 +343,7 @@ extern "C" {
     false, star_v1_ImuData_init_zero, false, star_v1_GpsData_init_zero, 0, 0, 0, 0, false,         \
       google_protobuf_Timestamp_init_zero, 0, 0, 0, false, star_v1_EncoderData_init_zero, false,   \
       star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false,                  \
-      star_v1_EncoderData_init_zero, 0                                                             \
+      star_v1_EncoderData_init_zero, 0, false, star_v1_ObstacleData_init_zero                      \
   }
 #define star_v1_ImuData_init_zero                                                                  \
   {                                                                                                \
@@ -327,6 +352,10 @@ extern "C" {
 #define star_v1_GpsData_init_zero                                                                  \
   {                                                                                                \
     0, 0, 0, 0, 0, _star_v1_GpsFix_MIN                                                             \
+  }
+#define star_v1_ObstacleData_init_zero                                                             \
+  {                                                                                                \
+    0, 0, 0, 0, 0, 0                                                                               \
   }
 #define star_v1_SystemStatus_init_zero                                                             \
   {                                                                                                \
@@ -369,6 +398,13 @@ extern "C" {
 #define star_v1_TelemetryData_encoder_back_left_tag   17
 #define star_v1_TelemetryData_encoder_back_right_tag  18
 #define star_v1_TelemetryData_frame_sequence_tag      19
+#define star_v1_TelemetryData_obstacle_tag            3
+#define star_v1_ObstacleData_distance_0_m_tag         1
+#define star_v1_ObstacleData_distance_1_m_tag         2
+#define star_v1_ObstacleData_distance_2_m_tag         3
+#define star_v1_ObstacleData_distance_3_m_tag         4
+#define star_v1_ObstacleData_any_obstacle_tag         5
+#define star_v1_ObstacleData_detected_mask_tag        6
 #define star_v1_GetTelemetryResponse_header_tag       1
 #define star_v1_GetTelemetryResponse_telemetry_tag    2
 #define star_v1_SystemStatus_connection_status_tag    1
@@ -432,7 +468,8 @@ extern "C" {
   X(a, STATIC, OPTIONAL, MESSAGE, encoder_front_right, 16)                                         \
   X(a, STATIC, OPTIONAL, MESSAGE, encoder_back_left, 17)                                           \
   X(a, STATIC, OPTIONAL, MESSAGE, encoder_back_right, 18)                                          \
-  X(a, STATIC, SINGULAR, UINT32, frame_sequence, 19)
+  X(a, STATIC, SINGULAR, UINT32, frame_sequence, 19)                                               \
+  X(a, STATIC, OPTIONAL, MESSAGE, obstacle, 3)
 #define star_v1_TelemetryData_CALLBACK                    NULL
 #define star_v1_TelemetryData_DEFAULT                     NULL
 #define star_v1_TelemetryData_imu_MSGTYPE                 star_v1_ImuData
@@ -442,6 +479,17 @@ extern "C" {
 #define star_v1_TelemetryData_encoder_front_right_MSGTYPE star_v1_EncoderData
 #define star_v1_TelemetryData_encoder_back_left_MSGTYPE   star_v1_EncoderData
 #define star_v1_TelemetryData_encoder_back_right_MSGTYPE  star_v1_EncoderData
+#define star_v1_TelemetryData_obstacle_MSGTYPE            star_v1_ObstacleData
+
+#define star_v1_ObstacleData_FIELDLIST(X, a)                                                       \
+  X(a, STATIC, SINGULAR, FLOAT, distance_0_m, 1)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_1_m, 2)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_2_m, 3)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_3_m, 4)                                                   \
+  X(a, STATIC, SINGULAR, BOOL, any_obstacle, 5)                                                    \
+  X(a, STATIC, SINGULAR, UINT32, detected_mask, 6)
+#define star_v1_ObstacleData_CALLBACK NULL
+#define star_v1_ObstacleData_DEFAULT  NULL
 
 #define star_v1_ImuData_FIELDLIST(X, a)                                                            \
   X(a, STATIC, SINGULAR, DOUBLE, pitch_rad, 1)                                                     \
@@ -485,6 +533,7 @@ extern const pb_msgdesc_t star_v1_GetSystemStatusRequest_msg;
 extern const pb_msgdesc_t star_v1_GetSystemStatusResponse_msg;
 extern const pb_msgdesc_t star_v1_TelemetryData_msg;
 extern const pb_msgdesc_t star_v1_ImuData_msg;
+extern const pb_msgdesc_t star_v1_ObstacleData_msg;
 extern const pb_msgdesc_t star_v1_GpsData_msg;
 extern const pb_msgdesc_t star_v1_SystemStatus_msg;
 
@@ -496,6 +545,7 @@ extern const pb_msgdesc_t star_v1_SystemStatus_msg;
 #define star_v1_GetSystemStatusResponse_fields &star_v1_GetSystemStatusResponse_msg
 #define star_v1_TelemetryData_fields           &star_v1_TelemetryData_msg
 #define star_v1_ImuData_fields                 &star_v1_ImuData_msg
+#define star_v1_ObstacleData_fields            &star_v1_ObstacleData_msg
 #define star_v1_GpsData_fields                 &star_v1_GpsData_msg
 #define star_v1_SystemStatus_fields            &star_v1_SystemStatus_msg
 
@@ -504,12 +554,13 @@ extern const pb_msgdesc_t star_v1_SystemStatus_msg;
 #define star_v1_GetSystemStatusRequest_size     149
 #define star_v1_GetSystemStatusResponse_size    425
 #define star_v1_GetTelemetryRequest_size        149
-#define star_v1_GetTelemetryResponse_size       767
+#define star_v1_GetTelemetryResponse_size       802
 #define star_v1_GpsData_size                    49
 #define star_v1_ImuData_size                    81
+#define star_v1_ObstacleData_size               32
 #define star_v1_StreamTelemetryRequest_size     688
 #define star_v1_SystemStatus_size               60
-#define star_v1_TelemetryData_size              401
+#define star_v1_TelemetryData_size              436
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
@@ -121,13 +121,13 @@ typedef struct _star_v1_ImuData {
  Reports distance and detection state from 4 HC-SR04 sensors. */
 typedef struct _star_v1_ObstacleData {
   /* Distance from sensor 0 in meters. 0.0 if sensor invalid. */
-  float distance_0_m;
+  float distance_front_left_m;
   /* Distance from sensor 1 in meters. 0.0 if sensor invalid. */
-  float distance_1_m;
+  float distance_front_right_m;
   /* Distance from sensor 2 in meters. 0.0 if sensor invalid. */
-  float distance_2_m;
+  float distance_back_left_m;
   /* Distance from sensor 3 in meters. 0.0 if sensor invalid. */
-  float distance_3_m;
+  float distance_back_right_m;
   /* Any sensor has detected an obstacle within threshold distance. */
   bool any_obstacle;
   /* Per-sensor detection bitmask. Bit N set = sensor N detected obstacle.
@@ -399,10 +399,10 @@ extern "C" {
 #define star_v1_TelemetryData_encoder_back_right_tag  18
 #define star_v1_TelemetryData_frame_sequence_tag      19
 #define star_v1_TelemetryData_obstacle_tag            3
-#define star_v1_ObstacleData_distance_0_m_tag         1
-#define star_v1_ObstacleData_distance_1_m_tag         2
-#define star_v1_ObstacleData_distance_2_m_tag         3
-#define star_v1_ObstacleData_distance_3_m_tag         4
+#define star_v1_ObstacleData_distance_front_left_m_tag         1
+#define star_v1_ObstacleData_distance_front_right_m_tag         2
+#define star_v1_ObstacleData_distance_back_left_m_tag         3
+#define star_v1_ObstacleData_distance_back_right_m_tag         4
 #define star_v1_ObstacleData_any_obstacle_tag         5
 #define star_v1_ObstacleData_detected_mask_tag        6
 #define star_v1_GetTelemetryResponse_header_tag       1
@@ -482,10 +482,10 @@ extern "C" {
 #define star_v1_TelemetryData_obstacle_MSGTYPE            star_v1_ObstacleData
 
 #define star_v1_ObstacleData_FIELDLIST(X, a)                                                       \
-  X(a, STATIC, SINGULAR, FLOAT, distance_0_m, 1)                                                   \
-  X(a, STATIC, SINGULAR, FLOAT, distance_1_m, 2)                                                   \
-  X(a, STATIC, SINGULAR, FLOAT, distance_2_m, 3)                                                   \
-  X(a, STATIC, SINGULAR, FLOAT, distance_3_m, 4)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_front_left_m, 1)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_front_right_m, 2)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_back_left_m, 3)                                                   \
+  X(a, STATIC, SINGULAR, FLOAT, distance_back_right_m, 4)                                                   \
   X(a, STATIC, SINGULAR, BOOL, any_obstacle, 5)                                                    \
   X(a, STATIC, SINGULAR, UINT32, detected_mask, 6)
 #define star_v1_ObstacleData_CALLBACK NULL

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_TELEMETRY_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_TELEMETRY_PB_H_INCLUDED
 #include <pb.h>
-
 #include "google/protobuf/timestamp.pb.h"
 #include "star/v1/common.pb.h"
 #include "star/v1/motor_control.pb.h"
@@ -16,515 +15,453 @@
 /* Enum definitions */
 /* GPS fix type. */
 typedef enum _star_v1_GpsFix {
-  /* Unknown fix type. */
-  star_v1_GpsFix_GPS_FIX_UNKNOWN = 0,
-  /* No fix available. */
-  star_v1_GpsFix_GPS_FIX_NONE = 1,
-  /* 2D fix (latitude/longitude only). */
-  star_v1_GpsFix_GPS_FIX_2D = 2,
-  /* 3D fix (latitude/longitude/altitude). */
-  star_v1_GpsFix_GPS_FIX_3D = 3,
-  /* Differential GPS fix. */
-  star_v1_GpsFix_GPS_FIX_DGPS = 4,
-  /* RTK float solution. */
-  star_v1_GpsFix_GPS_FIX_RTK_FLOAT = 5,
-  /* RTK fixed solution. */
-  star_v1_GpsFix_GPS_FIX_RTK_FIXED = 6
+    /* Unknown fix type. */
+    star_v1_GpsFix_GPS_FIX_UNKNOWN = 0,
+    /* No fix available. */
+    star_v1_GpsFix_GPS_FIX_NONE = 1,
+    /* 2D fix (latitude/longitude only). */
+    star_v1_GpsFix_GPS_FIX_2D = 2,
+    /* 3D fix (latitude/longitude/altitude). */
+    star_v1_GpsFix_GPS_FIX_3D = 3,
+    /* Differential GPS fix. */
+    star_v1_GpsFix_GPS_FIX_DGPS = 4,
+    /* RTK float solution. */
+    star_v1_GpsFix_GPS_FIX_RTK_FLOAT = 5,
+    /* RTK fixed solution. */
+    star_v1_GpsFix_GPS_FIX_RTK_FIXED = 6
 } star_v1_GpsFix;
 
 /* Connection state enumeration. */
 typedef enum _star_v1_ConnectionStatus {
-  /* Unknown connection state. */
-  star_v1_ConnectionStatus_CONNECTION_STATUS_UNKNOWN = 0,
-  /* Connected and communicating. */
-  star_v1_ConnectionStatus_CONNECTION_STATUS_CONNECTED = 1,
-  /* Not connected. */
-  star_v1_ConnectionStatus_CONNECTION_STATUS_DISCONNECTED = 2,
-  /* Connection in progress. */
-  star_v1_ConnectionStatus_CONNECTION_STATUS_CONNECTING = 3,
-  /* Connection error occurred. */
-  star_v1_ConnectionStatus_CONNECTION_STATUS_ERROR = 4
+    /* Unknown connection state. */
+    star_v1_ConnectionStatus_CONNECTION_STATUS_UNKNOWN = 0,
+    /* Connected and communicating. */
+    star_v1_ConnectionStatus_CONNECTION_STATUS_CONNECTED = 1,
+    /* Not connected. */
+    star_v1_ConnectionStatus_CONNECTION_STATUS_DISCONNECTED = 2,
+    /* Connection in progress. */
+    star_v1_ConnectionStatus_CONNECTION_STATUS_CONNECTING = 3,
+    /* Connection error occurred. */
+    star_v1_ConnectionStatus_CONNECTION_STATUS_ERROR = 4
 } star_v1_ConnectionStatus;
 
 /* Robot operating mode enumeration. */
 typedef enum _star_v1_RobotMode {
-  /* Unknown operating mode. */
-  star_v1_RobotMode_ROBOT_MODE_UNKNOWN = 0,
-  /* Robot is idle (motors off). */
-  star_v1_RobotMode_ROBOT_MODE_IDLE = 1,
-  /* Manual control mode (joystick/UI). */
-  star_v1_RobotMode_ROBOT_MODE_MANUAL = 2,
-  /* Autonomous navigation mode (Nav2). */
-  star_v1_RobotMode_ROBOT_MODE_AUTONOMOUS = 3,
-  /* SLAM mapping mode. */
-  star_v1_RobotMode_ROBOT_MODE_MAPPING = 4,
-  /* Emergency stop active. */
-  star_v1_RobotMode_ROBOT_MODE_EMERGENCY_STOP = 5
+    /* Unknown operating mode. */
+    star_v1_RobotMode_ROBOT_MODE_UNKNOWN = 0,
+    /* Robot is idle (motors off). */
+    star_v1_RobotMode_ROBOT_MODE_IDLE = 1,
+    /* Manual control mode (joystick/UI). */
+    star_v1_RobotMode_ROBOT_MODE_MANUAL = 2,
+    /* Autonomous navigation mode (Nav2). */
+    star_v1_RobotMode_ROBOT_MODE_AUTONOMOUS = 3,
+    /* SLAM mapping mode. */
+    star_v1_RobotMode_ROBOT_MODE_MAPPING = 4,
+    /* Emergency stop active. */
+    star_v1_RobotMode_ROBOT_MODE_EMERGENCY_STOP = 5
 } star_v1_RobotMode;
 
 /* Struct definitions */
 /* Request for telemetry snapshot. */
 typedef struct _star_v1_GetTelemetryRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_GetTelemetryRequest;
 
 /* Request to stream telemetry. */
 typedef struct _star_v1_StreamTelemetryRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
-  /* Desired update rate in Hz.
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
+    /* Desired update rate in Hz.
  Valid range: 1 to 100 Hz. */
-  int32_t rate_hz;
-  /* Fields to include (empty = all fields). */
-  pb_size_t fields_count;
-  char      fields[16][32];
+    int32_t rate_hz;
+    /* Fields to include (empty = all fields). */
+    pb_size_t fields_count;
+    char fields[16][32];
 } star_v1_StreamTelemetryRequest;
 
 /* Request for system status. */
 typedef struct _star_v1_GetSystemStatusRequest {
-  /* Standard request header. */
-  bool                  has_header;
-  star_v1_RequestHeader header;
+    /* Standard request header. */
+    bool has_header;
+    star_v1_RequestHeader header;
 } star_v1_GetSystemStatusRequest;
 
 /* IMU sensor data (orientation, velocity, acceleration).
  Uses MKS units: radians for angles, m/s^2 for acceleration. */
 typedef struct _star_v1_ImuData {
-  /* Pitch angle in radians.
+    /* Pitch angle in radians.
  Range: -pi/2 to pi/2. */
-  double pitch_rad;
-  /* Roll angle in radians.
+    double pitch_rad;
+    /* Roll angle in radians.
  Range: -pi to pi. */
-  double roll_rad;
-  /* Yaw angle in radians.
+    double roll_rad;
+    /* Yaw angle in radians.
  Range: -pi to pi. */
-  double yaw_rad;
-  /* Linear acceleration X in meters per second squared. */
-  double accel_x_mps2;
-  /* Linear acceleration Y in meters per second squared. */
-  double accel_y_mps2;
-  /* Linear acceleration Z in meters per second squared.
+    double yaw_rad;
+    /* Linear acceleration X in meters per second squared. */
+    double accel_x_mps2;
+    /* Linear acceleration Y in meters per second squared. */
+    double accel_y_mps2;
+    /* Linear acceleration Z in meters per second squared.
  At rest, should read approximately 9.81 m/s^2. */
-  double accel_z_mps2;
-  /* Angular velocity X (roll rate) in radians per second. */
-  double gyro_x_rad_per_s;
-  /* Angular velocity Y (pitch rate) in radians per second. */
-  double gyro_y_rad_per_s;
-  /* Angular velocity Z (yaw rate) in radians per second. */
-  double gyro_z_rad_per_s;
+    double accel_z_mps2;
+    /* Angular velocity X (roll rate) in radians per second. */
+    double gyro_x_rad_per_s;
+    /* Angular velocity Y (pitch rate) in radians per second. */
+    double gyro_y_rad_per_s;
+    /* Angular velocity Z (yaw rate) in radians per second. */
+    double gyro_z_rad_per_s;
 } star_v1_ImuData;
 
 /* Obstacle detection data from ultrasonic sensors (RX72N specific).
  Reports distance and detection state from 4 HC-SR04 sensors. */
 typedef struct _star_v1_ObstacleData {
-  /* Distance from sensor 0 in meters. 0.0 if sensor invalid. */
-  float distance_front_left_m;
-  /* Distance from sensor 1 in meters. 0.0 if sensor invalid. */
-  float distance_front_right_m;
-  /* Distance from sensor 2 in meters. 0.0 if sensor invalid. */
-  float distance_back_left_m;
-  /* Distance from sensor 3 in meters. 0.0 if sensor invalid. */
-  float distance_back_right_m;
-  /* Any sensor has detected an obstacle within threshold distance. */
-  bool any_obstacle;
-  /* Per-sensor detection bitmask. Bit N set = sensor N detected obstacle.
+    /* Distance from sensor 0 in meters. 0.0 if sensor invalid. */
+    float distance_front_left_m;
+    /* Distance from sensor 1 in meters. 0.0 if sensor invalid. */
+    float distance_front_right_m;
+    /* Distance from sensor 2 in meters. 0.0 if sensor invalid. */
+    float distance_back_left_m;
+    /* Distance from sensor 3 in meters. 0.0 if sensor invalid. */
+    float distance_back_right_m;
+    /* Any sensor has detected an obstacle within threshold distance. */
+    bool any_obstacle;
+    /* Per-sensor detection bitmask. Bit N set = sensor N detected obstacle.
  Bit 0: sensor 0, Bit 1: sensor 1, Bit 2: sensor 2, Bit 3: sensor 3. */
-  uint32_t detected_mask;
+    uint32_t detected_mask;
 } star_v1_ObstacleData;
 
 /* GPS position data. */
 typedef struct _star_v1_GpsData {
-  /* WGS84 latitude in degrees.
+    /* WGS84 latitude in degrees.
  Range: -90 to 90. */
-  double latitude_deg;
-  /* WGS84 longitude in degrees.
+    double latitude_deg;
+    /* WGS84 longitude in degrees.
  Range: -180 to 180. */
-  double longitude_deg;
-  /* Altitude above sea level in meters. */
-  double altitude_m;
-  /* Horizontal accuracy estimate in meters. */
-  double accuracy_m;
-  /* Number of satellites in view. */
-  int32_t satellites;
-  /* GPS fix type. */
-  star_v1_GpsFix fix_type;
+    double longitude_deg;
+    /* Altitude above sea level in meters. */
+    double altitude_m;
+    /* Horizontal accuracy estimate in meters. */
+    double accuracy_m;
+    /* Number of satellites in view. */
+    int32_t satellites;
+    /* GPS fix type. */
+    star_v1_GpsFix fix_type;
 } star_v1_GpsData;
 
 /* Complete telemetry snapshot from all sensors. */
 typedef struct _star_v1_TelemetryData {
-  /* IMU sensor data. */
-  bool            has_imu;
-  star_v1_ImuData imu;
-  /* GPS data (if available). */
-  bool            has_gps;
-  star_v1_GpsData gps;
-  /* WiFi signal strength in dBm.
+    /* IMU sensor data. */
+    bool has_imu;
+    star_v1_ImuData imu;
+    /* GPS data (if available). */
+    bool has_gps;
+    star_v1_GpsData gps;
+    /* Obstacle detection data from ultrasonic sensors (RX72N specific). */
+    bool has_obstacle;
+    star_v1_ObstacleData obstacle;
+    /* WiFi signal strength in dBm.
  Typical range: -100 to -30 dBm. */
-  int32_t wifi_signal_dbm;
-  /* CPU usage percentage.
+    int32_t wifi_signal_dbm;
+    /* CPU usage percentage.
  Range: 0 to 100 percent. */
-  double cpu_usage_percent;
-  /* Temperature in Celsius (from DS18B20 sensor). */
-  double temperature_celsius;
-  /* Motor load percentage (average across motors).
+    double cpu_usage_percent;
+    /* Temperature in Celsius (from DS18B20 sensor). */
+    double temperature_celsius;
+    /* Motor load percentage (average across motors).
  Range: 0 to 100 percent. */
-  double motor_load_percent;
-  /* Telemetry timestamp. */
-  bool                      has_timestamp;
-  google_protobuf_Timestamp timestamp;
-  /* Emergency stop state (RX72N specific). */
-  bool emergency_stop;
-  /* Motor fault flags bitfield (RX72N specific).
+    double motor_load_percent;
+    /* Telemetry timestamp. */
+    bool has_timestamp;
+    google_protobuf_Timestamp timestamp;
+    /* Emergency stop state (RX72N specific). */
+    bool emergency_stop;
+    /* Motor fault flags bitfield (RX72N specific).
  Bit 0: Motor 0 fault, Bit 1: Motor 1 fault, etc. */
-  uint32_t fault_flags;
-  /* Timestamp in microseconds since boot (RX72N specific). */
-  int64_t timestamp_us;
-  /* Encoder data from motors (RX72N specific - fixed size for embedded).
+    uint32_t fault_flags;
+    /* Timestamp in microseconds since boot (RX72N specific). */
+    int64_t timestamp_us;
+    /* Encoder data from motors (RX72N specific - fixed size for embedded).
  Front left motor encoder data. */
-  bool                has_encoder_front_left;
-  star_v1_EncoderData encoder_front_left;
-  /* Front right motor encoder data. */
-  bool                has_encoder_front_right;
-  star_v1_EncoderData encoder_front_right;
-  /* Back left motor encoder data (reserved for future 4-motor support). */
-  bool                has_encoder_back_left;
-  star_v1_EncoderData encoder_back_left;
-  /* Back right motor encoder data (reserved for future 4-motor support). */
-  bool                has_encoder_back_right;
-  star_v1_EncoderData encoder_back_right;
-  /* Frame sequence number from transport layer for drop detection.
+    bool has_encoder_front_left;
+    star_v1_EncoderData encoder_front_left;
+    /* Front right motor encoder data. */
+    bool has_encoder_front_right;
+    star_v1_EncoderData encoder_front_right;
+    /* Back left motor encoder data (reserved for future 4-motor support). */
+    bool has_encoder_back_left;
+    star_v1_EncoderData encoder_back_left;
+    /* Back right motor encoder data (reserved for future 4-motor support). */
+    bool has_encoder_back_right;
+    star_v1_EncoderData encoder_back_right;
+    /* Frame sequence number from transport layer for drop detection.
  Increments with each transmitted frame. Used by diagnostics to detect
  missing frames in the telemetry stream. */
-  uint32_t frame_sequence;
-  /* Obstacle detection data from ultrasonic sensors (RX72N specific). */
-  bool                 has_obstacle;
-  star_v1_ObstacleData obstacle;
+    uint32_t frame_sequence;
 } star_v1_TelemetryData;
 
 /* Response with telemetry snapshot. */
 typedef struct _star_v1_GetTelemetryResponse {
-  /* Standard response header. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* Current telemetry data. */
-  bool                  has_telemetry;
-  star_v1_TelemetryData telemetry;
+    /* Standard response header. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* Current telemetry data. */
+    bool has_telemetry;
+    star_v1_TelemetryData telemetry;
 } star_v1_GetTelemetryResponse;
 
 /* Complete system status information. */
 typedef struct _star_v1_SystemStatus {
-  /* Overall connection state. */
-  star_v1_ConnectionStatus connection_status;
-  /* Current operating mode. */
-  star_v1_RobotMode mode;
-  /* RX72N motor controller connected. */
-  bool rx72n_connected;
-  /* LiDAR sensor connected. */
-  bool lidar_connected;
-  /* ROS2 bridge connected. */
-  bool ros_connected;
-  /* RX72N firmware version string. */
-  char firmware_version[32];
-  /* System uptime in seconds. */
-  uint64_t uptime_s;
-  /* Free heap memory in bytes. */
-  uint32_t free_heap_bytes;
+    /* Overall connection state. */
+    star_v1_ConnectionStatus connection_status;
+    /* Current operating mode. */
+    star_v1_RobotMode mode;
+    /* RX72N motor controller connected. */
+    bool rx72n_connected;
+    /* LiDAR sensor connected. */
+    bool lidar_connected;
+    /* ROS2 bridge connected. */
+    bool ros_connected;
+    /* RX72N firmware version string. */
+    char firmware_version[32];
+    /* System uptime in seconds. */
+    uint64_t uptime_s;
+    /* Free heap memory in bytes. */
+    uint32_t free_heap_bytes;
 } star_v1_SystemStatus;
 
 /* Response with system status. */
 typedef struct _star_v1_GetSystemStatusResponse {
-  /* Standard response header. */
-  bool                   has_header;
-  star_v1_ResponseHeader header;
-  /* System status information. */
-  bool                 has_status;
-  star_v1_SystemStatus status;
+    /* Standard response header. */
+    bool has_header;
+    star_v1_ResponseHeader header;
+    /* System status information. */
+    bool has_status;
+    star_v1_SystemStatus status;
 } star_v1_GetSystemStatusResponse;
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Helper constants for enums */
-#define _star_v1_GpsFix_MIN       star_v1_GpsFix_GPS_FIX_UNKNOWN
-#define _star_v1_GpsFix_MAX       star_v1_GpsFix_GPS_FIX_RTK_FIXED
-#define _star_v1_GpsFix_ARRAYSIZE ((star_v1_GpsFix)(star_v1_GpsFix_GPS_FIX_RTK_FIXED + 1))
+#define _star_v1_GpsFix_MIN star_v1_GpsFix_GPS_FIX_UNKNOWN
+#define _star_v1_GpsFix_MAX star_v1_GpsFix_GPS_FIX_RTK_FIXED
+#define _star_v1_GpsFix_ARRAYSIZE ((star_v1_GpsFix)(star_v1_GpsFix_GPS_FIX_RTK_FIXED+1))
 
 #define _star_v1_ConnectionStatus_MIN star_v1_ConnectionStatus_CONNECTION_STATUS_UNKNOWN
 #define _star_v1_ConnectionStatus_MAX star_v1_ConnectionStatus_CONNECTION_STATUS_ERROR
-#define _star_v1_ConnectionStatus_ARRAYSIZE                                                        \
-  ((star_v1_ConnectionStatus)(star_v1_ConnectionStatus_CONNECTION_STATUS_ERROR + 1))
+#define _star_v1_ConnectionStatus_ARRAYSIZE ((star_v1_ConnectionStatus)(star_v1_ConnectionStatus_CONNECTION_STATUS_ERROR+1))
 
 #define _star_v1_RobotMode_MIN star_v1_RobotMode_ROBOT_MODE_UNKNOWN
 #define _star_v1_RobotMode_MAX star_v1_RobotMode_ROBOT_MODE_EMERGENCY_STOP
-#define _star_v1_RobotMode_ARRAYSIZE                                                               \
-  ((star_v1_RobotMode)(star_v1_RobotMode_ROBOT_MODE_EMERGENCY_STOP + 1))
+#define _star_v1_RobotMode_ARRAYSIZE ((star_v1_RobotMode)(star_v1_RobotMode_ROBOT_MODE_EMERGENCY_STOP+1))
+
+
+
+
+
+
+
+
 
 #define star_v1_GpsData_fix_type_ENUMTYPE star_v1_GpsFix
 
 #define star_v1_SystemStatus_connection_status_ENUMTYPE star_v1_ConnectionStatus
-#define star_v1_SystemStatus_mode_ENUMTYPE              star_v1_RobotMode
+#define star_v1_SystemStatus_mode_ENUMTYPE star_v1_RobotMode
+
 
 /* Initializer values for message structs */
-#define star_v1_GetTelemetryRequest_init_default                                                   \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_GetTelemetryResponse_init_default                                                  \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_TelemetryData_init_default          \
-  }
-#define star_v1_StreamTelemetryRequest_init_default                                                \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default, 0, 0,                                               \
-    {                                                                                              \
-      "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""                               \
-    }                                                                                              \
-  }
-#define star_v1_GetSystemStatusRequest_init_default                                                \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_default                                                      \
-  }
-#define star_v1_GetSystemStatusResponse_init_default                                               \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_default, false, star_v1_SystemStatus_init_default           \
-  }
-#define star_v1_TelemetryData_init_default                                                         \
-  {                                                                                                \
-    false, star_v1_ImuData_init_default, false, star_v1_GpsData_init_default, 0, 0, 0, 0, false,   \
-      google_protobuf_Timestamp_init_default, 0, 0, 0, false, star_v1_EncoderData_init_default,    \
-      false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false,     \
-      star_v1_EncoderData_init_default, 0, false, star_v1_ObstacleData_init_default                \
-  }
-#define star_v1_ImuData_init_default                                                               \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0, 0, 0, 0                                                                      \
-  }
-#define star_v1_GpsData_init_default                                                               \
-  {                                                                                                \
-    0, 0, 0, 0, 0, _star_v1_GpsFix_MIN                                                             \
-  }
-#define star_v1_ObstacleData_init_default                                                          \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0                                                                               \
-  }
-#define star_v1_SystemStatus_init_default                                                          \
-  {                                                                                                \
-    _star_v1_ConnectionStatus_MIN, _star_v1_RobotMode_MIN, 0, 0, 0, "", 0, 0                       \
-  }
-#define star_v1_GetTelemetryRequest_init_zero                                                      \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_GetTelemetryResponse_init_zero                                                     \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_TelemetryData_init_zero                \
-  }
-#define star_v1_StreamTelemetryRequest_init_zero                                                   \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero, 0, 0,                                                  \
-    {                                                                                              \
-      "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""                               \
-    }                                                                                              \
-  }
-#define star_v1_GetSystemStatusRequest_init_zero                                                   \
-  {                                                                                                \
-    false, star_v1_RequestHeader_init_zero                                                         \
-  }
-#define star_v1_GetSystemStatusResponse_init_zero                                                  \
-  {                                                                                                \
-    false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemStatus_init_zero                 \
-  }
-#define star_v1_TelemetryData_init_zero                                                            \
-  {                                                                                                \
-    false, star_v1_ImuData_init_zero, false, star_v1_GpsData_init_zero, 0, 0, 0, 0, false,         \
-      google_protobuf_Timestamp_init_zero, 0, 0, 0, false, star_v1_EncoderData_init_zero, false,   \
-      star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false,                  \
-      star_v1_EncoderData_init_zero, 0, false, star_v1_ObstacleData_init_zero                      \
-  }
-#define star_v1_ImuData_init_zero                                                                  \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0, 0, 0, 0                                                                      \
-  }
-#define star_v1_GpsData_init_zero                                                                  \
-  {                                                                                                \
-    0, 0, 0, 0, 0, _star_v1_GpsFix_MIN                                                             \
-  }
-#define star_v1_ObstacleData_init_zero                                                             \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0                                                                               \
-  }
-#define star_v1_SystemStatus_init_zero                                                             \
-  {                                                                                                \
-    _star_v1_ConnectionStatus_MIN, _star_v1_RobotMode_MIN, 0, 0, 0, "", 0, 0                       \
-  }
+#define star_v1_GetTelemetryRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_GetTelemetryResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_TelemetryData_init_default}
+#define star_v1_StreamTelemetryRequest_init_default {false, star_v1_RequestHeader_init_default, 0, 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}}
+#define star_v1_GetSystemStatusRequest_init_default {false, star_v1_RequestHeader_init_default}
+#define star_v1_GetSystemStatusResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_SystemStatus_init_default}
+#define star_v1_TelemetryData_init_default       {false, star_v1_ImuData_init_default, false, star_v1_GpsData_init_default, false, star_v1_ObstacleData_init_default, 0, 0, 0, 0, false, google_protobuf_Timestamp_init_default, 0, 0, 0, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, 0}
+#define star_v1_ImuData_init_default             {0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define star_v1_ObstacleData_init_default        {0, 0, 0, 0, 0, 0}
+#define star_v1_GpsData_init_default             {0, 0, 0, 0, 0, _star_v1_GpsFix_MIN}
+#define star_v1_SystemStatus_init_default        {_star_v1_ConnectionStatus_MIN, _star_v1_RobotMode_MIN, 0, 0, 0, "", 0, 0}
+#define star_v1_GetTelemetryRequest_init_zero    {false, star_v1_RequestHeader_init_zero}
+#define star_v1_GetTelemetryResponse_init_zero   {false, star_v1_ResponseHeader_init_zero, false, star_v1_TelemetryData_init_zero}
+#define star_v1_StreamTelemetryRequest_init_zero {false, star_v1_RequestHeader_init_zero, 0, 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}}
+#define star_v1_GetSystemStatusRequest_init_zero {false, star_v1_RequestHeader_init_zero}
+#define star_v1_GetSystemStatusResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemStatus_init_zero}
+#define star_v1_TelemetryData_init_zero          {false, star_v1_ImuData_init_zero, false, star_v1_GpsData_init_zero, false, star_v1_ObstacleData_init_zero, 0, 0, 0, 0, false, google_protobuf_Timestamp_init_zero, 0, 0, 0, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, 0}
+#define star_v1_ImuData_init_zero                {0, 0, 0, 0, 0, 0, 0, 0, 0}
+#define star_v1_ObstacleData_init_zero           {0, 0, 0, 0, 0, 0}
+#define star_v1_GpsData_init_zero                {0, 0, 0, 0, 0, _star_v1_GpsFix_MIN}
+#define star_v1_SystemStatus_init_zero           {_star_v1_ConnectionStatus_MIN, _star_v1_RobotMode_MIN, 0, 0, 0, "", 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_GetTelemetryRequest_header_tag        1
-#define star_v1_StreamTelemetryRequest_header_tag     1
-#define star_v1_StreamTelemetryRequest_rate_hz_tag    2
-#define star_v1_StreamTelemetryRequest_fields_tag     3
-#define star_v1_GetSystemStatusRequest_header_tag     1
-#define star_v1_ImuData_pitch_rad_tag                 1
-#define star_v1_ImuData_roll_rad_tag                  2
-#define star_v1_ImuData_yaw_rad_tag                   3
-#define star_v1_ImuData_accel_x_mps2_tag              4
-#define star_v1_ImuData_accel_y_mps2_tag              5
-#define star_v1_ImuData_accel_z_mps2_tag              6
-#define star_v1_ImuData_gyro_x_rad_per_s_tag          7
-#define star_v1_ImuData_gyro_y_rad_per_s_tag          8
-#define star_v1_ImuData_gyro_z_rad_per_s_tag          9
-#define star_v1_GpsData_latitude_deg_tag              1
-#define star_v1_GpsData_longitude_deg_tag             2
-#define star_v1_GpsData_altitude_m_tag                3
-#define star_v1_GpsData_accuracy_m_tag                4
-#define star_v1_GpsData_satellites_tag                5
-#define star_v1_GpsData_fix_type_tag                  6
-#define star_v1_TelemetryData_imu_tag                 1
-#define star_v1_TelemetryData_gps_tag                 2
-#define star_v1_TelemetryData_wifi_signal_dbm_tag     4
-#define star_v1_TelemetryData_cpu_usage_percent_tag   5
+#define star_v1_GetTelemetryRequest_header_tag   1
+#define star_v1_StreamTelemetryRequest_header_tag 1
+#define star_v1_StreamTelemetryRequest_rate_hz_tag 2
+#define star_v1_StreamTelemetryRequest_fields_tag 3
+#define star_v1_GetSystemStatusRequest_header_tag 1
+#define star_v1_ImuData_pitch_rad_tag            1
+#define star_v1_ImuData_roll_rad_tag             2
+#define star_v1_ImuData_yaw_rad_tag              3
+#define star_v1_ImuData_accel_x_mps2_tag         4
+#define star_v1_ImuData_accel_y_mps2_tag         5
+#define star_v1_ImuData_accel_z_mps2_tag         6
+#define star_v1_ImuData_gyro_x_rad_per_s_tag     7
+#define star_v1_ImuData_gyro_y_rad_per_s_tag     8
+#define star_v1_ImuData_gyro_z_rad_per_s_tag     9
+#define star_v1_ObstacleData_distance_front_left_m_tag 1
+#define star_v1_ObstacleData_distance_front_right_m_tag 2
+#define star_v1_ObstacleData_distance_back_left_m_tag 3
+#define star_v1_ObstacleData_distance_back_right_m_tag 4
+#define star_v1_ObstacleData_any_obstacle_tag    5
+#define star_v1_ObstacleData_detected_mask_tag   6
+#define star_v1_GpsData_latitude_deg_tag         1
+#define star_v1_GpsData_longitude_deg_tag        2
+#define star_v1_GpsData_altitude_m_tag           3
+#define star_v1_GpsData_accuracy_m_tag           4
+#define star_v1_GpsData_satellites_tag           5
+#define star_v1_GpsData_fix_type_tag             6
+#define star_v1_TelemetryData_imu_tag            1
+#define star_v1_TelemetryData_gps_tag            2
+#define star_v1_TelemetryData_obstacle_tag       3
+#define star_v1_TelemetryData_wifi_signal_dbm_tag 4
+#define star_v1_TelemetryData_cpu_usage_percent_tag 5
 #define star_v1_TelemetryData_temperature_celsius_tag 6
-#define star_v1_TelemetryData_motor_load_percent_tag  7
-#define star_v1_TelemetryData_timestamp_tag           8
-#define star_v1_TelemetryData_emergency_stop_tag      10
-#define star_v1_TelemetryData_fault_flags_tag         11
-#define star_v1_TelemetryData_timestamp_us_tag        14
-#define star_v1_TelemetryData_encoder_front_left_tag  15
+#define star_v1_TelemetryData_motor_load_percent_tag 7
+#define star_v1_TelemetryData_timestamp_tag      8
+#define star_v1_TelemetryData_emergency_stop_tag 10
+#define star_v1_TelemetryData_fault_flags_tag    11
+#define star_v1_TelemetryData_timestamp_us_tag   14
+#define star_v1_TelemetryData_encoder_front_left_tag 15
 #define star_v1_TelemetryData_encoder_front_right_tag 16
-#define star_v1_TelemetryData_encoder_back_left_tag   17
-#define star_v1_TelemetryData_encoder_back_right_tag  18
-#define star_v1_TelemetryData_frame_sequence_tag      19
-#define star_v1_TelemetryData_obstacle_tag            3
-#define star_v1_ObstacleData_distance_front_left_m_tag         1
-#define star_v1_ObstacleData_distance_front_right_m_tag         2
-#define star_v1_ObstacleData_distance_back_left_m_tag         3
-#define star_v1_ObstacleData_distance_back_right_m_tag         4
-#define star_v1_ObstacleData_any_obstacle_tag         5
-#define star_v1_ObstacleData_detected_mask_tag        6
-#define star_v1_GetTelemetryResponse_header_tag       1
-#define star_v1_GetTelemetryResponse_telemetry_tag    2
-#define star_v1_SystemStatus_connection_status_tag    1
-#define star_v1_SystemStatus_mode_tag                 2
-#define star_v1_SystemStatus_rx72n_connected_tag      3
-#define star_v1_SystemStatus_lidar_connected_tag      4
-#define star_v1_SystemStatus_ros_connected_tag        5
-#define star_v1_SystemStatus_firmware_version_tag     6
-#define star_v1_SystemStatus_uptime_s_tag             7
-#define star_v1_SystemStatus_free_heap_bytes_tag      8
-#define star_v1_GetSystemStatusResponse_header_tag    1
-#define star_v1_GetSystemStatusResponse_status_tag    2
+#define star_v1_TelemetryData_encoder_back_left_tag 17
+#define star_v1_TelemetryData_encoder_back_right_tag 18
+#define star_v1_TelemetryData_frame_sequence_tag 19
+#define star_v1_GetTelemetryResponse_header_tag  1
+#define star_v1_GetTelemetryResponse_telemetry_tag 2
+#define star_v1_SystemStatus_connection_status_tag 1
+#define star_v1_SystemStatus_mode_tag            2
+#define star_v1_SystemStatus_rx72n_connected_tag 3
+#define star_v1_SystemStatus_lidar_connected_tag 4
+#define star_v1_SystemStatus_ros_connected_tag   5
+#define star_v1_SystemStatus_firmware_version_tag 6
+#define star_v1_SystemStatus_uptime_s_tag        7
+#define star_v1_SystemStatus_free_heap_bytes_tag 8
+#define star_v1_GetSystemStatusResponse_header_tag 1
+#define star_v1_GetSystemStatusResponse_status_tag 2
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_GetTelemetryRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetTelemetryRequest_CALLBACK        NULL
-#define star_v1_GetTelemetryRequest_DEFAULT         NULL
-#define star_v1_GetTelemetryRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_GetTelemetryRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_GetTelemetryRequest_CALLBACK NULL
+#define star_v1_GetTelemetryRequest_DEFAULT NULL
+#define star_v1_GetTelemetryRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetTelemetryResponse_FIELDLIST(X, a)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, telemetry, 2)
-#define star_v1_GetTelemetryResponse_CALLBACK          NULL
-#define star_v1_GetTelemetryResponse_DEFAULT           NULL
-#define star_v1_GetTelemetryResponse_header_MSGTYPE    star_v1_ResponseHeader
+#define star_v1_GetTelemetryResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  telemetry,         2)
+#define star_v1_GetTelemetryResponse_CALLBACK NULL
+#define star_v1_GetTelemetryResponse_DEFAULT NULL
+#define star_v1_GetTelemetryResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetTelemetryResponse_telemetry_MSGTYPE star_v1_TelemetryData
 
-#define star_v1_StreamTelemetryRequest_FIELDLIST(X, a)                                             \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, SINGULAR, INT32, rate_hz, 2)                                                        \
-  X(a, STATIC, REPEATED, STRING, fields, 3)
-#define star_v1_StreamTelemetryRequest_CALLBACK       NULL
-#define star_v1_StreamTelemetryRequest_DEFAULT        NULL
+#define star_v1_StreamTelemetryRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   SINGULAR, INT32,    rate_hz,           2) \
+X(a, STATIC,   REPEATED, STRING,   fields,            3)
+#define star_v1_StreamTelemetryRequest_CALLBACK NULL
+#define star_v1_StreamTelemetryRequest_DEFAULT NULL
 #define star_v1_StreamTelemetryRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetSystemStatusRequest_FIELDLIST(X, a) X(a, STATIC, OPTIONAL, MESSAGE, header, 1)
-#define star_v1_GetSystemStatusRequest_CALLBACK        NULL
-#define star_v1_GetSystemStatusRequest_DEFAULT         NULL
-#define star_v1_GetSystemStatusRequest_header_MSGTYPE  star_v1_RequestHeader
+#define star_v1_GetSystemStatusRequest_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1)
+#define star_v1_GetSystemStatusRequest_CALLBACK NULL
+#define star_v1_GetSystemStatusRequest_DEFAULT NULL
+#define star_v1_GetSystemStatusRequest_header_MSGTYPE star_v1_RequestHeader
 
-#define star_v1_GetSystemStatusResponse_FIELDLIST(X, a)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, header, 1)                                                       \
-  X(a, STATIC, OPTIONAL, MESSAGE, status, 2)
-#define star_v1_GetSystemStatusResponse_CALLBACK       NULL
-#define star_v1_GetSystemStatusResponse_DEFAULT        NULL
+#define star_v1_GetSystemStatusResponse_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  header,            1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  status,            2)
+#define star_v1_GetSystemStatusResponse_CALLBACK NULL
+#define star_v1_GetSystemStatusResponse_DEFAULT NULL
 #define star_v1_GetSystemStatusResponse_header_MSGTYPE star_v1_ResponseHeader
 #define star_v1_GetSystemStatusResponse_status_MSGTYPE star_v1_SystemStatus
 
-#define star_v1_TelemetryData_FIELDLIST(X, a)                                                      \
-  X(a, STATIC, OPTIONAL, MESSAGE, imu, 1)                                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, gps, 2)                                                          \
-  X(a, STATIC, SINGULAR, INT32, wifi_signal_dbm, 4)                                                \
-  X(a, STATIC, SINGULAR, DOUBLE, cpu_usage_percent, 5)                                             \
-  X(a, STATIC, SINGULAR, DOUBLE, temperature_celsius, 6)                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, motor_load_percent, 7)                                            \
-  X(a, STATIC, OPTIONAL, MESSAGE, timestamp, 8)                                                    \
-  X(a, STATIC, SINGULAR, BOOL, emergency_stop, 10)                                                 \
-  X(a, STATIC, SINGULAR, UINT32, fault_flags, 11)                                                  \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 14)                                                  \
-  X(a, STATIC, OPTIONAL, MESSAGE, encoder_front_left, 15)                                          \
-  X(a, STATIC, OPTIONAL, MESSAGE, encoder_front_right, 16)                                         \
-  X(a, STATIC, OPTIONAL, MESSAGE, encoder_back_left, 17)                                           \
-  X(a, STATIC, OPTIONAL, MESSAGE, encoder_back_right, 18)                                          \
-  X(a, STATIC, SINGULAR, UINT32, frame_sequence, 19)                                               \
-  X(a, STATIC, OPTIONAL, MESSAGE, obstacle, 3)
-#define star_v1_TelemetryData_CALLBACK                    NULL
-#define star_v1_TelemetryData_DEFAULT                     NULL
-#define star_v1_TelemetryData_imu_MSGTYPE                 star_v1_ImuData
-#define star_v1_TelemetryData_gps_MSGTYPE                 star_v1_GpsData
-#define star_v1_TelemetryData_timestamp_MSGTYPE           google_protobuf_Timestamp
-#define star_v1_TelemetryData_encoder_front_left_MSGTYPE  star_v1_EncoderData
+#define star_v1_TelemetryData_FIELDLIST(X, a) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  imu,               1) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  gps,               2) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  obstacle,          3) \
+X(a, STATIC,   SINGULAR, INT32,    wifi_signal_dbm,   4) \
+X(a, STATIC,   SINGULAR, DOUBLE,   cpu_usage_percent,   5) \
+X(a, STATIC,   SINGULAR, DOUBLE,   temperature_celsius,   6) \
+X(a, STATIC,   SINGULAR, DOUBLE,   motor_load_percent,   7) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  timestamp,         8) \
+X(a, STATIC,   SINGULAR, BOOL,     emergency_stop,   10) \
+X(a, STATIC,   SINGULAR, UINT32,   fault_flags,      11) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,     14) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  encoder_front_left,  15) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  encoder_front_right,  16) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  encoder_back_left,  17) \
+X(a, STATIC,   OPTIONAL, MESSAGE,  encoder_back_right,  18) \
+X(a, STATIC,   SINGULAR, UINT32,   frame_sequence,   19)
+#define star_v1_TelemetryData_CALLBACK NULL
+#define star_v1_TelemetryData_DEFAULT NULL
+#define star_v1_TelemetryData_imu_MSGTYPE star_v1_ImuData
+#define star_v1_TelemetryData_gps_MSGTYPE star_v1_GpsData
+#define star_v1_TelemetryData_obstacle_MSGTYPE star_v1_ObstacleData
+#define star_v1_TelemetryData_timestamp_MSGTYPE google_protobuf_Timestamp
+#define star_v1_TelemetryData_encoder_front_left_MSGTYPE star_v1_EncoderData
 #define star_v1_TelemetryData_encoder_front_right_MSGTYPE star_v1_EncoderData
-#define star_v1_TelemetryData_encoder_back_left_MSGTYPE   star_v1_EncoderData
-#define star_v1_TelemetryData_encoder_back_right_MSGTYPE  star_v1_EncoderData
-#define star_v1_TelemetryData_obstacle_MSGTYPE            star_v1_ObstacleData
+#define star_v1_TelemetryData_encoder_back_left_MSGTYPE star_v1_EncoderData
+#define star_v1_TelemetryData_encoder_back_right_MSGTYPE star_v1_EncoderData
 
-#define star_v1_ObstacleData_FIELDLIST(X, a)                                                       \
-  X(a, STATIC, SINGULAR, FLOAT, distance_front_left_m, 1)                                                   \
-  X(a, STATIC, SINGULAR, FLOAT, distance_front_right_m, 2)                                                   \
-  X(a, STATIC, SINGULAR, FLOAT, distance_back_left_m, 3)                                                   \
-  X(a, STATIC, SINGULAR, FLOAT, distance_back_right_m, 4)                                                   \
-  X(a, STATIC, SINGULAR, BOOL, any_obstacle, 5)                                                    \
-  X(a, STATIC, SINGULAR, UINT32, detected_mask, 6)
-#define star_v1_ObstacleData_CALLBACK NULL
-#define star_v1_ObstacleData_DEFAULT  NULL
-
-#define star_v1_ImuData_FIELDLIST(X, a)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, pitch_rad, 1)                                                     \
-  X(a, STATIC, SINGULAR, DOUBLE, roll_rad, 2)                                                      \
-  X(a, STATIC, SINGULAR, DOUBLE, yaw_rad, 3)                                                       \
-  X(a, STATIC, SINGULAR, DOUBLE, accel_x_mps2, 4)                                                  \
-  X(a, STATIC, SINGULAR, DOUBLE, accel_y_mps2, 5)                                                  \
-  X(a, STATIC, SINGULAR, DOUBLE, accel_z_mps2, 6)                                                  \
-  X(a, STATIC, SINGULAR, DOUBLE, gyro_x_rad_per_s, 7)                                              \
-  X(a, STATIC, SINGULAR, DOUBLE, gyro_y_rad_per_s, 8)                                              \
-  X(a, STATIC, SINGULAR, DOUBLE, gyro_z_rad_per_s, 9)
+#define star_v1_ImuData_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   pitch_rad,         1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   roll_rad,          2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   yaw_rad,           3) \
+X(a, STATIC,   SINGULAR, DOUBLE,   accel_x_mps2,      4) \
+X(a, STATIC,   SINGULAR, DOUBLE,   accel_y_mps2,      5) \
+X(a, STATIC,   SINGULAR, DOUBLE,   accel_z_mps2,      6) \
+X(a, STATIC,   SINGULAR, DOUBLE,   gyro_x_rad_per_s,   7) \
+X(a, STATIC,   SINGULAR, DOUBLE,   gyro_y_rad_per_s,   8) \
+X(a, STATIC,   SINGULAR, DOUBLE,   gyro_z_rad_per_s,   9)
 #define star_v1_ImuData_CALLBACK NULL
-#define star_v1_ImuData_DEFAULT  NULL
+#define star_v1_ImuData_DEFAULT NULL
 
-#define star_v1_GpsData_FIELDLIST(X, a)                                                            \
-  X(a, STATIC, SINGULAR, DOUBLE, latitude_deg, 1)                                                  \
-  X(a, STATIC, SINGULAR, DOUBLE, longitude_deg, 2)                                                 \
-  X(a, STATIC, SINGULAR, DOUBLE, altitude_m, 3)                                                    \
-  X(a, STATIC, SINGULAR, DOUBLE, accuracy_m, 4)                                                    \
-  X(a, STATIC, SINGULAR, INT32, satellites, 5)                                                     \
-  X(a, STATIC, SINGULAR, UENUM, fix_type, 6)
+#define star_v1_ObstacleData_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, FLOAT,    distance_front_left_m,   1) \
+X(a, STATIC,   SINGULAR, FLOAT,    distance_front_right_m,   2) \
+X(a, STATIC,   SINGULAR, FLOAT,    distance_back_left_m,   3) \
+X(a, STATIC,   SINGULAR, FLOAT,    distance_back_right_m,   4) \
+X(a, STATIC,   SINGULAR, BOOL,     any_obstacle,      5) \
+X(a, STATIC,   SINGULAR, UINT32,   detected_mask,     6)
+#define star_v1_ObstacleData_CALLBACK NULL
+#define star_v1_ObstacleData_DEFAULT NULL
+
+#define star_v1_GpsData_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   latitude_deg,      1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   longitude_deg,     2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   altitude_m,        3) \
+X(a, STATIC,   SINGULAR, DOUBLE,   accuracy_m,        4) \
+X(a, STATIC,   SINGULAR, INT32,    satellites,        5) \
+X(a, STATIC,   SINGULAR, UENUM,    fix_type,          6)
 #define star_v1_GpsData_CALLBACK NULL
-#define star_v1_GpsData_DEFAULT  NULL
+#define star_v1_GpsData_DEFAULT NULL
 
-#define star_v1_SystemStatus_FIELDLIST(X, a)                                                       \
-  X(a, STATIC, SINGULAR, UENUM, connection_status, 1)                                              \
-  X(a, STATIC, SINGULAR, UENUM, mode, 2)                                                           \
-  X(a, STATIC, SINGULAR, BOOL, rx72n_connected, 3)                                                 \
-  X(a, STATIC, SINGULAR, BOOL, lidar_connected, 4)                                                 \
-  X(a, STATIC, SINGULAR, BOOL, ros_connected, 5)                                                   \
-  X(a, STATIC, SINGULAR, STRING, firmware_version, 6)                                              \
-  X(a, STATIC, SINGULAR, UINT64, uptime_s, 7)                                                      \
-  X(a, STATIC, SINGULAR, UINT32, free_heap_bytes, 8)
+#define star_v1_SystemStatus_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UENUM,    connection_status,   1) \
+X(a, STATIC,   SINGULAR, UENUM,    mode,              2) \
+X(a, STATIC,   SINGULAR, BOOL,     rx72n_connected,   3) \
+X(a, STATIC,   SINGULAR, BOOL,     lidar_connected,   4) \
+X(a, STATIC,   SINGULAR, BOOL,     ros_connected,     5) \
+X(a, STATIC,   SINGULAR, STRING,   firmware_version,   6) \
+X(a, STATIC,   SINGULAR, UINT64,   uptime_s,          7) \
+X(a, STATIC,   SINGULAR, UINT32,   free_heap_bytes,   8)
 #define star_v1_SystemStatus_CALLBACK NULL
-#define star_v1_SystemStatus_DEFAULT  NULL
+#define star_v1_SystemStatus_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_GetTelemetryRequest_msg;
 extern const pb_msgdesc_t star_v1_GetTelemetryResponse_msg;
@@ -538,29 +475,29 @@ extern const pb_msgdesc_t star_v1_GpsData_msg;
 extern const pb_msgdesc_t star_v1_SystemStatus_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_GetTelemetryRequest_fields     &star_v1_GetTelemetryRequest_msg
-#define star_v1_GetTelemetryResponse_fields    &star_v1_GetTelemetryResponse_msg
-#define star_v1_StreamTelemetryRequest_fields  &star_v1_StreamTelemetryRequest_msg
-#define star_v1_GetSystemStatusRequest_fields  &star_v1_GetSystemStatusRequest_msg
+#define star_v1_GetTelemetryRequest_fields &star_v1_GetTelemetryRequest_msg
+#define star_v1_GetTelemetryResponse_fields &star_v1_GetTelemetryResponse_msg
+#define star_v1_StreamTelemetryRequest_fields &star_v1_StreamTelemetryRequest_msg
+#define star_v1_GetSystemStatusRequest_fields &star_v1_GetSystemStatusRequest_msg
 #define star_v1_GetSystemStatusResponse_fields &star_v1_GetSystemStatusResponse_msg
-#define star_v1_TelemetryData_fields           &star_v1_TelemetryData_msg
-#define star_v1_ImuData_fields                 &star_v1_ImuData_msg
-#define star_v1_ObstacleData_fields            &star_v1_ObstacleData_msg
-#define star_v1_GpsData_fields                 &star_v1_GpsData_msg
-#define star_v1_SystemStatus_fields            &star_v1_SystemStatus_msg
+#define star_v1_TelemetryData_fields &star_v1_TelemetryData_msg
+#define star_v1_ImuData_fields &star_v1_ImuData_msg
+#define star_v1_ObstacleData_fields &star_v1_ObstacleData_msg
+#define star_v1_GpsData_fields &star_v1_GpsData_msg
+#define star_v1_SystemStatus_fields &star_v1_SystemStatus_msg
 
 /* Maximum encoded size of messages (where known) */
-#define STAR_V1_STAR_V1_TELEMETRY_PB_H_MAX_SIZE star_v1_GetTelemetryResponse_size
-#define star_v1_GetSystemStatusRequest_size     149
-#define star_v1_GetSystemStatusResponse_size    425
-#define star_v1_GetTelemetryRequest_size        149
-#define star_v1_GetTelemetryResponse_size       802
-#define star_v1_GpsData_size                    49
-#define star_v1_ImuData_size                    81
-#define star_v1_ObstacleData_size               32
-#define star_v1_StreamTelemetryRequest_size     688
-#define star_v1_SystemStatus_size               60
-#define star_v1_TelemetryData_size              436
+#define STAR_V1_STAR_V1_TELEMETRY_PB_H_MAX_SIZE  star_v1_GetTelemetryResponse_size
+#define star_v1_GetSystemStatusRequest_size      149
+#define star_v1_GetSystemStatusResponse_size     425
+#define star_v1_GetTelemetryRequest_size         149
+#define star_v1_GetTelemetryResponse_size        797
+#define star_v1_GpsData_size                     49
+#define star_v1_ImuData_size                     81
+#define star_v1_ObstacleData_size                28
+#define star_v1_StreamTelemetryRequest_size      688
+#define star_v1_SystemStatus_size                60
+#define star_v1_TelemetryData_size               431
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/ui.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/ui.pb.c
@@ -8,15 +8,24 @@
 
 PB_BIND(star_v1_STAREnvelope, star_v1_STAREnvelope, 4)
 
+
 PB_BIND(star_v1_MotorStatusList, star_v1_MotorStatusList, AUTO)
+
 
 PB_BIND(star_v1_OdometryData, star_v1_OdometryData, AUTO)
 
+
 PB_BIND(star_v1_LidarScan, star_v1_LidarScan, 2)
+
 
 PB_BIND(star_v1_Alert, star_v1_Alert, AUTO)
 
+
 PB_BIND(star_v1_EStopCommand, star_v1_EStopCommand, AUTO)
+
+
+
+
 
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
@@ -25,3 +34,4 @@ PB_BIND(star_v1_EStopCommand, star_v1_EStopCommand, AUTO)
  */
 PB_STATIC_ASSERT(sizeof(double) == 8, DOUBLE_MUST_BE_8_BYTES)
 #endif
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/ui.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/ui.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_UI_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_UI_PB_H_INCLUDED
 #include <pb.h>
-
 #include "star/v1/controller.pb.h"
 #include "star/v1/motor_control.pb.h"
 #include "star/v1/telemetry.pb.h"
@@ -16,41 +15,41 @@
 /* Enum definitions */
 /* Alert severity level. */
 typedef enum _star_v1_AlertLevel {
-  /* Unknown or unset alert level. */
-  star_v1_AlertLevel_ALERT_LEVEL_UNKNOWN = 0,
-  /* Informational alert. */
-  star_v1_AlertLevel_ALERT_LEVEL_INFO = 1,
-  /* Warning alert requiring attention. */
-  star_v1_AlertLevel_ALERT_LEVEL_WARN = 2,
-  /* Error alert indicating degraded operation. */
-  star_v1_AlertLevel_ALERT_LEVEL_ERROR = 3,
-  /* Critical alert requiring immediate action. */
-  star_v1_AlertLevel_ALERT_LEVEL_CRITICAL = 4
+    /* Unknown or unset alert level. */
+    star_v1_AlertLevel_ALERT_LEVEL_UNKNOWN = 0,
+    /* Informational alert. */
+    star_v1_AlertLevel_ALERT_LEVEL_INFO = 1,
+    /* Warning alert requiring attention. */
+    star_v1_AlertLevel_ALERT_LEVEL_WARN = 2,
+    /* Error alert indicating degraded operation. */
+    star_v1_AlertLevel_ALERT_LEVEL_ERROR = 3,
+    /* Critical alert requiring immediate action. */
+    star_v1_AlertLevel_ALERT_LEVEL_CRITICAL = 4
 } star_v1_AlertLevel;
 
 /* Struct definitions */
 /* MotorStatusList bundles the status of all drive motors into one envelope payload. */
 typedef struct _star_v1_MotorStatusList {
-  /* Per-motor status for each drive motor.
+    /* Per-motor status for each drive motor.
  nanopb max_count:4 (4-motor robot configuration, see ui.options). */
-  pb_size_t           motors_count;
-  star_v1_MotorStatus motors[4];
+    pb_size_t motors_count;
+    star_v1_MotorStatus motors[4];
 } star_v1_MotorStatusList;
 
 /* OdometryData reports the robot's estimated pose and velocity from wheel odometry. */
 typedef struct _star_v1_OdometryData {
-  /* X position in metres, world frame. */
-  double x_m;
-  /* Y position in metres, world frame. */
-  double y_m;
-  /* Heading angle in radians [-pi, pi]. */
-  double theta_rad;
-  /* Forward linear velocity in m/s. */
-  double linear_velocity_mps;
-  /* Angular velocity in rad/s. */
-  double angular_velocity_rad_per_s;
-  /* Source timestamp in microseconds (CLOCK_MONOTONIC). */
-  int64_t timestamp_us;
+    /* X position in metres, world frame. */
+    double x_m;
+    /* Y position in metres, world frame. */
+    double y_m;
+    /* Heading angle in radians [-pi, pi]. */
+    double theta_rad;
+    /* Forward linear velocity in m/s. */
+    double linear_velocity_mps;
+    /* Angular velocity in rad/s. */
+    double angular_velocity_rad_per_s;
+    /* Source timestamp in microseconds (CLOCK_MONOTONIC). */
+    int64_t timestamp_us;
 } star_v1_OdometryData;
 
 /* LidarScan is a single 360deg scan from the RPLiDAR C1.
@@ -58,44 +57,44 @@ typedef struct _star_v1_OdometryData {
  Maximum samples per revolution: 500 (RPLiDAR C1 @ 10 Hz: 5 kHz sample rate / 10 Hz = 500 samples/rev).
  nanopb static bound: max_count:500 for all three arrays (see ui.options). */
 typedef struct _star_v1_LidarScan {
-  /* Angle in radians for each sample [0, 2*pi).
+    /* Angle in radians for each sample [0, 2*pi).
  nanopb max_count:500 (RPLiDAR C1 samples/rev; see ui.options). */
-  pb_size_t angle_rad_count;
-  float     angle_rad[500];
-  /* Range in metres for each sample (0 = invalid/out-of-range).
+    pb_size_t angle_rad_count;
+    float angle_rad[500];
+    /* Range in metres for each sample (0 = invalid/out-of-range).
  nanopb max_count:500 (RPLiDAR C1 samples/rev; see ui.options). */
-  pb_size_t range_m_count;
-  float     range_m[500];
-  /* Reflectance intensity in arbitrary sensor units (dimensionless, sensor-specific scale).
+    pb_size_t range_m_count;
+    float range_m[500];
+    /* Reflectance intensity in arbitrary sensor units (dimensionless, sensor-specific scale).
  nanopb max_count:500 (RPLiDAR C1 samples/rev; see ui.options). */
-  pb_size_t intensity_count;
-  float     intensity[500];
-  /* Scan start timestamp in microseconds (CLOCK_MONOTONIC, same epoch as other telemetry). */
-  int64_t timestamp_us;
+    pb_size_t intensity_count;
+    float intensity[500];
+    /* Scan start timestamp in microseconds (CLOCK_MONOTONIC, same epoch as other telemetry). */
+    int64_t timestamp_us;
 } star_v1_LidarScan;
 
 /* Alert is a structured diagnostic notification from any subsystem. */
 typedef struct _star_v1_Alert {
-  /* Severity of the alert. */
-  star_v1_AlertLevel level;
-  /* Short machine-readable alert code (max 16 chars). */
-  char code[17];
-  /* Human-readable description (max 128 chars). */
-  char message[129];
-  /* Subsystem that raised the alert (max 32 chars). */
-  char source[33];
-  /* Alert creation timestamp in microseconds (CLOCK_MONOTONIC). */
-  int64_t timestamp_us;
+    /* Severity of the alert. */
+    star_v1_AlertLevel level;
+    /* Short machine-readable alert code (max 16 chars). */
+    char code[17];
+    /* Human-readable description (max 128 chars). */
+    char message[129];
+    /* Subsystem that raised the alert (max 32 chars). */
+    char source[33];
+    /* Alert creation timestamp in microseconds (CLOCK_MONOTONIC). */
+    int64_t timestamp_us;
 } star_v1_Alert;
 
 /* EStopCommand activates or clears the robot emergency stop. */
 typedef struct _star_v1_EStopCommand {
-  /* true = stop active, false = stop cleared. */
-  bool active;
-  /* Reason for the stop (max 64 chars). */
-  char reason[65];
-  /* Command timestamp in microseconds (CLOCK_MONOTONIC). */
-  int64_t timestamp_us;
+    /* true = stop active, false = stop cleared. */
+    bool active;
+    /* Reason for the stop (max 64 chars). */
+    char reason[65];
+    /* Command timestamp in microseconds (CLOCK_MONOTONIC). */
+    int64_t timestamp_us;
 } star_v1_EStopCommand;
 
 /* STAREnvelope is a single multiplexed message type for the /ws WebSocket.
@@ -103,30 +102,31 @@ typedef struct _star_v1_EStopCommand {
    Payload variants: 1-9  (single-byte encoding, most frequent)
    Metadata: 14-15         (present on every message but single-byte range preserved for payload) */
 typedef struct _star_v1_STAREnvelope {
-  pb_size_t which_payload;
-  union {
-    /* Robot telemetry sensor readings. */
-    star_v1_TelemetryData telemetry;
-    /* Motor status list for all drive motors. */
-    star_v1_MotorStatusList motors;
-    /* Wheel odometry pose and velocity estimate. */
-    star_v1_OdometryData odometry;
-    /* Single 360-degree lidar scan. */
-    star_v1_LidarScan lidar;
-    /* Diagnostic alert from a subsystem. */
-    star_v1_Alert alert;
-    /* System health and resource status. */
-    star_v1_SystemStatus system;
-    /* Gamepad or joystick controller state. */
-    star_v1_ControllerState controller;
-    /* Emergency stop command or status. */
-    star_v1_EStopCommand estop;
-  } payload;
-  /* Monotonic sequence stamped by gateway on outbound messages. */
-  uint64_t seq;
-  /* Gateway wall-clock timestamp in milliseconds (Unix epoch) at send time. */
-  int64_t ts_ms;
+    pb_size_t which_payload;
+    union {
+        /* Robot telemetry sensor readings. */
+        star_v1_TelemetryData telemetry;
+        /* Motor status list for all drive motors. */
+        star_v1_MotorStatusList motors;
+        /* Wheel odometry pose and velocity estimate. */
+        star_v1_OdometryData odometry;
+        /* Single 360-degree lidar scan. */
+        star_v1_LidarScan lidar;
+        /* Diagnostic alert from a subsystem. */
+        star_v1_Alert alert;
+        /* System health and resource status. */
+        star_v1_SystemStatus system;
+        /* Gamepad or joystick controller state. */
+        star_v1_ControllerState controller;
+        /* Emergency stop command or status. */
+        star_v1_EStopCommand estop;
+    } payload;
+    /* Monotonic sequence stamped by gateway on outbound messages. */
+    uint64_t seq;
+    /* Gateway wall-clock timestamp in milliseconds (Unix epoch) at send time. */
+    int64_t ts_ms;
 } star_v1_STAREnvelope;
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -135,267 +135,123 @@ extern "C" {
 /* Helper constants for enums */
 #define _star_v1_AlertLevel_MIN star_v1_AlertLevel_ALERT_LEVEL_UNKNOWN
 #define _star_v1_AlertLevel_MAX star_v1_AlertLevel_ALERT_LEVEL_CRITICAL
-#define _star_v1_AlertLevel_ARRAYSIZE                                                              \
-  ((star_v1_AlertLevel)(star_v1_AlertLevel_ALERT_LEVEL_CRITICAL + 1))
+#define _star_v1_AlertLevel_ARRAYSIZE ((star_v1_AlertLevel)(star_v1_AlertLevel_ALERT_LEVEL_CRITICAL+1))
+
+
+
+
 
 #define star_v1_Alert_level_ENUMTYPE star_v1_AlertLevel
 
+
+
 /* Initializer values for message structs */
-#define star_v1_STAREnvelope_init_default                                                          \
-  {                                                                                                \
-    0, {star_v1_TelemetryData_init_default}, 0, 0                                                  \
-  }
-#define star_v1_MotorStatusList_init_default                                                       \
-  {                                                                                                \
-    0,                                                                                             \
-    {                                                                                              \
-      star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default,                          \
-        star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default                         \
-    }                                                                                              \
-  }
-#define star_v1_OdometryData_init_default                                                          \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0                                                                               \
-  }
-#define star_v1_LidarScan_init_default                                                             \
-  {                                                                                                \
-    0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                               \
-      0,                                                                                           \
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                \
-      0,                                                                                           \
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                \
-      0                                                                                            \
-  }
-#define star_v1_Alert_init_default                                                                 \
-  {                                                                                                \
-    _star_v1_AlertLevel_MIN, "", "", "", 0                                                         \
-  }
-#define star_v1_EStopCommand_init_default                                                          \
-  {                                                                                                \
-    0, "", 0                                                                                       \
-  }
-#define star_v1_STAREnvelope_init_zero                                                             \
-  {                                                                                                \
-    0, {star_v1_TelemetryData_init_zero}, 0, 0                                                     \
-  }
-#define star_v1_MotorStatusList_init_zero                                                          \
-  {                                                                                                \
-    0,                                                                                             \
-    {                                                                                              \
-      star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero, \
-        star_v1_MotorStatus_init_zero                                                              \
-    }                                                                                              \
-  }
-#define star_v1_OdometryData_init_zero                                                             \
-  {                                                                                                \
-    0, 0, 0, 0, 0, 0                                                                               \
-  }
-#define star_v1_LidarScan_init_zero                                                                \
-  {                                                                                                \
-    0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  \
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                               \
-      0,                                                                                           \
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                \
-      0,                                                                                           \
-      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   \
-       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},                                \
-      0                                                                                            \
-  }
-#define star_v1_Alert_init_zero                                                                    \
-  {                                                                                                \
-    _star_v1_AlertLevel_MIN, "", "", "", 0                                                         \
-  }
-#define star_v1_EStopCommand_init_zero                                                             \
-  {                                                                                                \
-    0, "", 0                                                                                       \
-  }
+#define star_v1_STAREnvelope_init_default        {0, {star_v1_TelemetryData_init_default}, 0, 0}
+#define star_v1_MotorStatusList_init_default     {0, {star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default, star_v1_MotorStatus_init_default}}
+#define star_v1_OdometryData_init_default        {0, 0, 0, 0, 0, 0}
+#define star_v1_LidarScan_init_default           {0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0}
+#define star_v1_Alert_init_default               {_star_v1_AlertLevel_MIN, "", "", "", 0}
+#define star_v1_EStopCommand_init_default        {0, "", 0}
+#define star_v1_STAREnvelope_init_zero           {0, {star_v1_TelemetryData_init_zero}, 0, 0}
+#define star_v1_MotorStatusList_init_zero        {0, {star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero, star_v1_MotorStatus_init_zero}}
+#define star_v1_OdometryData_init_zero           {0, 0, 0, 0, 0, 0}
+#define star_v1_LidarScan_init_zero              {0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0}
+#define star_v1_Alert_init_zero                  {_star_v1_AlertLevel_MIN, "", "", "", 0}
+#define star_v1_EStopCommand_init_zero           {0, "", 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_MotorStatusList_motors_tag                  1
-#define star_v1_OdometryData_x_m_tag                        1
-#define star_v1_OdometryData_y_m_tag                        2
-#define star_v1_OdometryData_theta_rad_tag                  3
-#define star_v1_OdometryData_linear_velocity_mps_tag        4
+#define star_v1_MotorStatusList_motors_tag       1
+#define star_v1_OdometryData_x_m_tag             1
+#define star_v1_OdometryData_y_m_tag             2
+#define star_v1_OdometryData_theta_rad_tag       3
+#define star_v1_OdometryData_linear_velocity_mps_tag 4
 #define star_v1_OdometryData_angular_velocity_rad_per_s_tag 5
-#define star_v1_OdometryData_timestamp_us_tag               6
-#define star_v1_LidarScan_angle_rad_tag                     1
-#define star_v1_LidarScan_range_m_tag                       2
-#define star_v1_LidarScan_intensity_tag                     3
-#define star_v1_LidarScan_timestamp_us_tag                  4
-#define star_v1_Alert_level_tag                             1
-#define star_v1_Alert_code_tag                              2
-#define star_v1_Alert_message_tag                           3
-#define star_v1_Alert_source_tag                            4
-#define star_v1_Alert_timestamp_us_tag                      5
-#define star_v1_EStopCommand_active_tag                     1
-#define star_v1_EStopCommand_reason_tag                     2
-#define star_v1_EStopCommand_timestamp_us_tag               3
-#define star_v1_STAREnvelope_telemetry_tag                  1
-#define star_v1_STAREnvelope_motors_tag                     2
-#define star_v1_STAREnvelope_odometry_tag                   4
-#define star_v1_STAREnvelope_lidar_tag                      5
-#define star_v1_STAREnvelope_alert_tag                      6
-#define star_v1_STAREnvelope_system_tag                     7
-#define star_v1_STAREnvelope_controller_tag                 8
-#define star_v1_STAREnvelope_estop_tag                      9
-#define star_v1_STAREnvelope_seq_tag                        14
-#define star_v1_STAREnvelope_ts_ms_tag                      15
+#define star_v1_OdometryData_timestamp_us_tag    6
+#define star_v1_LidarScan_angle_rad_tag          1
+#define star_v1_LidarScan_range_m_tag            2
+#define star_v1_LidarScan_intensity_tag          3
+#define star_v1_LidarScan_timestamp_us_tag       4
+#define star_v1_Alert_level_tag                  1
+#define star_v1_Alert_code_tag                   2
+#define star_v1_Alert_message_tag                3
+#define star_v1_Alert_source_tag                 4
+#define star_v1_Alert_timestamp_us_tag           5
+#define star_v1_EStopCommand_active_tag          1
+#define star_v1_EStopCommand_reason_tag          2
+#define star_v1_EStopCommand_timestamp_us_tag    3
+#define star_v1_STAREnvelope_telemetry_tag       1
+#define star_v1_STAREnvelope_motors_tag          2
+#define star_v1_STAREnvelope_odometry_tag        4
+#define star_v1_STAREnvelope_lidar_tag           5
+#define star_v1_STAREnvelope_alert_tag           6
+#define star_v1_STAREnvelope_system_tag          7
+#define star_v1_STAREnvelope_controller_tag      8
+#define star_v1_STAREnvelope_estop_tag           9
+#define star_v1_STAREnvelope_seq_tag             14
+#define star_v1_STAREnvelope_ts_ms_tag           15
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_STAREnvelope_FIELDLIST(X, a)                                                       \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, telemetry, payload.telemetry), 1)                         \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, motors, payload.motors), 2)                               \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, odometry, payload.odometry), 4)                           \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, lidar, payload.lidar), 5)                                 \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, alert, payload.alert), 6)                                 \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, system, payload.system), 7)                               \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, controller, payload.controller), 8)                       \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, estop, payload.estop), 9)                                 \
-  X(a, STATIC, SINGULAR, UINT64, seq, 14)                                                          \
-  X(a, STATIC, SINGULAR, INT64, ts_ms, 15)
-#define star_v1_STAREnvelope_CALLBACK                   NULL
-#define star_v1_STAREnvelope_DEFAULT                    NULL
-#define star_v1_STAREnvelope_payload_telemetry_MSGTYPE  star_v1_TelemetryData
-#define star_v1_STAREnvelope_payload_motors_MSGTYPE     star_v1_MotorStatusList
-#define star_v1_STAREnvelope_payload_odometry_MSGTYPE   star_v1_OdometryData
-#define star_v1_STAREnvelope_payload_lidar_MSGTYPE      star_v1_LidarScan
-#define star_v1_STAREnvelope_payload_alert_MSGTYPE      star_v1_Alert
-#define star_v1_STAREnvelope_payload_system_MSGTYPE     star_v1_SystemStatus
+#define star_v1_STAREnvelope_FIELDLIST(X, a) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,telemetry,payload.telemetry),   1) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,motors,payload.motors),   2) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,odometry,payload.odometry),   4) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,lidar,payload.lidar),   5) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,alert,payload.alert),   6) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,system,payload.system),   7) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,controller,payload.controller),   8) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,estop,payload.estop),   9) \
+X(a, STATIC,   SINGULAR, UINT64,   seq,              14) \
+X(a, STATIC,   SINGULAR, INT64,    ts_ms,            15)
+#define star_v1_STAREnvelope_CALLBACK NULL
+#define star_v1_STAREnvelope_DEFAULT NULL
+#define star_v1_STAREnvelope_payload_telemetry_MSGTYPE star_v1_TelemetryData
+#define star_v1_STAREnvelope_payload_motors_MSGTYPE star_v1_MotorStatusList
+#define star_v1_STAREnvelope_payload_odometry_MSGTYPE star_v1_OdometryData
+#define star_v1_STAREnvelope_payload_lidar_MSGTYPE star_v1_LidarScan
+#define star_v1_STAREnvelope_payload_alert_MSGTYPE star_v1_Alert
+#define star_v1_STAREnvelope_payload_system_MSGTYPE star_v1_SystemStatus
 #define star_v1_STAREnvelope_payload_controller_MSGTYPE star_v1_ControllerState
-#define star_v1_STAREnvelope_payload_estop_MSGTYPE      star_v1_EStopCommand
+#define star_v1_STAREnvelope_payload_estop_MSGTYPE star_v1_EStopCommand
 
-#define star_v1_MotorStatusList_FIELDLIST(X, a) X(a, STATIC, REPEATED, MESSAGE, motors, 1)
-#define star_v1_MotorStatusList_CALLBACK        NULL
-#define star_v1_MotorStatusList_DEFAULT         NULL
-#define star_v1_MotorStatusList_motors_MSGTYPE  star_v1_MotorStatus
+#define star_v1_MotorStatusList_FIELDLIST(X, a) \
+X(a, STATIC,   REPEATED, MESSAGE,  motors,            1)
+#define star_v1_MotorStatusList_CALLBACK NULL
+#define star_v1_MotorStatusList_DEFAULT NULL
+#define star_v1_MotorStatusList_motors_MSGTYPE star_v1_MotorStatus
 
-#define star_v1_OdometryData_FIELDLIST(X, a)                                                       \
-  X(a, STATIC, SINGULAR, DOUBLE, x_m, 1)                                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, y_m, 2)                                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, theta_rad, 3)                                                     \
-  X(a, STATIC, SINGULAR, DOUBLE, linear_velocity_mps, 4)                                           \
-  X(a, STATIC, SINGULAR, DOUBLE, angular_velocity_rad_per_s, 5)                                    \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 6)
+#define star_v1_OdometryData_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, DOUBLE,   x_m,               1) \
+X(a, STATIC,   SINGULAR, DOUBLE,   y_m,               2) \
+X(a, STATIC,   SINGULAR, DOUBLE,   theta_rad,         3) \
+X(a, STATIC,   SINGULAR, DOUBLE,   linear_velocity_mps,   4) \
+X(a, STATIC,   SINGULAR, DOUBLE,   angular_velocity_rad_per_s,   5) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      6)
 #define star_v1_OdometryData_CALLBACK NULL
-#define star_v1_OdometryData_DEFAULT  NULL
+#define star_v1_OdometryData_DEFAULT NULL
 
-#define star_v1_LidarScan_FIELDLIST(X, a)                                                          \
-  X(a, STATIC, REPEATED, FLOAT, angle_rad, 1)                                                      \
-  X(a, STATIC, REPEATED, FLOAT, range_m, 2)                                                        \
-  X(a, STATIC, REPEATED, FLOAT, intensity, 3)                                                      \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 4)
+#define star_v1_LidarScan_FIELDLIST(X, a) \
+X(a, STATIC,   REPEATED, FLOAT,    angle_rad,         1) \
+X(a, STATIC,   REPEATED, FLOAT,    range_m,           2) \
+X(a, STATIC,   REPEATED, FLOAT,    intensity,         3) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      4)
 #define star_v1_LidarScan_CALLBACK NULL
-#define star_v1_LidarScan_DEFAULT  NULL
+#define star_v1_LidarScan_DEFAULT NULL
 
-#define star_v1_Alert_FIELDLIST(X, a)                                                              \
-  X(a, STATIC, SINGULAR, UENUM, level, 1)                                                          \
-  X(a, STATIC, SINGULAR, STRING, code, 2)                                                          \
-  X(a, STATIC, SINGULAR, STRING, message, 3)                                                       \
-  X(a, STATIC, SINGULAR, STRING, source, 4)                                                        \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 5)
+#define star_v1_Alert_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, UENUM,    level,             1) \
+X(a, STATIC,   SINGULAR, STRING,   code,              2) \
+X(a, STATIC,   SINGULAR, STRING,   message,           3) \
+X(a, STATIC,   SINGULAR, STRING,   source,            4) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      5)
 #define star_v1_Alert_CALLBACK NULL
-#define star_v1_Alert_DEFAULT  NULL
+#define star_v1_Alert_DEFAULT NULL
 
-#define star_v1_EStopCommand_FIELDLIST(X, a)                                                       \
-  X(a, STATIC, SINGULAR, BOOL, active, 1)                                                          \
-  X(a, STATIC, SINGULAR, STRING, reason, 2)                                                        \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 3)
+#define star_v1_EStopCommand_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, BOOL,     active,            1) \
+X(a, STATIC,   SINGULAR, STRING,   reason,            2) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      3)
 #define star_v1_EStopCommand_CALLBACK NULL
-#define star_v1_EStopCommand_DEFAULT  NULL
+#define star_v1_EStopCommand_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_STAREnvelope_msg;
 extern const pb_msgdesc_t star_v1_MotorStatusList_msg;
@@ -405,21 +261,21 @@ extern const pb_msgdesc_t star_v1_Alert_msg;
 extern const pb_msgdesc_t star_v1_EStopCommand_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_STAREnvelope_fields    &star_v1_STAREnvelope_msg
+#define star_v1_STAREnvelope_fields &star_v1_STAREnvelope_msg
 #define star_v1_MotorStatusList_fields &star_v1_MotorStatusList_msg
-#define star_v1_OdometryData_fields    &star_v1_OdometryData_msg
-#define star_v1_LidarScan_fields       &star_v1_LidarScan_msg
-#define star_v1_Alert_fields           &star_v1_Alert_msg
-#define star_v1_EStopCommand_fields    &star_v1_EStopCommand_msg
+#define star_v1_OdometryData_fields &star_v1_OdometryData_msg
+#define star_v1_LidarScan_fields &star_v1_LidarScan_msg
+#define star_v1_Alert_fields &star_v1_Alert_msg
+#define star_v1_EStopCommand_fields &star_v1_EStopCommand_msg
 
 /* Maximum encoded size of messages (where known) */
-#define STAR_V1_STAR_V1_UI_PB_H_MAX_SIZE star_v1_STAREnvelope_size
-#define star_v1_Alert_size               196
-#define star_v1_EStopCommand_size        79
-#define star_v1_LidarScan_size           7511
-#define star_v1_MotorStatusList_size     264
-#define star_v1_OdometryData_size        56
-#define star_v1_STAREnvelope_size        7536
+#define STAR_V1_STAR_V1_UI_PB_H_MAX_SIZE         star_v1_STAREnvelope_size
+#define star_v1_Alert_size                       196
+#define star_v1_EStopCommand_size                79
+#define star_v1_LidarScan_size                   7511
+#define star_v1_MotorStatusList_size             264
+#define star_v1_OdometryData_size                56
+#define star_v1_STAREnvelope_size                7536
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/wire.pb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/wire.pb.c
@@ -8,4 +8,8 @@
 
 PB_BIND(star_v1_WireMessage, star_v1_WireMessage, 2)
 
+
 PB_BIND(star_v1_EmergencyStopCommand, star_v1_EmergencyStopCommand, AUTO)
+
+
+

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/wire.pb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/wire.pb.h
@@ -4,7 +4,6 @@
 #ifndef PB_STAR_V1_STAR_V1_WIRE_PB_H_INCLUDED
 #define PB_STAR_V1_STAR_V1_WIRE_PB_H_INCLUDED
 #include <pb.h>
-
 #include "star/v1/configuration.pb.h"
 #include "star/v1/diagnostics.pb.h"
 #include "star/v1/motor_control.pb.h"
@@ -20,17 +19,17 @@
  the firmware to engage hardware safety features and enter
  MOTOR_STATE_ESTOP as defined in motor_control.proto. */
 typedef struct _star_v1_EmergencyStopCommand {
-  /* Reason for emergency stop (for logging and diagnostics). */
-  char reason[128];
-  /* Request hardware E-Stop engagement if available.
+    /* Reason for emergency stop (for logging and diagnostics). */
+    char reason[128];
+    /* Request hardware E-Stop engagement if available.
  When true, firmware should:
  - Enter MOTOR_STATE_ESTOP
  - Disable PWM outputs via hardware
  - Engage brakes if available
  - Require explicit reset to exit E-Stop state */
-  bool engage_hardware_stop;
-  /* Client timestamp in microseconds for latency tracking. */
-  int64_t timestamp_us;
+    bool engage_hardware_stop;
+    /* Client timestamp in microseconds for latency tracking. */
+    int64_t timestamp_us;
 } star_v1_EmergencyStopCommand;
 
 /* WireMessage wraps all possible message types for wire-level multiplexing.
@@ -53,112 +52,90 @@ typedef struct _star_v1_EmergencyStopCommand {
        handleTelemetry(msg.TelemetryData)
    } */
 typedef struct _star_v1_WireMessage {
-  pb_size_t which_payload;
-  union {
-    /* Motor control commands (RPi5 -> RX72N) */
-    star_v1_VelocityCommand velocity_command;
-    /* Emergency stop command triggers immediate motor halt with hardware safety engagement. */
-    star_v1_EmergencyStopCommand emergency_stop_command;
-    /* Motor power command sets raw PWM duty cycle (bypasses PID control). */
-    star_v1_MotorPowerCommand motor_power_command;
-    /* Telemetry data (RX72N -> RPi5) */
-    star_v1_TelemetryData telemetry_data;
-    /* Encoder data contains quadrature encoder readings and velocity estimates. */
-    star_v1_EncoderData encoder_data;
-    /* Configuration (RPi5 -> RX72N) */
-    star_v1_PidConfig pid_config;
-    /* Retransmit configuration (RPi5 -> RX72N) */
-    star_v1_RetransmitConfig retransmit_config;
-    /* Transport diagnostics (RPi5 -> UI or bidirectional) */
-    star_v1_TransportDiagnostics transport_diagnostics;
-  } payload;
+    pb_size_t which_payload;
+    union {
+        /* Motor control commands (RPi5 -> RX72N) */
+        star_v1_VelocityCommand velocity_command;
+        /* Emergency stop command triggers immediate motor halt with hardware safety engagement. */
+        star_v1_EmergencyStopCommand emergency_stop_command;
+        /* Motor power command sets raw PWM duty cycle (bypasses PID control). */
+        star_v1_MotorPowerCommand motor_power_command;
+        /* Telemetry data (RX72N -> RPi5) */
+        star_v1_TelemetryData telemetry_data;
+        /* Encoder data contains quadrature encoder readings and velocity estimates. */
+        star_v1_EncoderData encoder_data;
+        /* Configuration (RPi5 -> RX72N) */
+        star_v1_PidConfig pid_config;
+        /* Retransmit configuration (RPi5 -> RX72N) */
+        star_v1_RetransmitConfig retransmit_config;
+        /* Transport diagnostics (RPi5 -> UI or bidirectional) */
+        star_v1_TransportDiagnostics transport_diagnostics;
+    } payload;
 } star_v1_WireMessage;
+
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define star_v1_WireMessage_init_default                                                           \
-  {                                                                                                \
-    0,                                                                                             \
-    {                                                                                              \
-      star_v1_VelocityCommand_init_default                                                         \
-    }                                                                                              \
-  }
-#define star_v1_EmergencyStopCommand_init_default                                                  \
-  {                                                                                                \
-    "", 0, 0                                                                                       \
-  }
-#define star_v1_WireMessage_init_zero                                                              \
-  {                                                                                                \
-    0,                                                                                             \
-    {                                                                                              \
-      star_v1_VelocityCommand_init_zero                                                            \
-    }                                                                                              \
-  }
-#define star_v1_EmergencyStopCommand_init_zero                                                     \
-  {                                                                                                \
-    "", 0, 0                                                                                       \
-  }
+#define star_v1_WireMessage_init_default         {0, {star_v1_VelocityCommand_init_default}}
+#define star_v1_EmergencyStopCommand_init_default {"", 0, 0}
+#define star_v1_WireMessage_init_zero            {0, {star_v1_VelocityCommand_init_zero}}
+#define star_v1_EmergencyStopCommand_init_zero   {"", 0, 0}
 
 /* Field tags (for use in manual encoding/decoding) */
-#define star_v1_EmergencyStopCommand_reason_tag               1
+#define star_v1_EmergencyStopCommand_reason_tag  1
 #define star_v1_EmergencyStopCommand_engage_hardware_stop_tag 2
-#define star_v1_EmergencyStopCommand_timestamp_us_tag         3
-#define star_v1_WireMessage_velocity_command_tag              1
-#define star_v1_WireMessage_emergency_stop_command_tag        2
-#define star_v1_WireMessage_motor_power_command_tag           3
-#define star_v1_WireMessage_telemetry_data_tag                10
-#define star_v1_WireMessage_encoder_data_tag                  11
-#define star_v1_WireMessage_pid_config_tag                    30
-#define star_v1_WireMessage_retransmit_config_tag             31
-#define star_v1_WireMessage_transport_diagnostics_tag         50
+#define star_v1_EmergencyStopCommand_timestamp_us_tag 3
+#define star_v1_WireMessage_velocity_command_tag 1
+#define star_v1_WireMessage_emergency_stop_command_tag 2
+#define star_v1_WireMessage_motor_power_command_tag 3
+#define star_v1_WireMessage_telemetry_data_tag   10
+#define star_v1_WireMessage_encoder_data_tag     11
+#define star_v1_WireMessage_pid_config_tag       30
+#define star_v1_WireMessage_retransmit_config_tag 31
+#define star_v1_WireMessage_transport_diagnostics_tag 50
 
 /* Struct field encoding specification for nanopb */
-#define star_v1_WireMessage_FIELDLIST(X, a)                                                        \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, velocity_command, payload.velocity_command), 1)           \
-  X(a,                                                                                             \
-    STATIC,                                                                                        \
-    ONEOF,                                                                                         \
-    MESSAGE,                                                                                       \
-    (payload, emergency_stop_command, payload.emergency_stop_command),                             \
-    2)                                                                                             \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, motor_power_command, payload.motor_power_command), 3)     \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, telemetry_data, payload.telemetry_data), 10)              \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, encoder_data, payload.encoder_data), 11)                  \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, pid_config, payload.pid_config), 30)                      \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, retransmit_config, payload.retransmit_config), 31)        \
-  X(a, STATIC, ONEOF, MESSAGE, (payload, transport_diagnostics, payload.transport_diagnostics), 50)
-#define star_v1_WireMessage_CALLBACK                               NULL
-#define star_v1_WireMessage_DEFAULT                                NULL
-#define star_v1_WireMessage_payload_velocity_command_MSGTYPE       star_v1_VelocityCommand
+#define star_v1_WireMessage_FIELDLIST(X, a) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,velocity_command,payload.velocity_command),   1) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,emergency_stop_command,payload.emergency_stop_command),   2) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,motor_power_command,payload.motor_power_command),   3) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,telemetry_data,payload.telemetry_data),  10) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,encoder_data,payload.encoder_data),  11) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,pid_config,payload.pid_config),  30) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,retransmit_config,payload.retransmit_config),  31) \
+X(a, STATIC,   ONEOF,    MESSAGE,  (payload,transport_diagnostics,payload.transport_diagnostics),  50)
+#define star_v1_WireMessage_CALLBACK NULL
+#define star_v1_WireMessage_DEFAULT NULL
+#define star_v1_WireMessage_payload_velocity_command_MSGTYPE star_v1_VelocityCommand
 #define star_v1_WireMessage_payload_emergency_stop_command_MSGTYPE star_v1_EmergencyStopCommand
-#define star_v1_WireMessage_payload_motor_power_command_MSGTYPE    star_v1_MotorPowerCommand
-#define star_v1_WireMessage_payload_telemetry_data_MSGTYPE         star_v1_TelemetryData
-#define star_v1_WireMessage_payload_encoder_data_MSGTYPE           star_v1_EncoderData
-#define star_v1_WireMessage_payload_pid_config_MSGTYPE             star_v1_PidConfig
-#define star_v1_WireMessage_payload_retransmit_config_MSGTYPE      star_v1_RetransmitConfig
-#define star_v1_WireMessage_payload_transport_diagnostics_MSGTYPE  star_v1_TransportDiagnostics
+#define star_v1_WireMessage_payload_motor_power_command_MSGTYPE star_v1_MotorPowerCommand
+#define star_v1_WireMessage_payload_telemetry_data_MSGTYPE star_v1_TelemetryData
+#define star_v1_WireMessage_payload_encoder_data_MSGTYPE star_v1_EncoderData
+#define star_v1_WireMessage_payload_pid_config_MSGTYPE star_v1_PidConfig
+#define star_v1_WireMessage_payload_retransmit_config_MSGTYPE star_v1_RetransmitConfig
+#define star_v1_WireMessage_payload_transport_diagnostics_MSGTYPE star_v1_TransportDiagnostics
 
-#define star_v1_EmergencyStopCommand_FIELDLIST(X, a)                                               \
-  X(a, STATIC, SINGULAR, STRING, reason, 1)                                                        \
-  X(a, STATIC, SINGULAR, BOOL, engage_hardware_stop, 2)                                            \
-  X(a, STATIC, SINGULAR, INT64, timestamp_us, 3)
+#define star_v1_EmergencyStopCommand_FIELDLIST(X, a) \
+X(a, STATIC,   SINGULAR, STRING,   reason,            1) \
+X(a, STATIC,   SINGULAR, BOOL,     engage_hardware_stop,   2) \
+X(a, STATIC,   SINGULAR, INT64,    timestamp_us,      3)
 #define star_v1_EmergencyStopCommand_CALLBACK NULL
-#define star_v1_EmergencyStopCommand_DEFAULT  NULL
+#define star_v1_EmergencyStopCommand_DEFAULT NULL
 
 extern const pb_msgdesc_t star_v1_WireMessage_msg;
 extern const pb_msgdesc_t star_v1_EmergencyStopCommand_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
-#define star_v1_WireMessage_fields          &star_v1_WireMessage_msg
+#define star_v1_WireMessage_fields &star_v1_WireMessage_msg
 #define star_v1_EmergencyStopCommand_fields &star_v1_EmergencyStopCommand_msg
 
 /* Maximum encoded size of messages (where known) */
-#define STAR_V1_STAR_V1_WIRE_PB_H_MAX_SIZE star_v1_WireMessage_size
-#define star_v1_EmergencyStopCommand_size  143
-#define star_v1_WireMessage_size           1403
+#define STAR_V1_STAR_V1_WIRE_PB_H_MAX_SIZE       star_v1_WireMessage_size
+#define star_v1_EmergencyStopCommand_size        143
+#define star_v1_WireMessage_size                 1403
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/e2-studio-star-rx72n-firmware/src/shared/shared_data.c
+++ b/e2-studio-star-rx72n-firmware/src/shared/shared_data.c
@@ -2262,7 +2262,7 @@ rx_err_t shared_data_update_obstacle(const obstacle_state_t* state)
  *
  * 1. **Validate output:** Check out_state not nullptr
  * 2. **Check initialization:** Return error if not initialized
- * 3. **Acquire obstacle_mutex:** Block until available
+ * 3. **Acquire obstacle_mutex:** Non-blocking try; returns k_rx_err_rtos_mutex if busy
  * 4. **Copy state:** memcpy from g_shared_data to caller's buffer
  * 5. **Release obstacle_mutex:** Allow writer to update
  *
@@ -2283,7 +2283,7 @@ rx_err_t shared_data_update_obstacle(const obstacle_state_t* state)
  *
  * @invariant obstacle_mutex held for <3 us
  *
- * @note Thread Safety: Protected by obstacle_mutex
+ * @note Thread Safety: Protected by obstacle_mutex (non-blocking acquire)
  * @note Performance: ~2.5 us total
  * @note Frequency: Called at 20 Hz by Telemetry Task
  *
@@ -2312,7 +2312,7 @@ rx_err_t shared_data_get_obstacle(obstacle_state_t* out_state)
     return k_rx_err_not_initialized;
   }
 
-  const UINT tx_status = tx_mutex_get(&g_shared_data.obstacle_mutex, TX_WAIT_FOREVER);
+  const UINT tx_status = tx_mutex_get(&g_shared_data.obstacle_mutex, TX_NO_WAIT);
   if (tx_status != TX_SUCCESS) {
     return k_rx_err_rtos_mutex;
   }

--- a/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1051,6 +1051,9 @@ static uint32_t s_sequence = 0;
 /** @brief Conversion factor: centi-degrees Celsius per degree Celsius */
 static const float s_cdegc_per_degree = 100.0F;
 
+/** @brief Conversion factor: centimeters per meter */
+static const float s_cm_per_m = 100.0F;
+
 /**
  * @enum telem_motor_idx_t
  * @brief Motor indices for telemetry encoder data
@@ -1083,6 +1086,76 @@ typedef enum : uint8_t {
 typedef enum : uint8_t {
   k_telem_sensor_ambient = 0, /**< DS18B20 ambient temperature sensor index */
 } telem_sensor_idx_t;
+
+/**
+ * @enum telem_obstacle_sensor_idx_t
+ * @brief Obstacle sensor array indices for telemetry population
+ *
+ * @details
+ * Maps each ultrasonic obstacle sensor to its physical position on the
+ * vehicle. The sensors are mounted at the four corners:
+ *   - 0: front-left
+ *   - 1: front-right
+ *   - 2: rear-left
+ *   - 3: rear-right
+ *
+ * These values are used as indices into the `telemetry_t::obstacle`
+ * distance and status arrays when assembling telemetry packets.
+ *
+ * @invariant Values are contiguous integers in the range 0–3, one for
+ * each installed sensor.
+ *
+ * @code
+ * // access front-left distance (already in meters)
+ * float dist_fl = telemetry->obstacle.distance_0_m;
+ *
+ * // build detected_mask for sensors 0 and 2
+ * uint32_t mask = (1U << k_telem_obstacle_shift_0) |
+ *                 (1U << k_telem_obstacle_shift_2);
+ * @endcode
+ *
+ * @see telem_obstacle_mask_shift_t
+ * @see telemetry_t
+ * @since Version 1.0.0
+ */
+typedef enum : uint8_t {
+  k_telem_obstacle_sensor_0 = 0, /**< Front-left ultrasonic sensor array index */
+  k_telem_obstacle_sensor_1 = 1, /**< Front-right ultrasonic sensor array index */
+  k_telem_obstacle_sensor_2 = 2, /**< Rear-left ultrasonic sensor array index */
+  k_telem_obstacle_sensor_3 = 3, /**< Rear-right ultrasonic sensor array index */
+} telem_obstacle_sensor_idx_t;
+
+/**
+ * @enum telem_obstacle_mask_shift_t
+ * @brief Bit shifts for constructing obstacle detected_mask field
+ *
+ * @details
+ * Each sensor corresponds to a bit in the `detected_mask` bitfield.  The
+ * shift values match the physical layout used by
+ * `telem_obstacle_sensor_idx_t`
+ * (front-left=0, front-right=1, rear-left=2, rear-right=3).  Masks are
+ * created with `(1U << k_telem_obstacle_shift_*)`.
+ *
+ * @invariant Valid values 0–3, representing the four sensors.
+ *
+ * @code
+ * uint32_t mask = (1U << k_telem_obstacle_shift_0) |
+ *                 (1U << k_telem_obstacle_shift_2); // front-left & rear-left
+ *
+ * if (telemetry->obstacle.detected_mask & (1U << k_telem_obstacle_shift_1)) {
+ *   // front-right detected
+ * }
+ * @endcode
+ *
+ * @see telem_obstacle_sensor_idx_t
+ * @since Version 1.0.0
+ */
+typedef enum : uint8_t {
+  k_telem_obstacle_shift_0 = 0, /**< Bit shift for front-left sensor detection flag */
+  k_telem_obstacle_shift_1 = 1, /**< Bit shift for front-right sensor detection flag */
+  k_telem_obstacle_shift_2 = 2, /**< Bit shift for rear-left sensor detection flag */
+  k_telem_obstacle_shift_3 = 3, /**< Bit shift for rear-right sensor detection flag */
+} telem_obstacle_mask_shift_t;
 
 /**
  * @enum telemetry_transport_t
@@ -1155,8 +1228,8 @@ static telemetry_transport_t internal_select_transport(void);
 static rx_err_t              internal_populate_motor_telemetry(star_v1_TelemetryData* telemetry);
 static void                  internal_collect_state(star_v1_TelemetryData* telemetry);
 static rx_err_t              internal_encode_telemetry(const star_v1_TelemetryData* telemetry,
-                                                       uint32_t*                    out_encoded_len);
-static rx_err_t internal_send_via_channel(rx_comm_channel_t channel, uint32_t encoded_len);
+                                                        uint32_t*                    out_encoded_len);
+static rx_err_t              internal_send_via_channel(rx_comm_channel_t channel, uint32_t encoded_len);
 
 /* =============================================================================
  * Public Functions
@@ -1283,15 +1356,15 @@ rx_err_t telemetry_task_create(void)
 
   /* Create the thread */
   UINT tx_status = tx_thread_create(&s_telem_thread,
-                                    "TelemTask",
-                                    internal_telem_task_entry,
-                                    k_telem_task_input,
-                                    s_telem_stack,
-                                    k_telem_task_stack_size,
-                                    k_telem_task_priority,
-                                    k_telem_task_priority,
-                                    TX_NO_TIME_SLICE,
-                                    TX_AUTO_START);
+                               "TelemTask",
+                               internal_telem_task_entry,
+                               k_telem_task_input,
+                               s_telem_stack,
+                               k_telem_task_stack_size,
+                               k_telem_task_priority,
+                               k_telem_task_priority,
+                               TX_NO_TIME_SLICE,
+                               TX_AUTO_START);
 
   if (tx_status != TX_SUCCESS) {
     rx_log_error_val(s_tag, "Thread create failed", (uint32_t)tx_status);
@@ -1587,7 +1660,7 @@ static telemetry_transport_t internal_select_transport(void)
 
   /* Query USB channel readiness */
   bool     usb_ready = false;
-  rx_err_t err = rx_comm_manager_channel_ready(&g_comm_manager, k_comm_channel_usb, &usb_ready);
+  rx_err_t err       = rx_comm_manager_channel_ready(&g_comm_manager, k_comm_channel_usb, &usb_ready);
   if (err != k_rx_ok) {
     /* Treat query failure as channel not ready */
     usb_ready = false;
@@ -1613,7 +1686,7 @@ static telemetry_transport_t internal_select_transport(void)
 
   /* Query SPI channel readiness */
   bool spi_ready = false;
-  err            = rx_comm_manager_channel_ready(&g_comm_manager, k_comm_channel_spi, &spi_ready);
+  err = rx_comm_manager_channel_ready(&g_comm_manager, k_comm_channel_spi, &spi_ready);
   if (err != k_rx_ok) {
     spi_ready = false;
   }
@@ -1732,7 +1805,7 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
  * @brief Collect all robot system state into the telemetry message (Phase 1 + Phase 2)
  *
  * @details
- * Reads motor and temperature state from shared_data and populates
+ * Reads motor, temperature, and obstacle state from shared_data and populates
  * the corresponding fields in `telemetry`. All reads are **non-blocking**
  * and non-fatal: if a data source is unavailable, the corresponding fields
  * are left at zero-init defaults and collection continues for remaining sources.
@@ -1741,6 +1814,7 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
  * 1. **Motor state** (via internal_populate_motor_telemetry()):
  *    E-stop flag, fault_flags bitfield, 4 encoder submessages
  * 2. **Temperature state:** temperature_celsius (cdegC->degC)
+ * 3. **Obstacle state:** 4 sensor distances (cm), any_obstacle flag, detected_mask bitmask
  *
  * @param[in,out] telemetry TelemetryData struct to populate (must not be NULL)
  *
@@ -1755,6 +1829,7 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
  *
  * @see internal_populate_motor_telemetry() Motor field population helper
  * @see shared_data_get_temp() Temperature state accessor
+ * @see shared_data_get_obstacle() Obstacle state accessor
  * @see internal_build_and_send_telemetry() Caller - sets timestamp before calling
  *
  * @since Version 1.1.0
@@ -1764,10 +1839,12 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
  * - Precondition 2: timestamp_us set before call (for encoder sub-timestamps)
  * - Postcondition 1: Motor fields populated if shared_data_get_motor_state() == k_rx_ok
  * - Postcondition 2: Temp fields populated if shared_data_get_temp() == k_rx_ok && valid
+ * - Postcondition 3: Obstacle fields populated if shared_data_get_obstacle() == k_rx_ok
  */
 static void internal_collect_state(star_v1_TelemetryData* telemetry)
 {
   temp_sensor_state_t temp_state;
+  obstacle_state_t    obstacle_state;
   rx_err_t            err;
 
   /* Collect motor state (non-fatal: missing data leaves fields at zero-init) */
@@ -1780,6 +1857,26 @@ static void internal_collect_state(star_v1_TelemetryData* telemetry)
     /* Convert from centi-degrees to degrees */
     telemetry->temperature_celsius =
       (float)temp_state.temperature_cdegc[k_telem_sensor_ambient] / s_cdegc_per_degree;
+  }
+
+  /* Collect obstacle state */
+  err = shared_data_get_obstacle(&obstacle_state);
+  if (err == k_rx_ok) {
+    telemetry->has_obstacle          = true;
+    telemetry->obstacle.distance_0_m =
+      (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_0] / s_cm_per_m;
+    telemetry->obstacle.distance_1_m =
+      (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_1] / s_cm_per_m;
+    telemetry->obstacle.distance_2_m =
+      (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_2] / s_cm_per_m;
+    telemetry->obstacle.distance_3_m =
+      (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_3] / s_cm_per_m;
+    telemetry->obstacle.any_obstacle  = obstacle_state.any_obstacle;
+    telemetry->obstacle.detected_mask =
+      ((uint32_t)obstacle_state.obstacle_detected[k_telem_obstacle_sensor_0] << k_telem_obstacle_shift_0) |
+      ((uint32_t)obstacle_state.obstacle_detected[k_telem_obstacle_sensor_1] << k_telem_obstacle_shift_1) |
+      ((uint32_t)obstacle_state.obstacle_detected[k_telem_obstacle_sensor_2] << k_telem_obstacle_shift_2) |
+      ((uint32_t)obstacle_state.obstacle_detected[k_telem_obstacle_sensor_3] << k_telem_obstacle_shift_3);
   }
 }
 
@@ -1820,11 +1917,12 @@ static void internal_collect_state(star_v1_TelemetryData* telemetry)
  * - Postcondition 2: *out_encoded_len valid only when k_rx_ok returned
  */
 static rx_err_t internal_encode_telemetry(const star_v1_TelemetryData* telemetry,
-                                          uint32_t*                    out_encoded_len)
+                                           uint32_t*                    out_encoded_len)
 {
   rx_err_t err;
 
-  err = rx_nanopb_encode_telemetry(telemetry, s_telem_buffer, k_telem_buffer_size, out_encoded_len);
+  err =
+    rx_nanopb_encode_telemetry(telemetry, s_telem_buffer, k_telem_buffer_size, out_encoded_len);
   if (err != k_rx_ok) {
     rx_log_error_val(s_tag, "Telemetry encode failed", (uint32_t)err);
   }

--- a/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1102,7 +1102,7 @@ typedef enum : uint8_t {
  * These values are used as indices into the `telemetry_t::obstacle`
  * distance and status arrays when assembling telemetry packets.
  *
- * @invariant Values are contiguous integers in the range 0–3, one for
+ * @invariant Values are contiguous integers in the range 0-3, one for
  * each installed sensor.
  *
  * @code
@@ -1136,7 +1136,7 @@ typedef enum : uint8_t {
  * (front-left=0, front-right=1, rear-left=2, rear-right=3).  Masks are
  * created with `(1U << k_telem_obstacle_shift_*)`.
  *
- * @invariant Valid values 0–3, representing the four sensors.
+ * @invariant Valid values 0-3, representing the four sensors.
  *
  * @code
  * uint32_t mask = (1U << k_telem_obstacle_shift_0) |

--- a/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1107,7 +1107,7 @@ typedef enum : uint8_t {
  *
  * @code
  * // access front-left distance (already in meters)
- * float dist_fl = telemetry->obstacle.distance_0_m;
+ * float dist_fl = telemetry->obstacle.distance_front_left_m;
  *
  * // build detected_mask for sensors 0 and 2
  * uint32_t mask = (1U << k_telem_obstacle_shift_0) |
@@ -1863,13 +1863,13 @@ static void internal_collect_state(star_v1_TelemetryData* telemetry)
   err = shared_data_get_obstacle(&obstacle_state);
   if (err == k_rx_ok) {
     telemetry->has_obstacle          = true;
-    telemetry->obstacle.distance_0_m =
+    telemetry->obstacle.distance_front_left_m =
       (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_0] / s_cm_per_m;
-    telemetry->obstacle.distance_1_m =
+    telemetry->obstacle.distance_front_right_m =
       (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_1] / s_cm_per_m;
-    telemetry->obstacle.distance_2_m =
+    telemetry->obstacle.distance_back_left_m =
       (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_2] / s_cm_per_m;
-    telemetry->obstacle.distance_3_m =
+    telemetry->obstacle.distance_back_right_m =
       (float)obstacle_state.distance_cm[k_telem_obstacle_sensor_3] / s_cm_per_m;
     telemetry->obstacle.any_obstacle  = obstacle_state.any_obstacle;
     telemetry->obstacle.detected_mask =

--- a/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1051,7 +1051,22 @@ static uint32_t s_sequence = 0;
 /** @brief Conversion factor: centi-degrees Celsius per degree Celsius */
 static const float s_cdegc_per_degree = 100.0F;
 
-/** @brief Conversion factor: centimeters per meter */
+/**
+ * @var s_cm_per_m
+ * @brief Centimetres per metre conversion factor (100.0).
+ *
+ * @details
+ * Used to convert obstacle sensor distances from the integer centimetre
+ * values stored in obstacle_state_t::distance_cm[] to floating-point
+ * metre values required by the star_v1_ObstacleData protobuf fields
+ * (distance_front_left_m, distance_front_right_m, etc.).
+ *
+ * Conversion: metres = (float)distance_cm[i] / s_cm_per_m
+ *
+ * @note Read-only; never modified after program start.
+ *
+ * @since Version 1.0.0
+ */
 static const float s_cm_per_m = 100.0F;
 
 /**
@@ -1814,7 +1829,7 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
  * 1. **Motor state** (via internal_populate_motor_telemetry()):
  *    E-stop flag, fault_flags bitfield, 4 encoder submessages
  * 2. **Temperature state:** temperature_celsius (cdegC->degC)
- * 3. **Obstacle state:** 4 sensor distances (cm), any_obstacle flag, detected_mask bitmask
+ * 3. **Obstacle state:** 4 sensor distances in metres (m), any_obstacle flag, detected_mask bitmask
  *
  * @param[in,out] telemetry TelemetryData struct to populate (must not be NULL)
  *

--- a/star-proto/proto/star/v1/configuration.proto
+++ b/star-proto/proto/star/v1/configuration.proto
@@ -335,7 +335,6 @@ message TimingConfiguration {
   // Motors stopped if no command received within timeout.
   // Valid range: 100-5000 ms. Typical: 500 ms.
   uint32 communication_timeout_ms = 3;
-
 }
 
 // Configuration validation result.

--- a/star-proto/proto/star/v1/telemetry.proto
+++ b/star-proto/proto/star/v1/telemetry.proto
@@ -175,16 +175,16 @@ message ImuData {
 // Reports distance and detection state from 4 HC-SR04 sensors.
 message ObstacleData {
   // Distance from sensor 0 in meters. 0.0 if sensor invalid.
-  float distance_0_m = 1;
+  float distance_front_left_m = 1;
 
   // Distance from sensor 1 in meters. 0.0 if sensor invalid.
-  float distance_1_m = 2;
+  float distance_front_right_m = 2;
 
   // Distance from sensor 2 in meters. 0.0 if sensor invalid.
-  float distance_2_m = 3;
+  float distance_back_left_m = 3;
 
   // Distance from sensor 3 in meters. 0.0 if sensor invalid.
-  float distance_3_m = 4;
+  float distance_back_right_m = 4;
 
   // Any sensor has detected an obstacle within threshold distance.
   bool any_obstacle = 5;

--- a/star-proto/proto/star/v1/telemetry.proto
+++ b/star-proto/proto/star/v1/telemetry.proto
@@ -131,6 +131,9 @@ message TelemetryData {
   // Increments with each transmitted frame. Used by diagnostics to detect
   // missing frames in the telemetry stream.
   uint32 frame_sequence = 19;
+
+  // Obstacle detection data from ultrasonic sensors (RX72N specific).
+  ObstacleData obstacle = 3;
 }
 
 // IMU sensor data (orientation, velocity, acceleration).
@@ -166,6 +169,29 @@ message ImuData {
 
   // Angular velocity Z (yaw rate) in radians per second.
   double gyro_z_rad_per_s = 9;
+}
+
+// Obstacle detection data from ultrasonic sensors (RX72N specific).
+// Reports distance and detection state from 4 HC-SR04 sensors.
+message ObstacleData {
+  // Distance from sensor 0 in meters. 0.0 if sensor invalid.
+  float distance_0_m = 1;
+
+  // Distance from sensor 1 in meters. 0.0 if sensor invalid.
+  float distance_1_m = 2;
+
+  // Distance from sensor 2 in meters. 0.0 if sensor invalid.
+  float distance_2_m = 3;
+
+  // Distance from sensor 3 in meters. 0.0 if sensor invalid.
+  float distance_3_m = 4;
+
+  // Any sensor has detected an obstacle within threshold distance.
+  bool any_obstacle = 5;
+
+  // Per-sensor detection bitmask. Bit N set = sensor N detected obstacle.
+  // Bit 0: sensor 0, Bit 1: sensor 1, Bit 2: sensor 2, Bit 3: sensor 3.
+  uint32 detected_mask = 6;
 }
 
 // GPS position data.


### PR DESCRIPTION
## Summary

Fixes #371. Obstacle detection sensor readings from the 4 HC-SR04 ultrasonic sensors were collected by the firmware but never included in the telemetry protobuf frame sent to the gateway.

- Added `ObstacleData` proto message to `telemetry.proto` with per-sensor distances (cm), `any_obstacle` flag, and `detected_mask` bitmask; assigned as optional field 20 on `TelemetryData`
- Regenerated nanopb bindings (`telemetry.pb.h`, `telemetry.pb.c`) with `star_v1_ObstacleData` struct, field descriptors, `PB_BIND`, init macros, size defines, and `has_obstacle` presence flag on `TelemetryData`
- Added `telem_obstacle_sensor_idx_t` and `telem_obstacle_mask_shift_t` C23 typed enums in `telemetry_task.c` to eliminate magic numbers when indexing sensor arrays and constructing the bitmask
- Wired `shared_data_get_obstacle()` into `internal_collect_state()` so all four sensor distances and detection flags are populated on every telemetry frame; updated Doxygen accordingly

## Test plan

- [ ] All 43 existing firmware unit tests pass (verified locally before this PR)
- [ ] Build `e2-studio-star-rx72n-firmware` with no warnings under `-Wall -Wextra -Werror`
- [ ] Confirm `buf lint` and `buf build` pass on `star-proto/` after proto addition
- [ ] On hardware: stream telemetry and verify `obstacle.distance_0_cm` through `distance_3_cm` populate with live HC-SR04 readings
- [ ] On hardware: place an object within threshold distance and verify `any_obstacle == true` and the correct bit in `detected_mask` is set
- [ ] Confirm gateway correctly deserialises `ObstacleData` from incoming telemetry frames

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time obstacle detection telemetry: four-point distance readings (meters), overall obstacle flag, and a compact detected-mask included in telemetry output.
  * Obstacle data integrated into phased telemetry collection alongside motor and temperature metrics.

* **Documentation**
  * Telemetry schema and protocol definitions updated to document the new obstacle fields and their semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->