### PR TITLE
fix(comm_task): send command responses back to RPi5

### DIFF
--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/rx_nanopb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/rx_nanopb.h
@@ -586,6 +586,52 @@ static const uint16_t s_nanopb_buffer_size = 512U;
                                                           star_v1_SetPIDGainsRequest* msg);
 
 /**
+ * @brief Encode SetPIDGainsResponse message to Protocol Buffer bytes
+ *
+ * @details
+ * Serializes a SetPIDGainsResponse message as acknowledgment to a PID gains
+ * update command. Sent back to RPi5 after processing a SetPIDGainsRequest.
+ *
+ * The response indicates whether the gains were successfully written to
+ * shared_data for the Motor Control Task to apply. The optional human-readable
+ * message field is left empty (NULL callback); the success boolean is
+ * sufficient for programmatic use.
+ *
+ * @param[in] msg Message to encode (must not be nullptr)
+ *   - has_header: must be true for header to be encoded
+ *   - header.status: k_star_v1_status_ok or error status
+ *   - header.request_id: echoed from the original request
+ *   - success: true if gains were written to shared_data
+ * @param[out] buffer Output buffer for encoded bytes (must not be nullptr)
+ * @param[in] buffer_size Size of output buffer in bytes
+ *   - Must be >= s_nanopb_buffer_size (1024 bytes)
+ * @param[out] len Actual encoded message length in bytes (must not be nullptr)
+ *
+ * @return rx_err_t Error code indicating result
+ * @retval k_rx_ok Success, buffer contains wire-format response
+ * @retval k_rx_err_invalid_arg nullptr in msg, buffer, or len
+ * @retval k_rx_err_not_initialized Module not initialized via rx_nanopb_init()
+ * @retval k_rx_err_invalid_size buffer_size too small or encoded length overflow
+ *
+ * @pre rx_nanopb_init() must be called before this function
+ * @pre buffer must point to at least buffer_size bytes of writable memory
+ * @post On k_rx_ok: buffer[0..*len-1] contains valid wire-format response
+ * @post On k_rx_ok: *len <= s_nanopb_buffer_size
+ *
+ * @note Not thread-safe; call only from Communication Task context
+ *
+ * @par Performance: ~15 us @ 240 MHz
+ *
+ * @see rx_nanopb_decode_pid_gains_request() Decode the incoming request
+ * @see rx_nanopb_create_response_header() Create header with status and request_id
+ * @since Version 1.0.0
+ */
+[[nodiscard]] rx_err_t rx_nanopb_encode_pid_gains_response(const star_v1_SetPIDGainsResponse* msg,
+                                                            uint8_t*                           buffer,
+                                                            uint32_t  buffer_size,
+                                                            uint32_t* len);
+
+/**
  * @brief Decode SetRetransmitConfigRequest from Protocol Buffer bytes
  *
  * @details

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/rx_nanopb.h
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/inc/rx_nanopb.h
@@ -604,7 +604,7 @@ static const uint16_t s_nanopb_buffer_size = 512U;
  *   - success: true if gains were written to shared_data
  * @param[out] buffer Output buffer for encoded bytes (must not be nullptr)
  * @param[in] buffer_size Size of output buffer in bytes
- *   - Must be >= s_nanopb_buffer_size (1024 bytes)
+ *   - Must be >= s_nanopb_buffer_size (512 bytes)
  * @param[out] len Actual encoded message length in bytes (must not be nullptr)
  *
  * @return rx_err_t Error code indicating result

--- a/e2-studio-star-rx72n-firmware/libs/rx_nanopb/src/rx_nanopb.c
+++ b/e2-studio-star-rx72n-firmware/libs/rx_nanopb/src/rx_nanopb.c
@@ -1200,6 +1200,81 @@ rx_err_t rx_nanopb_decode_pid_gains_request(const uint8_t*              buffer,
 }
 
 /**
+ * @brief Encode SetPIDGainsResponse message to Protocol Buffer bytes
+ *
+ * @details
+ * Serializes a SetPIDGainsResponse message as acknowledgment to a PID gains
+ * update command. Sent back to RPi5 after processing a SetPIDGainsRequest.
+ *
+ * The optional pb_callback_t message field is skipped when its encode callback
+ * is NULL (init_zero default). The success boolean and response header status
+ * are sufficient for programmatic acknowledgment.
+ *
+ * @param[in]  msg         Message to encode (must not be nullptr)
+ * @param[out] buffer      Output buffer for wire-format bytes (must not be nullptr)
+ * @param[in]  buffer_size Size of output buffer (must be >= s_nanopb_buffer_size)
+ * @param[out] len         Actual encoded length in bytes (must not be nullptr)
+ *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok Encode successful
+ * @retval k_rx_err_invalid_arg nullptr in msg, buffer, or len
+ * @retval k_rx_err_not_initialized Module not initialized
+ * @retval k_rx_err_invalid_size buffer_size too small or encoded length out of bounds
+ *
+ * @pre rx_nanopb_init() must be called before this function
+ * @pre buffer must point to at least buffer_size bytes of writable memory
+ * @post On k_rx_ok: buffer[0..*len-1] contains valid wire-format response
+ * @post On k_rx_ok: *len <= s_nanopb_buffer_size
+ *
+ * @note Not thread-safe; call only from Communication Task context
+ *
+ * @par Performance: ~15 us @ 240 MHz
+ *
+ * @see rx_nanopb_decode_pid_gains_request() Decode the incoming request
+ * @see rx_nanopb_create_response_header() Create header with status and request_id
+ * @since Version 1.0.0
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 5: [PASS] 3 preconditions, 2 postconditions documented
+ * - Rule 7: [PASS] pb_encode() return value checked
+ */
+rx_err_t rx_nanopb_encode_pid_gains_response(const star_v1_SetPIDGainsResponse* msg,
+                                              uint8_t*                           buffer,
+                                              const uint32_t                     buffer_size,
+                                              uint32_t*                          len)
+{
+  /* Pre-condition 1: nullptr pointer checks */
+  if (msg == nullptr || buffer == nullptr || len == nullptr) {
+    return k_rx_err_invalid_arg;
+  }
+
+  /* Pre-condition 2: Module initialized */
+  if (!s_initialized) {
+    return k_rx_err_not_initialized;
+  }
+
+  /* Pre-condition 3: Buffer size validation (NASA Rule 5 - buffer overflow prevention) */
+  if (buffer_size < s_nanopb_buffer_size) {
+    return k_rx_err_invalid_size;
+  }
+
+  pb_ostream_t stream = pb_ostream_from_buffer(buffer, buffer_size);
+
+  if (!pb_encode(&stream, star_v1_SetPIDGainsResponse_fields, msg)) {
+    return k_rx_err_invalid_size;
+  }
+
+  *len = stream.bytes_written;
+
+  /* Post-condition: Encoded length within bounds */
+  if (*len > s_nanopb_buffer_size) {
+    return k_rx_err_invalid_size;
+  }
+
+  return k_rx_ok;
+}
+
+/**
  * @brief Decode SetRetransmitConfigRequest from Protocol Buffer bytes
  * @param[in] buffer Raw protobuf bytes
  * @param[in] len Buffer length

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -1528,8 +1528,8 @@ static void internal_comm_task_entry(ULONG input)
  * @param[in] channel Channel the frame was received on
  *                    - Type: rx_comm_channel_t enum
  *                    - Values: k_comm_channel_usb_cdc, k_comm_channel_spi
- *                    - Purpose: Identify source (USB for debug, SPI for commands)
- *                    - Currently unused (suppressed with (void)channel)
+ *                    - Purpose: Forwarded to internal_handle_command_frame() so that
+ *                      command handlers can route responses back on the correct channel
  *
  * @param[in] frame Received frame structure (already validated by rx_comm_manager)
  *                  - Type: const rx_frame_t*
@@ -1780,6 +1780,10 @@ static void internal_frame_callback(rx_comm_channel_t channel, const rx_frame_t*
  * }
  * @enddot
  *
+ * @param[in] channel Channel the command arrived on (rx_comm_channel_t)
+ *                    - Values: k_comm_channel_usb_cdc, k_comm_channel_spi
+ *                    - Passed through to velocity, e-stop, and PID gains handlers
+ *                      so each can send its response on the originating channel
  * @param[in] frame Frame containing the command payload
  *                  - Type: const rx_frame_t*
  *                  - Must NOT be NULL
@@ -1868,6 +1872,14 @@ static void internal_send_command_response(rx_comm_channel_t channel,
                                            const uint8_t*    payload,
                                            const uint32_t    payload_len)
 {
+  if (payload == nullptr) {
+    rx_log_warn(s_tag, "internal_send_command_response: payload is NULL");
+    return;
+  }
+  if (payload_len == 0) {
+    rx_log_warn(s_tag, "internal_send_command_response: payload_len is zero");
+    return;
+  }
   const rx_err_t err = rx_comm_manager_respond(&g_comm_manager, channel, payload, payload_len);
   if (err != k_rx_ok) {
     rx_log_warn_val(s_tag, "Command response send failed", (uint32_t)err);

--- a/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
+++ b/e2-studio-star-rx72n-firmware/src/tasks/comm_task.c
@@ -428,6 +428,22 @@ typedef enum : uint8_t {
 } comm_motor_constants_t;
 
 /**
+ * @enum comm_response_buffer_t
+ * @brief Size constants for the command response encoding buffer
+ *
+ * @details
+ * Defines the static buffer size used to encode protobuf responses before
+ * sending them back to the RPi5 via rx_comm_manager_respond(). Sized to match
+ * the nanopb module's internal buffer (s_nanopb_buffer_size = 512 bytes) so
+ * that all rx_nanopb_encode_*_response() pre-condition checks pass.
+ *
+ * @since Version 1.0.0
+ */
+typedef enum : uint16_t {
+  k_comm_response_buffer_size = 512, /**< Response encode buffer size in bytes */
+} comm_response_buffer_t;
+
+/**
  * @enum retransmit_retries_limits_t
  * @brief Valid range limits for max_retries in SetRetransmitConfigRequest
  *
@@ -566,6 +582,23 @@ static rx_spi_comm_handle_t s_spi_comm_handle;
  */
 static rx_spi_link_t s_spi_link;
 
+/**
+ * @var s_response_buffer
+ * @brief Static buffer for encoding command response messages (NASA Rule 3 - no dynamic allocation)
+ *
+ * @details
+ * Used by internal_handle_velocity_command(), internal_handle_estop_command(), and
+ * internal_handle_pid_gains_command() to encode protobuf response messages before
+ * sending them back to the RPi5. Sized to match s_nanopb_buffer_size in rx_nanopb,
+ * satisfying the buffer_size >= s_nanopb_buffer_size pre-condition of all
+ * rx_nanopb_encode_*_response() functions.
+ *
+ * @note Accessed only from Communication Task context (single thread). No mutex needed.
+ * @warning Do not access from other tasks. All writes are guarded by single-task execution.
+ * @since Version 1.0.0
+ */
+static uint8_t s_response_buffer[k_comm_response_buffer_size];
+
 /* =============================================================================
  * Forward Declarations
  * =============================================================================
@@ -574,10 +607,15 @@ static rx_spi_link_t s_spi_link;
 static void internal_comm_task_entry(ULONG input);
 static void internal_init_transports(rx_comm_manager_config_t* config);
 static void internal_frame_callback(rx_comm_channel_t channel, const rx_frame_t* frame, void* ctx);
-static rx_err_t internal_handle_command_frame(const rx_frame_t* frame);
-static bool     internal_handle_velocity_command(const rx_frame_t* frame);
-static bool     internal_handle_estop_command(const rx_frame_t* frame);
-static bool     internal_handle_pid_gains_command(const rx_frame_t* frame);
+static void internal_send_command_response(rx_comm_channel_t channel,
+                                           const uint8_t*    payload,
+                                           uint32_t          payload_len);
+static rx_err_t internal_handle_command_frame(rx_comm_channel_t channel, const rx_frame_t* frame);
+static bool     internal_handle_velocity_command(rx_comm_channel_t channel,
+                                                 const rx_frame_t* frame);
+static bool     internal_handle_estop_command(rx_comm_channel_t channel, const rx_frame_t* frame);
+static bool     internal_handle_pid_gains_command(rx_comm_channel_t channel,
+                                                  const rx_frame_t* frame);
 static bool     internal_handle_retransmit_config_command(const rx_frame_t* frame);
 
 /* =============================================================================
@@ -1660,7 +1698,6 @@ static void internal_comm_task_entry(ULONG input)
  */
 static void internal_frame_callback(rx_comm_channel_t channel, const rx_frame_t* frame, void* ctx)
 {
-  (void)channel;
   (void)ctx;
 
   if (frame == nullptr) {
@@ -1676,7 +1713,7 @@ static void internal_frame_callback(rx_comm_channel_t channel, const rx_frame_t*
   /* Dispatch based on frame type */
   switch (frame->header.type) {
     case k_frame_type_command:
-      (void)internal_handle_command_frame(frame);
+      (void)internal_handle_command_frame(channel, frame);
       break;
 
     case k_frame_type_ack:
@@ -1778,17 +1815,17 @@ static void internal_frame_callback(rx_comm_channel_t channel, const rx_frame_t*
  * @callgraph
  * @callergraph
  */
-static rx_err_t internal_handle_command_frame(const rx_frame_t* frame)
+static rx_err_t internal_handle_command_frame(rx_comm_channel_t channel, const rx_frame_t* frame)
 {
   RX_CHECK_NULL_PTR(frame, s_tag, "frame pointer must not be NULL");
 
-  if (internal_handle_velocity_command(frame)) {
+  if (internal_handle_velocity_command(channel, frame)) {
     return k_rx_ok;
   }
-  if (internal_handle_estop_command(frame)) {
+  if (internal_handle_estop_command(channel, frame)) {
     return k_rx_ok;
   }
-  if (internal_handle_pid_gains_command(frame)) {
+  if (internal_handle_pid_gains_command(channel, frame)) {
     return k_rx_ok;
   }
   if (internal_handle_retransmit_config_command(frame)) {
@@ -1797,6 +1834,44 @@ static rx_err_t internal_handle_command_frame(const rx_frame_t* frame)
 
   rx_log_warn(s_tag, "unknown command frame message type");
   return k_rx_err_invalid_arg;
+}
+
+/**
+ * @brief Send an encoded command response back to the host on the originating channel
+ *
+ * @details
+ * Convenience wrapper around rx_comm_manager_respond() for use by command handlers.
+ * Sends a RESPONSE-type frame containing a pre-encoded protobuf payload on the channel
+ * that delivered the original command. Response sending is best-effort: a send failure
+ * is logged as a warning but does NOT affect command processing (the command has already
+ * been applied to shared_data before this function is called).
+ *
+ * @param[in] channel     Channel to send response on (must match incoming command channel)
+ * @param[in] payload     Encoded protobuf bytes to transmit (must not be nullptr)
+ * @param[in] payload_len Number of encoded bytes in payload
+ *
+ * @pre payload must not be nullptr
+ * @pre payload_len must be > 0
+ * @post Response frame queued for transmission on channel (send failure logged, not fatal)
+ *
+ * @note Not thread-safe; called only from Communication Task context
+ * @note Send failure does not affect command processing (best-effort)
+ *
+ * @see rx_comm_manager_respond() Underlying send function
+ * @since Version 1.0.0
+ *
+ * @par NASA Power of 10 Compliance:
+ * - Rule 5: [PASS] 2 preconditions, 1 postcondition documented
+ * - Rule 7: [PASS] rx_comm_manager_respond() return value checked
+ */
+static void internal_send_command_response(rx_comm_channel_t channel,
+                                           const uint8_t*    payload,
+                                           const uint32_t    payload_len)
+{
+  const rx_err_t err = rx_comm_manager_respond(&g_comm_manager, channel, payload, payload_len);
+  if (err != k_rx_ok) {
+    rx_log_warn_val(s_tag, "Command response send failed", (uint32_t)err);
+  }
 }
 
 /**
@@ -1813,8 +1888,10 @@ static rx_err_t internal_handle_command_frame(const rx_frame_t* frame)
  * 2. Verify has_command flag is set (sub-message present)
  * 3. Build motor_command_t: copy 4 velocities, sequence number, timestamp, valid=true
  * 4. Write to shared_data via shared_data_set_motor_command()
- * 5. Log result and return true
+ * 5. Encode SetVelocityResponse and send back on originating channel
+ * 6. Log result and return true
  *
+ * @param[in] channel Channel the command arrived on; response sent on same channel
  * @param[in] frame COMMAND frame to decode
  *                  - Must NOT be nullptr (caller guarantees)
  *                  - frame->payload and frame->header.length are used for decode
@@ -1827,21 +1904,24 @@ static rx_err_t internal_handle_command_frame(const rx_frame_t* frame)
  * @pre shared_data_init() must have been called
  * @post On true: shared_data motor command updated with new velocities
  * @post On true: k_event_new_motor_cmd event set (wakes Motor Control Task)
+ * @post On true: SetVelocityResponse sent back on channel (best-effort)
  *
  * @note Not thread-safe; executes in Communication Task context (Priority 5)
  * @note double -> float velocity conversion: +/-0.0001 m/s precision loss acceptable
+ * @note Response send failure is logged but does not affect command processing
  *
  * @since Version 1.0.0
  * @see rx_nanopb_decode_velocity_request() nanopb decode function
  * @see shared_data_set_motor_command() Thread-safe motor command write
+ * @see rx_nanopb_encode_velocity_response() Encodes the acknowledgment response
  * @see internal_handle_command_frame() Caller (cascade dispatcher)
  *
  * @par NASA Power of 10 Compliance:
- * - Rule 4: [PASS] Function body is under 30 lines
- * - Rule 5: [PASS] 2 preconditions, 2 postconditions documented
+ * - Rule 4: [PASS] Function body is under 45 lines
+ * - Rule 5: [PASS] 2 preconditions, 3 postconditions documented
  * - Rule 7: [PASS] All return values checked
  */
-static bool internal_handle_velocity_command(const rx_frame_t* frame)
+static bool internal_handle_velocity_command(rx_comm_channel_t channel, const rx_frame_t* frame)
 {
   star_v1_SetVelocityRequest velocity_req = {0};
   const rx_err_t             err =
@@ -1870,6 +1950,26 @@ static bool internal_handle_velocity_command(const rx_frame_t* frame)
   } else {
     rx_log_debug(s_tag, "Velocity command received");
   }
+
+  /* Send response back to host (best-effort; command already applied) */
+  {
+    star_v1_SetVelocityResponse response = (star_v1_SetVelocityResponse)star_v1_SetVelocityResponse_init_zero;
+    response.has_header              = true;
+    const star_v1_Status resp_status = (set_err == k_rx_ok) ? star_v1_Status_STATUS_OK
+                                                             : star_v1_Status_STATUS_INTERNAL_ERROR;
+    const char* req_id = velocity_req.has_header ? velocity_req.header.request_id : nullptr;
+    rx_nanopb_create_response_header(&response.header, resp_status, req_id);
+
+    uint32_t       encoded_len = 0;
+    const rx_err_t enc_err     = rx_nanopb_encode_velocity_response(
+      &response, s_response_buffer, (uint32_t)k_comm_response_buffer_size, &encoded_len);
+    if (enc_err == k_rx_ok) {
+      internal_send_command_response(channel, s_response_buffer, encoded_len);
+    } else {
+      rx_log_warn_val(s_tag, "Velocity response encode failed", (uint32_t)enc_err);
+    }
+  }
+
   return true;
 }
 
@@ -1885,8 +1985,10 @@ static bool internal_handle_velocity_command(const rx_frame_t* frame)
  * 1. Attempt nanopb decode via rx_nanopb_decode_estop_request()
  * 2. Log warning ("E-Stop request received")
  * 3. Call shared_data_trigger_estop(k_estop_reason_manual)
- * 4. Log any error and return true
+ * 4. Encode EmergencyStopResponse and send back on originating channel
+ * 5. Log any error and return true
  *
+ * @param[in] channel Channel the command arrived on; response sent on same channel
  * @param[in] frame COMMAND frame to decode
  *                  - Must NOT be nullptr (caller guarantees)
  *                  - frame->payload and frame->header.length are used for decode
@@ -1899,21 +2001,24 @@ static bool internal_handle_velocity_command(const rx_frame_t* frame)
  * @pre shared_data_init() must have been called
  * @post On true: estop_active == true in shared_data
  * @post On true: k_event_estop_triggered event set (wakes Motor Control Task)
+ * @post On true: EmergencyStopResponse sent back on channel (best-effort)
  *
  * @note Not thread-safe; executes in Communication Task context (Priority 5)
+ * @note Response send failure is logged but does not affect e-stop processing
  * @warning E-stop overrides any pending velocity commands; motors disabled immediately
  *
  * @since Version 1.0.0
  * @see rx_nanopb_decode_estop_request() nanopb decode function
  * @see shared_data_trigger_estop() Thread-safe emergency stop trigger
+ * @see rx_nanopb_encode_estop_response() Encodes the acknowledgment response
  * @see internal_handle_command_frame() Caller (cascade dispatcher)
  *
  * @par NASA Power of 10 Compliance:
- * - Rule 4: [PASS] Function body is under 20 lines
- * - Rule 5: [PASS] 2 preconditions, 2 postconditions documented
+ * - Rule 4: [PASS] Function body is under 35 lines
+ * - Rule 5: [PASS] 2 preconditions, 3 postconditions documented
  * - Rule 7: [PASS] All return values checked
  */
-static bool internal_handle_estop_command(const rx_frame_t* frame)
+static bool internal_handle_estop_command(rx_comm_channel_t channel, const rx_frame_t* frame)
 {
   star_v1_EmergencyStopRequest estop_req = {0};
   const rx_err_t               err =
@@ -1928,6 +2033,28 @@ static bool internal_handle_estop_command(const rx_frame_t* frame)
   if (trigger_err != k_rx_ok) {
     rx_log_error_val(s_tag, "Failed to trigger e-stop", (uint32_t)trigger_err);
   }
+
+  /* Send response back to host (best-effort; e-stop already triggered) */
+  {
+    star_v1_EmergencyStopResponse response =
+      (star_v1_EmergencyStopResponse)star_v1_EmergencyStopResponse_init_zero;
+    response.has_header      = true;
+    response.estop_engaged   = (trigger_err == k_rx_ok);
+    const star_v1_Status resp_status = (trigger_err == k_rx_ok) ? star_v1_Status_STATUS_OK
+                                                                 : star_v1_Status_STATUS_INTERNAL_ERROR;
+    const char* req_id = estop_req.has_header ? estop_req.header.request_id : nullptr;
+    rx_nanopb_create_response_header(&response.header, resp_status, req_id);
+
+    uint32_t       encoded_len = 0;
+    const rx_err_t enc_err     = rx_nanopb_encode_estop_response(
+      &response, s_response_buffer, (uint32_t)k_comm_response_buffer_size, &encoded_len);
+    if (enc_err == k_rx_ok) {
+      internal_send_command_response(channel, s_response_buffer, encoded_len);
+    } else {
+      rx_log_warn_val(s_tag, "E-Stop response encode failed", (uint32_t)enc_err);
+    }
+  }
+
   return true;
 }
 
@@ -1945,8 +2072,10 @@ static bool internal_handle_estop_command(const rx_frame_t* frame)
  * 2. Verify has_pid_config flag is set (sub-message present)
  * 3. Build pid_gains_t: convert kp, ki, kd, limits, set update_pending=true
  * 4. Write to shared_data via shared_data_set_pid_gains()
- * 5. Log result and return true
+ * 5. Encode SetPIDGainsResponse and send back on originating channel
+ * 6. Log result and return true
  *
+ * @param[in] channel Channel the command arrived on; response sent on same channel
  * @param[in] frame COMMAND frame to decode
  *                  - Must NOT be nullptr (caller guarantees)
  *                  - frame->payload and frame->header.length are used for decode
@@ -1959,21 +2088,25 @@ static bool internal_handle_estop_command(const rx_frame_t* frame)
  * @pre shared_data_init() must have been called
  * @post On true: shared_data PID gains updated with new values
  * @post On true: k_event_pid_gains_updated event set (Motor Control Task will apply)
+ * @post On true: SetPIDGainsResponse sent back on channel (best-effort)
  *
  * @note Not thread-safe; executes in Communication Task context (Priority 5)
  * @note double -> float gain conversion: precision loss negligible for PID tuning
+ * @note Response send failure is logged but does not affect command processing
+ * @note The optional message string field in SetPIDGainsResponse is left empty
  *
  * @since Version 1.0.0
  * @see rx_nanopb_decode_pid_gains_request() nanopb decode function
  * @see shared_data_set_pid_gains() Thread-safe PID gains write
+ * @see rx_nanopb_encode_pid_gains_response() Encodes the acknowledgment response
  * @see internal_handle_command_frame() Caller (cascade dispatcher)
  *
  * @par NASA Power of 10 Compliance:
- * - Rule 4: [PASS] Function body is under 30 lines
- * - Rule 5: [PASS] 2 preconditions, 2 postconditions documented
+ * - Rule 4: [PASS] Function body is under 45 lines
+ * - Rule 5: [PASS] 2 preconditions, 3 postconditions documented
  * - Rule 7: [PASS] All return values checked
  */
-static bool internal_handle_pid_gains_command(const rx_frame_t* frame)
+static bool internal_handle_pid_gains_command(rx_comm_channel_t channel, const rx_frame_t* frame)
 {
   star_v1_SetPIDGainsRequest pid_req = {0};
   const rx_err_t             err =
@@ -2001,6 +2134,29 @@ static bool internal_handle_pid_gains_command(const rx_frame_t* frame)
   } else {
     rx_log_info(s_tag, "PID gains updated successfully");
   }
+
+  /* Send response back to host (best-effort; gains already written to shared_data) */
+  {
+    star_v1_SetPIDGainsResponse response =
+      (star_v1_SetPIDGainsResponse)star_v1_SetPIDGainsResponse_init_zero;
+    response.has_header            = true;
+    response.success               = (set_err == k_rx_ok);
+    /* response.message left as init_zero: NULL callback skips optional string field */
+    const star_v1_Status resp_status = (set_err == k_rx_ok) ? star_v1_Status_STATUS_OK
+                                                             : star_v1_Status_STATUS_INTERNAL_ERROR;
+    const char* req_id = pid_req.has_header ? pid_req.header.request_id : nullptr;
+    rx_nanopb_create_response_header(&response.header, resp_status, req_id);
+
+    uint32_t       encoded_len = 0;
+    const rx_err_t enc_err     = rx_nanopb_encode_pid_gains_response(
+      &response, s_response_buffer, (uint32_t)k_comm_response_buffer_size, &encoded_len);
+    if (enc_err == k_rx_ok) {
+      internal_send_command_response(channel, s_response_buffer, encoded_len);
+    } else {
+      rx_log_warn_val(s_tag, "PID gains response encode failed", (uint32_t)enc_err);
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Closes #370

## Summary
- `comm_task` decoded incoming commands and updated `shared_data` but never sent a response frame back; the RPi5 was sending velocity, e-stop, and PID gains commands into a void
- Adds `internal_send_command_response()` as a best-effort helper, then wires `channel` through the callback chain so each handler can reply on the originating SPI channel
- Adds the missing `rx_nanopb_encode_pid_gains_response()` encoder (declaration + implementation) following the identical pattern as the existing velocity and e-stop encoders

## Test plan
- [x] Firmware builds with zero warnings (`-Werror`)
- [x] All 46 unit tests pass (`ctest --test-dir build`, including `test_rx_nanopb` and `test_communication_task`)
- [x] Code review checklist:
  - [x] NASA Power of 10 rules followed (static buffer for Rule 3, all return values checked for Rule 7)
  - [x] SOLID principles applied
  - [x] Doxygen documentation complete on all new functions and variables
  - [x] No magic numbers
  - [x] Inclusive terminology used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic response acknowledgments for velocity, emergency stop, and PID gains commands are sent back on the originating channel.
  * Responses include status and request ID when provided.

* **Bug Fixes / Behavior**
  * Response sending is best-effort and will not interfere with core command processing if delivery or encoding fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->