### PR TITLE
fix(ros2): harden star_spi_bridge with validation, docs, and operator fixes

### DIFF
--- a/star-ros2/src/star_spi_bridge/CMakeLists.txt
+++ b/star-ros2/src/star_spi_bridge/CMakeLists.txt
@@ -57,7 +57,7 @@ target_include_directories(spi_driver PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_compile_options(spi_driver PRIVATE
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic -Werror>
 )
 target_link_libraries(spi_driver
   ${Protobuf_LIBRARIES}
@@ -79,7 +79,7 @@ target_include_directories(star_spi_bridge_node PUBLIC
   $<INSTALL_INTERFACE:include>
 )
 target_compile_options(star_spi_bridge_node PRIVATE
-  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic>
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic -Werror>
 )
 target_link_libraries(star_spi_bridge_node spi_driver)
 ament_target_dependencies(star_spi_bridge_node
@@ -119,9 +119,15 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_spi_driver test/test_spi_driver.cpp)
   target_link_libraries(test_spi_driver spi_driver ${Protobuf_LIBRARIES})
+  target_compile_options(test_spi_driver PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic -Werror>
+  )
 
   ament_add_gtest(test_spi_message_converter test/test_spi_message_converter.cpp)
   target_link_libraries(test_spi_message_converter spi_driver ${Protobuf_LIBRARIES})
+  target_compile_options(test_spi_message_converter PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic -Werror>
+  )
 endif()
 
 ament_package()

--- a/star-ros2/src/star_spi_bridge/CMakeLists.txt
+++ b/star-ros2/src/star_spi_bridge/CMakeLists.txt
@@ -1,9 +1,16 @@
-cmake_minimum_required(VERSION 3.8)
-project(star_spi_bridge)
+cmake_minimum_required(VERSION 3.20)
+project(star_spi_bridge LANGUAGES C CXX)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
+# Language standard enforcement
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Position-independent code for shared-library compatibility
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Find dependencies
 find_package(ament_cmake REQUIRED)
@@ -32,16 +39,11 @@ if(NOT EXISTS "${STAR_PROTO_DIR}")
     "Run 'buf generate' in star-proto/ directory first.")
 endif()
 
-include_directories(${STAR_PROTO_DIR})
-
 # ============================================
 # Collect generated protobuf source files
 # ============================================
 
 file(GLOB PROTO_SRCS "${STAR_PROTO_DIR}/star/v1/*.pb.cc")
-
-# Include directories
-include_directories(include)
 
 # SPI Driver Library
 add_library(spi_driver
@@ -51,7 +53,11 @@ add_library(spi_driver
 )
 target_include_directories(spi_driver PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${STAR_PROTO_DIR}>
   $<INSTALL_INTERFACE:include>
+)
+target_compile_options(spi_driver PRIVATE
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic>
 )
 target_link_libraries(spi_driver
   ${Protobuf_LIBRARIES}
@@ -71,6 +77,9 @@ add_executable(star_spi_bridge_node src/star_spi_driver_node.cpp src/main.cpp)
 target_include_directories(star_spi_bridge_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
+)
+target_compile_options(star_spi_bridge_node PRIVATE
+  $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic>
 )
 target_link_libraries(star_spi_bridge_node spi_driver)
 ament_target_dependencies(star_spi_bridge_node

--- a/star-ros2/src/star_spi_bridge/CMakeLists.txt
+++ b/star-ros2/src/star_spi_bridge/CMakeLists.txt
@@ -79,6 +79,7 @@ ament_target_dependencies(star_spi_bridge_node
   geometry_msgs
   nav_msgs
   sensor_msgs
+  std_msgs
 )
 
 # Install rules

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_driver.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_driver.hpp
@@ -73,6 +73,9 @@ enum class FrameFlags : uint8_t
   SoftNack = 0x10,    /**< NACK with recoverable soft-error info (bit 4) */
 };
 
+/// @brief Bitmask covering all valid FrameFlags bits (bits 0-4); bits 5-7 are reserved.
+constexpr uint8_t FRAME_FLAGS_MASK = 0x1Fu;
+
 /**
  * @defgroup FrameFlagsOperators FrameFlags Bitwise Operators
  * @brief Bitwise operator overloads for combining FrameFlags values.
@@ -161,7 +164,7 @@ constexpr inline FrameFlags operator^(FrameFlags lhs, FrameFlags rhs)
 constexpr inline FrameFlags operator~(FrameFlags val)
 {
   return static_cast<FrameFlags>(
-    (~static_cast<std::underlying_type_t<FrameFlags>>(val)) & 0x1Fu);
+    (~static_cast<std::underlying_type_t<FrameFlags>>(val)) & FRAME_FLAGS_MASK);
 }
 /**
  * @brief Bitwise OR-assignment for FrameFlags.

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_driver.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_driver.hpp
@@ -394,8 +394,8 @@ private:
   uint32_t speed_hz_;
   int spi_fd_;
 
-  static const uint32_t k_crc32_polynomial = 0x04C11DB7;
-  static constexpr uint8_t k_bits_per_word = 8;
+  static const uint32_t CRC32_POLYNOMIAL = 0x04C11DB7;
+  static constexpr uint8_t BITS_PER_WORD = 8;
   // [SYNC: 0x55AA (2B, LE) - wire: 0xAA, 0x55]
   // [SEQ: sequence number (2B, LE)]
   // [LEN: payload length (2B, LE)]

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_driver.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_driver.hpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace star_spi_bridge
@@ -29,19 +30,191 @@ namespace star_spi_bridge
  *
  * @details
  * Each frame carries a one-byte type field at offset 6 in the header.
- * Values match the RX72N firmware rx_frame_type_t enum so both sides
- * agree on the semantics of every message.
+ * Values match the RX72N firmware rx_frame_type_t enum (rx_frame.h) and
+ * the Go gateway frame.go so all three sides agree on message semantics.
  *
  * @see SpiDriver::encode_frame  Frame construction
  * @see SpiDriver::decode_frame  Frame parsing
+ * @see star_spi_bridge::FrameFlags  Control flags companion enum
  *
  * @since Version 1.0.0
  */
 enum class FrameType : uint8_t
 {
-  VelocityCommand = 0x01, /**< Motor velocity setpoint (RPi5 -> RX72N) */
-  TelemetryData = 0x02    /**< Sensor telemetry payload  (RX72N -> RPi5) */
+  Ping = 0x00,     /**< Keepalive request (RPi5 -> RX72N or RX72N -> RPi5) */
+  Pong = 0x01,     /**< Keepalive response echoing the PING payload */
+  Command = 0x10,  /**< Protobuf-encoded command (RPi5 -> RX72N) */
+  Response = 0x11, /**< Protobuf-encoded response (RX72N -> RPi5) */
+  Ack = 0x12,      /**< Positive acknowledgment, empty payload (SPI only) */
+  Nack = 0x13,     /**< Negative acknowledgment, empty payload (SPI only) */
+  ResetAck = 0xFE, /**< Confirms reset completed; seq matches reset request */
+  Reset = 0xFF,    /**< Request to reset communication state */
 };
+
+/**
+ * @brief Frame control flags for SPI protocol messages.
+ *
+ * @details
+ * Bit flags that modify frame handling. Multiple flags may be combined with
+ * bitwise OR. Values match the RX72N firmware rx_frame_flags_t enum
+ * (rx_frame.h) and the Go gateway flags.go.
+ *
+ * @see star_spi_bridge::FrameType  Frame type companion enum
+ *
+ * @since Version 1.0.0
+ */
+enum class FrameFlags : uint8_t
+{
+  None = 0x00,        /**< No flags set; default for frames needing no special handling */
+  RequiresAck = 0x01, /**< Sender expects an ACK or NACK response (bit 0) */
+  Retransmit = 0x02,  /**< This is a retry after timeout or NACK (bit 1) */
+  Priority = 0x04,    /**< Process before normal-priority frames (bit 2) */
+  FecEnabled = 0x08,  /**< Payload uses forward error correction (bit 3) */
+  SoftNack = 0x10,    /**< NACK with recoverable soft-error info (bit 4) */
+};
+
+/**
+ * @defgroup FrameFlagsOperators FrameFlags Bitwise Operators
+ * @brief Bitwise operator overloads for combining FrameFlags values.
+ *
+ * @details
+ * These constexpr operators allow FrameFlags enumerators to be combined
+ * without verbose static_cast boilerplate.  All operators work by casting to
+ * and from the underlying type (uint8_t via std::underlying_type_t<FrameFlags>).
+ *
+ * Example:
+ * @code
+ * const uint8_t flags = static_cast<uint8_t>(
+ *     FrameFlags::RequiresAck | FrameFlags::Priority);
+ * @endcode
+ *
+ * @since Version 1.0.0
+ * @{
+ */
+
+/**
+ * @brief Bitwise OR for FrameFlags.
+ * @param[in] lhs  Left-hand operand.
+ * @param[in] rhs  Right-hand operand.
+ * @return FrameFlags result of lhs | rhs.
+ * @pre  lhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  rhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @post The returned value has exactly the union of bits set in lhs and rhs.
+ * @post No bits outside the FrameFlags underlying type (uint8_t) are affected.
+ * @note Constexpr and thread-safe; has no side effects.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags operator|(FrameFlags lhs, FrameFlags rhs)
+{
+  return static_cast<FrameFlags>(
+    static_cast<std::underlying_type_t<FrameFlags>>(lhs) |
+    static_cast<std::underlying_type_t<FrameFlags>>(rhs));
+}
+/**
+ * @brief Bitwise AND for FrameFlags.
+ * @param[in] lhs  Left-hand operand.
+ * @param[in] rhs  Right-hand operand.
+ * @return FrameFlags result of lhs & rhs.
+ * @pre  lhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  rhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @post The returned value has only the bits set that are present in both lhs and rhs.
+ * @post No bits outside the FrameFlags underlying type (uint8_t) are affected.
+ * @note Constexpr and thread-safe; has no side effects.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags operator&(FrameFlags lhs, FrameFlags rhs)
+{
+  return static_cast<FrameFlags>(
+    static_cast<std::underlying_type_t<FrameFlags>>(lhs) &
+    static_cast<std::underlying_type_t<FrameFlags>>(rhs));
+}
+/**
+ * @brief Bitwise XOR for FrameFlags.
+ * @param[in] lhs  Left-hand operand.
+ * @param[in] rhs  Right-hand operand.
+ * @return FrameFlags result of lhs ^ rhs.
+ * @pre  lhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  rhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @post The returned value has bits set where lhs and rhs differ.
+ * @post No bits outside the FrameFlags underlying type (uint8_t) are affected.
+ * @note Constexpr and thread-safe; has no side effects.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags operator^(FrameFlags lhs, FrameFlags rhs)
+{
+  return static_cast<FrameFlags>(
+    static_cast<std::underlying_type_t<FrameFlags>>(lhs) ^
+    static_cast<std::underlying_type_t<FrameFlags>>(rhs));
+}
+/**
+ * @brief Bitwise NOT for FrameFlags.
+ * @param[in] val  Operand to complement.
+ * @return FrameFlags bitwise complement of val, masked to the valid flag range (bits 0-4).
+ * @pre  val is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  The caller expects a mask-complement result; bits 5-7 of the underlying byte
+ *       are always cleared because they have no defined meaning in the protocol.
+ * @post Bits 0-4 of the result are the bitwise complement of the corresponding bits in val.
+ * @post Bits 5-7 of the result are always 0 (mask 0x1F applied).
+ * @note Constexpr and thread-safe; has no side effects.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags operator~(FrameFlags val)
+{
+  return static_cast<FrameFlags>(
+    (~static_cast<std::underlying_type_t<FrameFlags>>(val)) & 0x1Fu);
+}
+/**
+ * @brief Bitwise OR-assignment for FrameFlags.
+ * @param[in,out] lhs  Left-hand operand; receives the result.
+ * @param[in]     rhs  Right-hand operand.
+ * @return Reference to lhs after applying lhs |= rhs.
+ * @pre  lhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  rhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @post lhs contains the union of bits from the original lhs and rhs.
+ * @post No bits outside the FrameFlags underlying type (uint8_t) are modified.
+ * @note Constexpr; thread-safe only when no other thread concurrently writes lhs.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags & operator|=(FrameFlags & lhs, FrameFlags rhs)
+{
+  lhs = lhs | rhs;
+  return lhs;
+}
+/**
+ * @brief Bitwise AND-assignment for FrameFlags.
+ * @param[in,out] lhs  Left-hand operand; receives the result.
+ * @param[in]     rhs  Right-hand operand.
+ * @return Reference to lhs after applying lhs &= rhs.
+ * @pre  lhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  rhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @post lhs contains only the bits that were set in both the original lhs and rhs.
+ * @post No bits outside the FrameFlags underlying type (uint8_t) are modified.
+ * @note Constexpr; thread-safe only when no other thread concurrently writes lhs.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags & operator&=(FrameFlags & lhs, FrameFlags rhs)
+{
+  lhs = lhs & rhs;
+  return lhs;
+}
+/**
+ * @brief Bitwise XOR-assignment for FrameFlags.
+ * @param[in,out] lhs  Left-hand operand; receives the result.
+ * @param[in]     rhs  Right-hand operand.
+ * @return Reference to lhs after applying lhs ^= rhs.
+ * @pre  lhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @pre  rhs is a valid FrameFlags value or combination of FrameFlags enumerators.
+ * @post lhs contains bits set where the original lhs and rhs differ.
+ * @post No bits outside the FrameFlags underlying type (uint8_t) are modified.
+ * @note Constexpr; thread-safe only when no other thread concurrently writes lhs.
+ * @since Version 1.0.0
+ */
+constexpr inline FrameFlags & operator^=(FrameFlags & lhs, FrameFlags rhs)
+{
+  lhs = lhs ^ rhs;
+  return lhs;
+}
+/** @} */  // end of FrameFlagsOperators group
 
 /**
  * @brief SPI driver for framed communication with the RX72N peripheral MCU.

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_message_converter.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_message_converter.hpp
@@ -1,11 +1,36 @@
+/**
+ * @file spi_message_converter.hpp
+ * @brief Message conversion utilities between ROS2 message types and protobuf
+ *        representations for the STAR SPI bridge.
+ *
+ * @details
+ * Declares SpiMessageConverter, which converts between ROS2 geometry, nav,
+ * sensor messages and the star::v1 protobuf types exchanged over the SPI link
+ * with the RX72N peripheral MCU.
+ *
+ * Conversion directions:
+ *  - ROS2 -> Protobuf: geometry_msgs::msg::Twist -> star::v1::VelocityCommand
+ *  - Protobuf -> ROS2: star::v1::TelemetryData -> nav_msgs::msg::Odometry,
+ *                      sensor_msgs::msg::JointState, sensor_msgs::msg::Range
+ *
+ * @note Instances are NOT thread-safe.  Each SpiMessageConverter holds
+ *       internal dead-reckoning state (pose, previous encoder ticks) that must
+ *       not be accessed concurrently from multiple threads.
+ *
+ * @author Locked Inc.
+ * @date 2026
+ * @copyright Copyright 2026 Locked Inc.
+ * @since Version 1.0.0
+ */
+
 // Copyright 2026 Locked Inc.
 
-#ifndef STAR_SPI_BRIDGE__SPI_MESSAGE_CONVERTER_HPP_
-#define STAR_SPI_BRIDGE__SPI_MESSAGE_CONVERTER_HPP_
+#pragma once
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/range.hpp>
 
 #include "star/v1/motor_control.pb.h"
 #include "star/v1/telemetry.pb.h"
@@ -36,6 +61,53 @@ public:
   void telemetry_to_joint_state(
     const star::v1::TelemetryData & telemetry,
     sensor_msgs::msg::JointState & joint_state);
+  /**
+   * @brief Convert TelemetryData obstacle fields to four Range messages.
+   *
+   * @details
+   * Populates each sensor_msgs::msg::Range with the HC-SR04 ultrasonic sensor
+   * characteristics (radiation_type, field_of_view, min/max range) and the
+   * per-sensor distance reported in telemetry.obstacle().  The header.frame_id
+   * of each output reflects the physical sensor mounting location.
+   *
+   * @param[in]  telemetry    Protobuf telemetry payload received from the
+   *                          RX72N; must contain a populated obstacle sub-message.
+   * @param[out] front_left   Range message for the front-left ultrasonic sensor.
+   * @param[out] front_right  Range message for the front-right ultrasonic sensor.
+   * @param[out] back_left    Range message for the back-left ultrasonic sensor.
+   * @param[out] back_right   Range message for the back-right ultrasonic sensor.
+   *
+   * @pre  telemetry.obstacle() sub-message is present and populated by the
+   *       RX72N firmware.
+   * @pre  Distance values in telemetry are within the valid HC-SR04 sensor
+   *       range (0.02 m - 4.0 m); out-of-range values are clamped or set to
+   *       NaN by callers.
+   *
+   * @post Each output Range message has radiation_type, field_of_view,
+   *       min_range, and max_range set to HC-SR04 sensor constants.
+   * @post Each output Range message has header.frame_id and range populated
+   *       from telemetry; no exceptions are thrown for valid inputs.
+   *
+   * @note Not thread-safe; the SpiMessageConverter instance must not be used
+   *       concurrently from multiple threads.
+   *
+   * @see SpiMessageConverter::telemetry_to_odometry  Related conversion helper
+   * @see SpiMessageConverter::telemetry_to_joint_state  Related conversion helper
+   *
+   * @code
+   * sensor_msgs::msg::Range fl, fr, bl, br;
+   * converter.telemetry_to_obstacle_ranges(telemetry, fl, fr, bl, br);
+   * obstacle_front_left_pub_->publish(fl);
+   * @endcode
+   *
+   * @since Version 1.0.0
+   */
+  void telemetry_to_obstacle_ranges(
+    const star::v1::TelemetryData & telemetry,
+    sensor_msgs::msg::Range & front_left,
+    sensor_msgs::msg::Range & front_right,
+    sensor_msgs::msg::Range & back_left,
+    sensor_msgs::msg::Range & back_right);
 
 private:
   Parameters params_;
@@ -56,5 +128,3 @@ private:
 };
 
 }  // namespace star_spi_bridge
-
-#endif  // STAR_SPI_BRIDGE__SPI_MESSAGE_CONVERTER_HPP_

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_message_converter.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/spi_message_converter.hpp
@@ -79,14 +79,16 @@ public:
    *
    * @pre  telemetry.obstacle() sub-message is present and populated by the
    *       RX72N firmware.
-   * @pre  Distance values in telemetry are within the valid HC-SR04 sensor
-   *       range (0.02 m - 4.0 m); out-of-range values are clamped or set to
-   *       NaN by callers.
+   * @pre  Distance values in telemetry are expected to be within the valid
+   *       HC-SR04 sensor range (0.02 m - 4.0 m); finite out-of-range values
+   *       are clamped to the nearest boundary by this function, and non-finite
+   *       values are set to NaN.
    *
    * @post Each output Range message has radiation_type, field_of_view,
    *       min_range, and max_range set to HC-SR04 sensor constants.
-   * @post Each output Range message has header.frame_id and range populated
-   *       from telemetry; no exceptions are thrown for valid inputs.
+   * @post Each output Range message has header.frame_id and range set to a
+   *       finite value clamped to [0.02, 4.0] m, or NaN for non-finite inputs;
+   *       no exceptions are thrown for valid inputs.
    *
    * @note Not thread-safe; the SpiMessageConverter instance must not be used
    *       concurrently from multiple threads.

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
@@ -1,10 +1,34 @@
+/**
+ * @file star_spi_driver_node.hpp
+ * @brief ROS2 lifecycle node for the STAR SPI bridge to the RX72N peripheral MCU.
+ *
+ * @details
+ * Declares StarSpiDriverNode, a rclcpp_lifecycle::LifecycleNode that owns the
+ * SpiDriver and SpiMessageConverter instances.  At 100 Hz the node sends a
+ * framed protobuf VelocityCommand to the RX72N over SPI and publishes the
+ * decoded TelemetryData as standard ROS2 messages (odometry, joint states,
+ * IMU, obstacle ranges).
+ *
+ * Lifecycle transitions:
+ *  - on_configure  : initialize SPI device, create publishers/subscriptions.
+ *  - on_activate   : start 100 Hz timer, activate lifecycle publishers.
+ *  - on_deactivate : send zero-velocity frame, stop timer, deactivate publishers.
+ *  - on_cleanup    : release all resources.
+ *  - on_shutdown   : delegate to on_cleanup.
+ *
+ * @author Locked Inc.
+ * @date 2026
+ * @copyright Copyright 2026 Locked Inc.
+ * @since Version 1.0.0
+ */
+
 // Copyright 2026 Locked Inc.
 
-#ifndef STAR_SPI_BRIDGE__STAR_SPI_DRIVER_NODE_HPP_
-#define STAR_SPI_BRIDGE__STAR_SPI_DRIVER_NODE_HPP_
+#pragma once
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -12,6 +36,8 @@
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
+#include <sensor_msgs/msg/range.hpp>
+#include <std_msgs/msg/bool.hpp>
 
 #include "star_spi_bridge/spi_driver.hpp"
 #include "star_spi_bridge/spi_message_converter.hpp"
@@ -39,27 +65,143 @@ public:
 
 private:
   // Callbacks
+  /**
+   * @brief ROS2 subscription callback for incoming velocity commands.
+   *
+   * @details
+   * Called by the ROS2 executor thread when a new geometry_msgs::msg::Twist
+   * arrives on the "cmd_vel" topic.  Stores the message in current_cmd_vel_
+   * and records the receive timestamp in last_cmd_vel_time_ so the 100 Hz
+   * timer watchdog can detect stale commands.
+   *
+   * @param[in] msg  Shared pointer to the received Twist message.
+   *
+   * @pre  The ROS2 node and cmd_vel subscription are fully initialized (i.e.,
+   *       on_configure() has completed successfully).
+   * @pre  msg != nullptr and contains a valid, finite Twist (linear/angular).
+   *
+   * @note Executed on the ROS2 executor thread (single-threaded executor by
+   *       default).  Not concurrently re-entrant; no mutex is required provided
+   *       a single-threaded executor is used.  If a multi-threaded executor is
+   *       used, access to current_cmd_vel_ and last_cmd_vel_time_ must be guarded.
+   *
+   * @post current_cmd_vel_ updated to the received velocity.
+   * @post last_cmd_vel_time_ updated to the current ROS clock time.
+   *
+   * @since Version 1.0.0
+   */
   void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
+
+  /**
+   * @brief ROS2 subscription callback for emergency stop requests.
+   *
+   * @details
+   * Called by the ROS2 executor thread when a std_msgs::msg::Bool arrives on
+   * the "emergency_stop" topic with data == true.  Serializes an
+   * EmergencyStopRequest protobuf, encodes it as a Priority + RequiresAck SPI
+   * frame, and performs a synchronous SPI transfer to the RX72N.
+   *
+   * @param[in] msg  Shared pointer to the received Bool message.  If msg->data
+   *                 is false the callback returns immediately without action.
+   *
+   * @pre  The ROS2 executor is running and the emergency_stop subscription is
+   *       active (on_configure() has completed successfully).
+   * @pre  spi_driver_ is non-null and the SPI device is initialized; if null,
+   *       an error is logged and the callback returns early without transferring.
+   *
+   * @note Executed on the ROS2 executor thread.  Blocks until the SPI transfer
+   *       completes (typically < 1 ms at 10 MHz).  Not concurrently re-entrant
+   *       with timer_callback; use a single-threaded executor.
+   *
+   * @post If msg->data is true, an EmergencyStopRequest frame is sent to the
+   *       RX72N via SPI.  No ACK/NACK flow-control state is modified.
+   * @post SPI transfer errors are logged via RCLCPP_ERROR but do not propagate.
+   *
+   * @since Version 1.0.0
+   */
+  void emergency_stop_callback(const std_msgs::msg::Bool::SharedPtr msg);
+
+  /**
+   * @brief 100 Hz periodic control and telemetry loop.
+   *
+   * @details
+   * Fired at exactly 10 ms intervals by the wall timer created in on_activate().
+   * Each invocation performs:
+   *  1. Command-velocity watchdog: zero the velocity if no cmd_vel arrived
+   *     within cmd_vel_timeout_ms_.
+   *  2. ACK/NACK flow control: retransmit the last frame if pending_ack_ is
+   *     set and retry_count_ has not exhausted K_MAX_RETRIES.
+   *  3. Encode a SetVelocityRequest protobuf into a STAR SPI frame.
+   *  4. Full-duplex SPI transfer (send command, receive telemetry simultaneously).
+   *  5. Decode the received frame and dispatch on type (Ack, Nack, Response).
+   *  6. On Response: parse TelemetryData and publish Odometry, JointState,
+   *     IMU (if populated), obstacle Range messages, and obstacle detected flag.
+   *
+   * @par Frequency and Timing:
+   * 100 Hz is required to match the RX72N firmware control loop rate and to
+   * maintain sub-10ms command latency for safe differential drive operation.
+   * Real-time budget: SPI transfer at 10 MHz for a max 1040-byte frame takes
+   * approx. 0.83 ms; total callback execution must remain well under 10 ms.
+   *
+   * @pre  The ROS2 executor is running and the node is in the Active lifecycle
+   *       state (on_activate() has completed successfully).
+   * @pre  spi_driver_ is non-null and the SPI interface is initialized and
+   *       ready for full-duplex transfer.
+   *
+   * @note Executed on the ROS2 executor thread.  Not re-entrant.  The timer
+   *       is wall-clock based (not simulation-clock); on a real-time OS or
+   *       with elevated thread priority the 10 ms period is met reliably.
+   * @note No mutex protects current_cmd_vel_; assume a single-threaded executor.
+   *
+   * @post SPI frame transmitted and received each call.
+   * @post ROS2 topics published when telemetry Response frames are decoded.
+   *
+   * @since Version 1.0.0
+   */
   void timer_callback();  // 100 Hz loop
+
+  // -- Private constants ---------------------------------------------------
+  /** @brief Maximum number of retransmit attempts before dropping a frame. */
+  static constexpr int K_MAX_RETRIES = 3;
 
   // Components
   std::unique_ptr<SpiDriver> spi_driver_;
   std::unique_ptr<SpiMessageConverter> converter_;
 
-  // ROS handles
+  // ROS handles -- subscriptions
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_;
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr emergency_stop_sub_;
+
+  // ROS handles -- lifecycle publishers
   rclcpp_lifecycle::LifecyclePublisher<nav_msgs::msg::Odometry>::SharedPtr
     odom_pub_;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::JointState>::SharedPtr
     joint_state_pub_;
   rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Imu>::SharedPtr
-    imu_pub_;  /**< Lifecycle publisher for /imu/data (sensor_msgs/Imu). */
+    imu_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Range>::SharedPtr
+    obstacle_front_left_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Range>::SharedPtr
+    obstacle_front_right_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Range>::SharedPtr
+    obstacle_back_left_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::Range>::SharedPtr
+    obstacle_back_right_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
+    obstacle_detected_pub_;
+
   rclcpp::TimerBase::SharedPtr timer_;
 
-  // State
+  // State -- command velocity
   geometry_msgs::msg::Twist current_cmd_vel_;
   rclcpp::Time last_cmd_vel_time_;
   uint16_t tx_seq_ = 0;
+
+  // State -- ACK/NACK flow control
+  bool pending_ack_ = false;
+  int retry_count_ = 0;
+  uint16_t last_tx_seq_ = 0;
+  std::vector<uint8_t> last_tx_frame_;
 
   // Parameters
   std::string spi_device_path_;
@@ -68,5 +210,3 @@ private:
 };
 
 }  // namespace star_spi_bridge
-
-#endif  // STAR_SPI_BRIDGE__STAR_SPI_DRIVER_NODE_HPP_

--- a/star-ros2/src/star_spi_bridge/src/spi_driver.cpp
+++ b/star-ros2/src/star_spi_bridge/src/spi_driver.cpp
@@ -210,7 +210,7 @@ bool SpiDriver::initialize()
   }
 
   // Configure bits per word (8 bits)
-  uint8_t bits = k_bits_per_word;
+  uint8_t bits = BITS_PER_WORD;
   if (ioctl(spi_fd_, SPI_IOC_WR_BITS_PER_WORD, &bits) < 0) {
     RCLCPP_ERROR(logger(), "Failed to set SPI bits per word");
     close_device();
@@ -276,7 +276,7 @@ bool SpiDriver::transfer(
       xfer, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(rx_data.data())));
   set_spi_xfer_len(xfer, static_cast<uint32_t>(tx_data.size()));
   set_spi_xfer_speed_hz(xfer, speed_hz_);
-  set_spi_xfer_bits_per_word(xfer, k_bits_per_word);
+  set_spi_xfer_bits_per_word(xfer, BITS_PER_WORD);
 
   int ret = ioctl(spi_fd_, SPI_IOC_MESSAGE(1), &xfer);
   if (ret < 0) {

--- a/star-ros2/src/star_spi_bridge/src/spi_driver.cpp
+++ b/star-ros2/src/star_spi_bridge/src/spi_driver.cpp
@@ -110,29 +110,47 @@ inline void set_spi_xfer_bits_per_word(spi_ioc_transfer & xfer, uint8_t value)
 #endif
 }
 
-inline bool is_valid_frame_type(FrameType frame_type)
+/**
+ * @brief Check whether a FrameType value is one of the eight valid protocol types.
+ *
+ * @details
+ * Validates the frame type field decoded from an incoming SPI frame against the
+ * eight explicit values defined in the STAR SPI protocol (rx_frame.h on the
+ * RX72N firmware side).  A contiguous range check is intentionally avoided
+ * because valid codes are sparse: 0x00-0x01, 0x10-0x13, 0xFE-0xFF.  Any byte
+ * not in this enumerated set is treated as an unknown or corrupted frame type.
+ *
+ * @param[in] frame_type  FrameType value to validate.  May be any uint8_t
+ *                        bit-pattern cast to FrameType.
+ *
+ * @return true   The value is one of: Ping, Pong, Command, Response, Ack,
+ *                Nack, ResetAck, or Reset.
+ * @return false  The value does not match any known FrameType enumerator.
+ *
+ * @throw None  This function is noexcept and does not throw.
+ *
+ * @see star_spi_bridge::FrameType  Enumeration of all valid frame types.
+ * @see SpiDriver::decode_frame  Primary caller; rejects frames with unknown types.
+ *
+ * @since Version 1.0.0
+ */
+inline bool is_valid_frame_type(FrameType frame_type) noexcept
 {
-  using U = std::underlying_type_t<FrameType>;
-  const auto raw = static_cast<U>(frame_type);
-  // Range-check: accept only values within [VelocityCommand, TelemetryData].
-  // This guards against corrupt wire data or future enum additions that have
-  // not yet been handled in the switch below.
-  constexpr auto k_min = static_cast<U>(FrameType::VelocityCommand); // 0x01
-  constexpr auto k_max = static_cast<U>(FrameType::TelemetryData);   // 0x02
-  if (raw < k_min || raw > k_max) {
-    return false;
-  }
+  // Accept exactly the 8 frame type values defined in rx_frame.h.
+  // A contiguous range check would accept invalid bytes between 0x02 and 0x0F
+  // and between 0x14 and 0xFD, so we enumerate valid values explicitly.
   switch (frame_type) {
-    case FrameType::VelocityCommand: {
-        return true;
-      }
-    case FrameType::TelemetryData: {
-        return true;
-      }
-    default: {
-    // Unreachable: all values in [k_min, k_max] are handled above.
-        return false;
-      }
+    case FrameType::Ping:
+    case FrameType::Pong:
+    case FrameType::Command:
+    case FrameType::Response:
+    case FrameType::Ack:
+    case FrameType::Nack:
+    case FrameType::ResetAck:
+    case FrameType::Reset:
+      return true;
+    default:
+      return false;
   }
 }
 }  // namespace
@@ -370,6 +388,16 @@ bool SpiDriver::decode_frame(
   // Extract fields (Little Endian: LSB first)
   seq = frame[2] | (static_cast<uint16_t>(frame[3]) << 8);
   type = static_cast<FrameType>(frame[6]);
+
+  // Reject frames carrying an unknown or reserved frame type byte
+  if (!is_valid_frame_type(type)) {
+    static rclcpp::Clock throttle_clock{RCL_STEADY_TIME};
+    RCLCPP_WARN_THROTTLE(logger(), throttle_clock, 1000,
+                         "decode_frame: unknown frame type 0x%02X",
+                         static_cast<uint8_t>(type));
+    return false;
+  }
+
   flags = frame[7];
 
   payload.assign(frame.begin() + HEADER_SIZE, frame.end() - CRC_SIZE);

--- a/star-ros2/src/star_spi_bridge/src/spi_message_converter.cpp
+++ b/star-ros2/src/star_spi_bridge/src/spi_message_converter.cpp
@@ -195,9 +195,9 @@ void SpiMessageConverter::telemetry_to_joint_state(
  * field_of_view, min_range, max_range) and the measured distance.
  * If a distance value is not finite (NaN or Inf), the corresponding msg.range
  * is set to std::numeric_limits<float>::quiet_NaN() so consumers can detect
- * invalid readings.  Out-of-[min, max]-range finite distances are passed
- * through unmodified; the caller or the Range consumer is responsible for
- * interpreting readings outside the sensor's reliable operating range.
+ * invalid readings.  Finite values outside the sensor operating range
+ * [MIN_RANGE_M, MAX_RANGE_M] are clamped to the nearest boundary so that
+ * all published Range messages carry values within the declared min/max.
  *
  * @param[in]  telemetry    Protobuf telemetry payload from the RX72N.  Must
  *                          contain a populated obstacle sub-message.
@@ -209,12 +209,13 @@ void SpiMessageConverter::telemetry_to_joint_state(
  * @pre  telemetry.obstacle() is present (contains at least a default-constructed
  *       ObstacleData sub-message).
  * @pre  Distance values from telemetry are expected to be in [0.02, 4.0] m;
- *       non-finite values are handled gracefully (set to NaN).
+ *       finite values outside this range are clamped to the boundary.
  *
  * @post Each output Range message has radiation_type, field_of_view, min_range,
  *       and max_range set to HC-SR04 sensor constants.
  * @post Each output Range message has header.frame_id populated and msg.range
- *       is either a finite distance or quiet_NaN() if the source was non-finite.
+ *       is either a finite value clamped to [MIN_RANGE_M, MAX_RANGE_M] or
+ *       quiet_NaN() if the source was non-finite.
  *
  * @note Not thread-safe; the SpiMessageConverter instance must not be accessed
  *       concurrently from multiple threads.
@@ -245,11 +246,12 @@ void SpiMessageConverter::telemetry_to_obstacle_ranges(
       msg.max_range = MAX_RANGE_M;
       msg.header.frame_id = frame_id;
       if (std::isfinite(distance_m)) {
-        msg.range = distance_m;
+        // Clamp finite values to the HC-SR04 valid operating range
+        msg.range = std::clamp(distance_m, MIN_RANGE_M, MAX_RANGE_M);
       } else {
         msg.range = std::numeric_limits<float>::quiet_NaN();
       }
-      // Postcondition: range is never Inf; it is either a finite sensor reading or NaN
+      // Postcondition: range is a clamped finite value in [MIN_RANGE_M, MAX_RANGE_M], or NaN
       assert(!std::isinf(msg.range));
     };
 

--- a/star-ros2/src/star_spi_bridge/src/spi_message_converter.cpp
+++ b/star-ros2/src/star_spi_bridge/src/spi_message_converter.cpp
@@ -3,6 +3,7 @@
 #include "star_spi_bridge/spi_message_converter.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <limits>
 #include <tf2/LinearMath/Quaternion.h>  // NOLINT(build/include_order)
@@ -183,6 +184,80 @@ void SpiMessageConverter::telemetry_to_joint_state(
     enc_fr.velocity_mps() * inv_radius,
     enc_bl.velocity_mps() * inv_radius,
     enc_br.velocity_mps() * inv_radius};
+}
+
+/**
+ * @brief Convert TelemetryData obstacle fields to four sensor_msgs::msg::Range messages.
+ *
+ * @details
+ * Reads per-sensor distances from telemetry.obstacle() and populates four
+ * Range messages with HC-SR04 ultrasonic sensor metadata (radiation_type,
+ * field_of_view, min_range, max_range) and the measured distance.
+ * If a distance value is not finite (NaN or Inf), the corresponding msg.range
+ * is set to std::numeric_limits<float>::quiet_NaN() so consumers can detect
+ * invalid readings.  Out-of-[min, max]-range finite distances are passed
+ * through unmodified; the caller or the Range consumer is responsible for
+ * interpreting readings outside the sensor's reliable operating range.
+ *
+ * @param[in]  telemetry    Protobuf telemetry payload from the RX72N.  Must
+ *                          contain a populated obstacle sub-message.
+ * @param[out] front_left   Populated Range message for the front-left sensor.
+ * @param[out] front_right  Populated Range message for the front-right sensor.
+ * @param[out] back_left    Populated Range message for the back-left sensor.
+ * @param[out] back_right   Populated Range message for the back-right sensor.
+ *
+ * @pre  telemetry.obstacle() is present (contains at least a default-constructed
+ *       ObstacleData sub-message).
+ * @pre  Distance values from telemetry are expected to be in [0.02, 4.0] m;
+ *       non-finite values are handled gracefully (set to NaN).
+ *
+ * @post Each output Range message has radiation_type, field_of_view, min_range,
+ *       and max_range set to HC-SR04 sensor constants.
+ * @post Each output Range message has header.frame_id populated and msg.range
+ *       is either a finite distance or quiet_NaN() if the source was non-finite.
+ *
+ * @note Not thread-safe; the SpiMessageConverter instance must not be accessed
+ *       concurrently from multiple threads.
+ *
+ * @see SpiMessageConverter::telemetry_to_odometry    Related telemetry conversion.
+ * @see SpiMessageConverter::telemetry_to_joint_state Related telemetry conversion.
+ *
+ * @since Version 1.0.0
+ */
+void SpiMessageConverter::telemetry_to_obstacle_ranges(
+  const star::v1::TelemetryData & telemetry,
+  sensor_msgs::msg::Range & front_left,
+  sensor_msgs::msg::Range & front_right,
+  sensor_msgs::msg::Range & back_left,
+  sensor_msgs::msg::Range & back_right)
+{
+  // HC-SR04 ultrasonic sensor characteristics
+  static constexpr float FIELD_OF_VIEW_RAD = 0.2618F;  // ~15 degrees
+  static constexpr float MIN_RANGE_M = 0.02F;
+  static constexpr float MAX_RANGE_M = 4.0F;
+
+  auto populate = [&](sensor_msgs::msg::Range & msg, const std::string & frame_id,
+    float distance_m) {
+      assert(!frame_id.empty());
+      msg.radiation_type = sensor_msgs::msg::Range::ULTRASOUND;
+      msg.field_of_view = FIELD_OF_VIEW_RAD;
+      msg.min_range = MIN_RANGE_M;
+      msg.max_range = MAX_RANGE_M;
+      msg.header.frame_id = frame_id;
+      if (std::isfinite(distance_m)) {
+        msg.range = distance_m;
+      } else {
+        msg.range = std::numeric_limits<float>::quiet_NaN();
+      }
+      // Postcondition: range is never Inf; it is either a finite sensor reading or NaN
+      assert(!std::isinf(msg.range));
+    };
+
+  const auto & obs = telemetry.obstacle();
+  populate(front_left, "obstacle_sensor_front_left", obs.distance_front_left_m());
+  populate(front_right, "obstacle_sensor_front_right", obs.distance_front_right_m());
+  populate(back_left, "obstacle_sensor_back_left", obs.distance_back_left_m());
+  populate(back_right, "obstacle_sensor_back_right", obs.distance_back_right_m());
 }
 
 double SpiMessageConverter::normalize_angle(double angle)

--- a/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
+++ b/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
@@ -440,7 +440,7 @@ void StarSpiDriverNode::timer_callback()
         constexpr double kImuEpsilon = 1e-6;
         const bool imu_populated =
           (std::fabs(imu_data.accel_z_mps2()) > kImuEpsilon ||
-           std::fabs(imu_data.gyro_z_rad_per_s()) > kImuEpsilon);
+          std::fabs(imu_data.gyro_z_rad_per_s()) > kImuEpsilon);
         if (imu_populated) {
           sensor_msgs::msg::Imu imu_msg;
           imu_msg.header.stamp = now;

--- a/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
+++ b/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
@@ -133,6 +133,14 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
   // Stop timer first so no new transfers start
   timer_.reset();
 
+  // Reset ACK/retry state now that the timer is stopped
+  pending_ack_ = false;
+  retry_count_ = 0;
+  last_tx_frame_.clear();
+  last_tx_seq_ = tx_seq_;
+
+  bool success = true;
+
   // Send zero-velocity with Priority flag for safety before deactivation
   star::v1::SetVelocityRequest zero_req;
   zero_req.mutable_command()->set_front_left_velocity_mps(0.0);
@@ -147,6 +155,7 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
   {
     RCLCPP_ERROR(get_logger(),
                  "Failed to serialize zero-velocity request during deactivation");
+    success = false;
   } else {
     const uint8_t zero_flags =
       static_cast<uint8_t>(FrameFlags::RequiresAck) |
@@ -157,6 +166,7 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
     std::vector<uint8_t> dummy_rx;
     if (!spi_driver_->transfer(zero_frame, dummy_rx)) {
       RCLCPP_ERROR(get_logger(), "SPI transfer failed for deactivation stop frame");
+      success = false;
     } else {
       tx_seq_++;
     }
@@ -171,8 +181,9 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
   obstacle_back_right_pub_->on_deactivate();
   obstacle_detected_pub_->on_deactivate();
 
-  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
-         CallbackReturn::SUCCESS;
+  return success ?
+         rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS :
+         rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::FAILURE;
 }
 
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
@@ -304,7 +315,30 @@ void StarSpiDriverNode::emergency_stop_callback(
       return;
     }
 
-    // Only increment sequence after successful encode + transfer
+    // Validate ACK/NACK response before accepting the transfer
+    uint16_t rx_seq = 0;
+    FrameType rx_type = FrameType::Ping;
+    uint8_t rx_flags = 0;
+    std::vector<uint8_t> rx_payload;
+    if (!SpiDriver::decode_frame(rx_frame, rx_seq, rx_type, rx_flags, rx_payload)) {
+      RCLCPP_ERROR(get_logger(),
+                   "Failed to decode ACK response during emergency stop");
+      return;
+    }
+    if (rx_type == FrameType::Nack) {
+      RCLCPP_ERROR(get_logger(),
+                   "Emergency stop NACK received (seq=%u); command may not have been applied",
+                   rx_seq);
+      return;
+    }
+    if (rx_type != FrameType::Ack || rx_seq != tx_seq_) {
+      RCLCPP_ERROR(get_logger(),
+                   "Unexpected response during emergency stop: type=0x%02X seq=%u (expected Ack seq=%u)",
+                   static_cast<uint8_t>(rx_type), rx_seq, tx_seq_);
+      return;
+    }
+
+    // Only increment sequence after confirmed ACK
     tx_seq_++;
   } catch (const std::exception & e) {
     RCLCPP_ERROR(get_logger(), "Exception in emergency_stop_callback: %s", e.what());

--- a/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
+++ b/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
@@ -17,7 +17,6 @@ using namespace std::chrono_literals;
 namespace star_spi_bridge
 {
 static constexpr int kLogThrottleMs = 1000;
-static constexpr int kMaxRetries = 3;
 
 // IMU sensor noise model (variance = sigma^2, all diagonal).
 // sigma_orientation ~5.7 deg, sigma_angular_vel ~0.032 rad/s, sigma_accel ~0.1 m/s^2
@@ -143,17 +142,25 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
 
   std::vector<uint8_t> zero_payload(
     static_cast<size_t>(zero_req.ByteSizeLong()));
-  zero_req.SerializeToArray(zero_payload.data(),
-                            static_cast<int>(zero_payload.size()));
-
-  const uint8_t zero_flags =
-    static_cast<uint8_t>(FrameFlags::RequiresAck) |
-    static_cast<uint8_t>(FrameFlags::Priority);
-  std::vector<uint8_t> zero_frame;
-  SpiDriver::encode_frame(tx_seq_++, FrameType::Command, zero_flags,
-                          zero_payload, zero_frame);
-  std::vector<uint8_t> dummy_rx;
-  (void)spi_driver_->transfer(zero_frame, dummy_rx);
+  if (!zero_req.SerializeToArray(zero_payload.data(),
+                                 static_cast<int>(zero_payload.size())))
+  {
+    RCLCPP_ERROR(get_logger(),
+                 "Failed to serialize zero-velocity request during deactivation");
+  } else {
+    const uint8_t zero_flags =
+      static_cast<uint8_t>(FrameFlags::RequiresAck) |
+      static_cast<uint8_t>(FrameFlags::Priority);
+    std::vector<uint8_t> zero_frame;
+    SpiDriver::encode_frame(tx_seq_, FrameType::Command, zero_flags,
+                            zero_payload, zero_frame);
+    std::vector<uint8_t> dummy_rx;
+    if (!spi_driver_->transfer(zero_frame, dummy_rx)) {
+      RCLCPP_ERROR(get_logger(), "SPI transfer failed for deactivation stop frame");
+    } else {
+      tx_seq_++;
+    }
+  }
 
   odom_pub_->on_deactivate();
   joint_state_pub_->on_deactivate();
@@ -306,200 +313,219 @@ void StarSpiDriverNode::emergency_stop_callback(
 
 void StarSpiDriverNode::timer_callback()
 {
-  // Check for command velocity timeout (watchdog safety)
-  auto now = get_clock()->now();
-  double time_since_cmd = (now - last_cmd_vel_time_).seconds();
+  try {
+    // Check for command velocity timeout (watchdog safety)
+    auto now = get_clock()->now();
+    double time_since_cmd = (now - last_cmd_vel_time_).seconds();
 
-  geometry_msgs::msg::Twist cmd_vel_to_send;
-  if (time_since_cmd <= (cmd_vel_timeout_ms_ / 1000.0)) {
-    cmd_vel_to_send = current_cmd_vel_;
-  }
-  // else: zero velocity (default-constructed Twist)
+    geometry_msgs::msg::Twist cmd_vel_to_send;
+    if (time_since_cmd <= (cmd_vel_timeout_ms_ / 1000.0)) {
+      cmd_vel_to_send = current_cmd_vel_;
+    }
+    // else: zero velocity (default-constructed Twist)
 
-  // ACK/NACK flow control: retransmit cached frame on timeout/NACK
-  std::vector<uint8_t> tx_frame;
-  if (pending_ack_ && retry_count_ < kMaxRetries && !last_tx_frame_.empty()) {
-    // Retransmit the cached frame
-    tx_frame = last_tx_frame_;
-    retry_count_++;
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                         "Retransmitting frame (attempt %d/%d)", retry_count_,
-                         kMaxRetries);
-  } else {
-    if (pending_ack_ && retry_count_ >= kMaxRetries) {
-      RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                            "ACK timeout after %d retries; dropping frame",
-                            kMaxRetries);
-      pending_ack_ = false;
+    // ACK/NACK flow control: retransmit cached frame on timeout/NACK
+    std::vector<uint8_t> tx_frame;
+    bool is_retransmit = false;
+    if (pending_ack_ && retry_count_ < K_MAX_RETRIES && !last_tx_frame_.empty()) {
+      // Retransmit the cached frame
+      tx_frame = last_tx_frame_;
+      is_retransmit = true;
+      retry_count_++;
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                           "Retransmitting frame (attempt %d/%d)", retry_count_,
+                           K_MAX_RETRIES);
+    } else {
+      if (pending_ack_ && retry_count_ >= K_MAX_RETRIES) {
+        RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                              "ACK timeout after %d retries; dropping frame",
+                              K_MAX_RETRIES);
+        pending_ack_ = false;
+        retry_count_ = 0;
+      }
+
+      // Convert Twist to protobuf VelocityCommand wrapped in SetVelocityRequest.
+      // Firmware expects SetVelocityRequest, not bare VelocityCommand.
+      star::v1::VelocityCommand velocity_cmd;
+      if (!converter_->twist_to_velocity_command(cmd_vel_to_send, velocity_cmd)) {
+        RCLCPP_WARN(get_logger(),
+                    "Failed to convert Twist to VelocityCommand (NaN/Inf?)");
+        velocity_cmd.set_front_left_velocity_mps(0.0);
+        velocity_cmd.set_front_right_velocity_mps(0.0);
+        velocity_cmd.set_back_left_velocity_mps(0.0);
+        velocity_cmd.set_back_right_velocity_mps(0.0);
+      }
+
+      star::v1::SetVelocityRequest request;
+      *request.mutable_command() = velocity_cmd;
+
+      std::vector<uint8_t> payload(static_cast<size_t>(request.ByteSizeLong()));
+      if (!request.SerializeToArray(payload.data(),
+                                    static_cast<int>(payload.size())))
+      {
+        RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                              "Failed to serialize SetVelocityRequest; skipping cycle");
+        return;
+      }
+
+      const uint8_t flags = static_cast<uint8_t>(FrameFlags::RequiresAck);
+      last_tx_seq_ = tx_seq_;
+      SpiDriver::encode_frame(tx_seq_, FrameType::Command, flags, payload,
+                              tx_frame);
+      last_tx_frame_ = tx_frame;
+      pending_ack_ = true;
       retry_count_ = 0;
     }
 
-    // Convert Twist to protobuf VelocityCommand wrapped in SetVelocityRequest.
-    // Firmware expects SetVelocityRequest, not bare VelocityCommand.
-    star::v1::VelocityCommand velocity_cmd;
-    if (!converter_->twist_to_velocity_command(cmd_vel_to_send, velocity_cmd)) {
-      RCLCPP_WARN(get_logger(),
-                  "Failed to convert Twist to VelocityCommand (NaN/Inf?)");
-      velocity_cmd.set_front_left_velocity_mps(0.0);
-      velocity_cmd.set_front_right_velocity_mps(0.0);
-      velocity_cmd.set_back_left_velocity_mps(0.0);
-      velocity_cmd.set_back_right_velocity_mps(0.0);
+    // Perform full-duplex SPI transfer
+    std::vector<uint8_t> rx_frame;
+    if (!spi_driver_->transfer(tx_frame, rx_frame)) {
+      RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                            "SPI Transfer Failed");
+      return;
     }
 
-    star::v1::SetVelocityRequest request;
-    *request.mutable_command() = velocity_cmd;
+    // Increment tx_seq_ only after a successful new-frame transfer (not retransmit)
+    if (!is_retransmit) {
+      tx_seq_++;
+    }
 
-    std::vector<uint8_t> payload(static_cast<size_t>(request.ByteSizeLong()));
-    request.SerializeToArray(payload.data(), static_cast<int>(payload.size()));
+    // Decode received frame
+    uint16_t rx_seq = 0;
+    FrameType rx_type = FrameType::Ping;
+    uint8_t rx_flags = 0;
+    std::vector<uint8_t> rx_payload;
 
-    const uint8_t flags = static_cast<uint8_t>(FrameFlags::RequiresAck);
-    last_tx_seq_ = tx_seq_;
-    SpiDriver::encode_frame(tx_seq_++, FrameType::Command, flags, payload,
-                            tx_frame);
-    last_tx_frame_ = tx_frame;
-    pending_ack_ = true;
-    retry_count_ = 0;
-  }
+    if (!SpiDriver::decode_frame(rx_frame, rx_seq, rx_type, rx_flags, rx_payload)) {
+      RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), kLogThrottleMs,
+          "SPI Frame Decode Failed (CRC mismatch or garbage)");
+      return;
+    }
 
-  // Perform full-duplex SPI transfer
-  std::vector<uint8_t> rx_frame;
-  if (!spi_driver_->transfer(tx_frame, rx_frame)) {
-    RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                          "SPI Transfer Failed");
-    return;
-  }
-
-  // Decode received frame
-  uint16_t rx_seq = 0;
-  FrameType rx_type = FrameType::Ping;
-  uint8_t rx_flags = 0;
-  std::vector<uint8_t> rx_payload;
-
-  if (!SpiDriver::decode_frame(rx_frame, rx_seq, rx_type, rx_flags, rx_payload)) {
-    RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), kLogThrottleMs,
-        "SPI Frame Decode Failed (CRC mismatch or garbage)");
-    return;
-  }
-
-  // Dispatch on received frame type
-  switch (rx_type) {
-    case FrameType::Ack: {
-        if (rx_seq == last_tx_seq_) {
-          pending_ack_ = false;
-          retry_count_ = 0;
-        }
-        break;
-      }
-
-    case FrameType::Nack: {
-        RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                             "NACK received for seq=%u", rx_seq);
-        // pending_ack_ stays true; retransmit will happen next tick
-        break;
-      }
-
-    case FrameType::Ping: {
-        RCLCPP_DEBUG(get_logger(), "PING received from RX72N");
-        break;
-      }
-
-    case FrameType::Response: {
-        // Response implies command was received; clear ACK state
-        pending_ack_ = false;
-        retry_count_ = 0;
-
-        star::v1::TelemetryData telemetry;
-        if (!telemetry.ParseFromArray(rx_payload.data(),
-                                      static_cast<int>(rx_payload.size())))
-        {
-          RCLCPP_WARN(get_logger(), "Failed to parse TelemetryData protobuf");
+    // Dispatch on received frame type
+    switch (rx_type) {
+      case FrameType::Ack: {
+          if (rx_seq == last_tx_seq_) {
+            pending_ack_ = false;
+            retry_count_ = 0;
+          }
           break;
         }
 
-        // Check emergency stop flag from motor controller
-        if (telemetry.emergency_stop()) {
-          RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                                "RX72N EMERGENCY STOP ACTIVE");
+      case FrameType::Nack: {
+          RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                               "NACK received for seq=%u", rx_seq);
+          // pending_ack_ stays true; retransmit will happen next tick
+          break;
         }
 
-        // Publish Odometry
-        nav_msgs::msg::Odometry odom;
-        odom.header.stamp = now;
-        converter_->telemetry_to_odometry(telemetry, odom);
-        odom_pub_->publish(odom);
-
-        // Publish Joint States
-        sensor_msgs::msg::JointState joint_state;
-        joint_state.header.stamp = now;
-        converter_->telemetry_to_joint_state(telemetry, joint_state);
-        joint_state_pub_->publish(joint_state);
-
-        // Publish IMU data if populated
-        const auto & imu_data = telemetry.imu();
-        constexpr double kImuEpsilon = 1e-6;
-        const bool imu_populated =
-          (std::fabs(imu_data.accel_z_mps2()) > kImuEpsilon ||
-          std::fabs(imu_data.gyro_z_rad_per_s()) > kImuEpsilon);
-        if (imu_populated) {
-          sensor_msgs::msg::Imu imu_msg;
-          imu_msg.header.stamp = now;
-          imu_msg.header.frame_id = "imu_link";
-
-          tf2::Quaternion q;
-          q.setRPY(imu_data.roll_rad(), imu_data.pitch_rad(), imu_data.yaw_rad());
-          imu_msg.orientation.x = q.x();
-          imu_msg.orientation.y = q.y();
-          imu_msg.orientation.z = q.z();
-          imu_msg.orientation.w = q.w();
-          imu_msg.orientation_covariance = {
-            kImuOrientationVar, 0.0, 0.0,
-            0.0, kImuOrientationVar, 0.0,
-            0.0, 0.0, kImuOrientationVar};
-
-          imu_msg.angular_velocity.x = imu_data.gyro_x_rad_per_s();
-          imu_msg.angular_velocity.y = imu_data.gyro_y_rad_per_s();
-          imu_msg.angular_velocity.z = imu_data.gyro_z_rad_per_s();
-          imu_msg.angular_velocity_covariance = {
-            kImuAngularVelocityVar, 0.0, 0.0,
-            0.0, kImuAngularVelocityVar, 0.0,
-            0.0, 0.0, kImuAngularVelocityVar};
-
-          imu_msg.linear_acceleration.x = imu_data.accel_x_mps2();
-          imu_msg.linear_acceleration.y = imu_data.accel_y_mps2();
-          imu_msg.linear_acceleration.z = imu_data.accel_z_mps2();
-          imu_msg.linear_acceleration_covariance = {
-            kImuLinearAccelVar, 0.0, 0.0,
-            0.0, kImuLinearAccelVar, 0.0,
-            0.0, 0.0, kImuLinearAccelVar};
-
-          imu_pub_->publish(imu_msg);
+      case FrameType::Ping: {
+          RCLCPP_DEBUG(get_logger(), "PING received from RX72N");
+          break;
         }
 
-        // Publish obstacle ranges
-        sensor_msgs::msg::Range obs_fl, obs_fr, obs_bl, obs_br;
-        obs_fl.header.stamp = now;
-        obs_fr.header.stamp = now;
-        obs_bl.header.stamp = now;
-        obs_br.header.stamp = now;
-        converter_->telemetry_to_obstacle_ranges(telemetry, obs_fl, obs_fr,
-                                                 obs_bl, obs_br);
-        obstacle_front_left_pub_->publish(obs_fl);
-        obstacle_front_right_pub_->publish(obs_fr);
-        obstacle_back_left_pub_->publish(obs_bl);
-        obstacle_back_right_pub_->publish(obs_br);
+      case FrameType::Response: {
+          // Response implies command was received; clear ACK state
+          pending_ack_ = false;
+          retry_count_ = 0;
 
-        std_msgs::msg::Bool detected_msg;
-        detected_msg.data = telemetry.obstacle().any_obstacle();
-        obstacle_detected_pub_->publish(detected_msg);
-        break;
-      }
+          star::v1::TelemetryData telemetry;
+          if (!telemetry.ParseFromArray(rx_payload.data(),
+                                        static_cast<int>(rx_payload.size())))
+          {
+            RCLCPP_WARN(get_logger(), "Failed to parse TelemetryData protobuf");
+            break;
+          }
 
-    default: {
-        RCLCPP_DEBUG(get_logger(), "Received unhandled frame type: 0x%02X",
-                     static_cast<uint8_t>(rx_type));
-        break;
-      }
+          // Check emergency stop flag from motor controller
+          if (telemetry.emergency_stop()) {
+            RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                                  "RX72N EMERGENCY STOP ACTIVE");
+          }
+
+          // Publish Odometry
+          nav_msgs::msg::Odometry odom;
+          odom.header.stamp = now;
+          converter_->telemetry_to_odometry(telemetry, odom);
+          odom_pub_->publish(odom);
+
+          // Publish Joint States
+          sensor_msgs::msg::JointState joint_state;
+          joint_state.header.stamp = now;
+          converter_->telemetry_to_joint_state(telemetry, joint_state);
+          joint_state_pub_->publish(joint_state);
+
+          // Publish IMU data if populated
+          const auto & imu_data = telemetry.imu();
+          constexpr double kImuEpsilon = 1e-6;
+          const bool imu_populated =
+            (std::fabs(imu_data.accel_z_mps2()) > kImuEpsilon ||
+            std::fabs(imu_data.gyro_z_rad_per_s()) > kImuEpsilon);
+          if (imu_populated) {
+            sensor_msgs::msg::Imu imu_msg;
+            imu_msg.header.stamp = now;
+            imu_msg.header.frame_id = "imu_link";
+
+            tf2::Quaternion q;
+            q.setRPY(imu_data.roll_rad(), imu_data.pitch_rad(), imu_data.yaw_rad());
+            imu_msg.orientation.x = q.x();
+            imu_msg.orientation.y = q.y();
+            imu_msg.orientation.z = q.z();
+            imu_msg.orientation.w = q.w();
+            imu_msg.orientation_covariance = {
+              kImuOrientationVar, 0.0, 0.0,
+              0.0, kImuOrientationVar, 0.0,
+              0.0, 0.0, kImuOrientationVar};
+
+            imu_msg.angular_velocity.x = imu_data.gyro_x_rad_per_s();
+            imu_msg.angular_velocity.y = imu_data.gyro_y_rad_per_s();
+            imu_msg.angular_velocity.z = imu_data.gyro_z_rad_per_s();
+            imu_msg.angular_velocity_covariance = {
+              kImuAngularVelocityVar, 0.0, 0.0,
+              0.0, kImuAngularVelocityVar, 0.0,
+              0.0, 0.0, kImuAngularVelocityVar};
+
+            imu_msg.linear_acceleration.x = imu_data.accel_x_mps2();
+            imu_msg.linear_acceleration.y = imu_data.accel_y_mps2();
+            imu_msg.linear_acceleration.z = imu_data.accel_z_mps2();
+            imu_msg.linear_acceleration_covariance = {
+              kImuLinearAccelVar, 0.0, 0.0,
+              0.0, kImuLinearAccelVar, 0.0,
+              0.0, 0.0, kImuLinearAccelVar};
+
+            imu_pub_->publish(imu_msg);
+          }
+
+          // Publish obstacle ranges
+          sensor_msgs::msg::Range obs_fl, obs_fr, obs_bl, obs_br;
+          obs_fl.header.stamp = now;
+          obs_fr.header.stamp = now;
+          obs_bl.header.stamp = now;
+          obs_br.header.stamp = now;
+          converter_->telemetry_to_obstacle_ranges(telemetry, obs_fl, obs_fr,
+                                                   obs_bl, obs_br);
+          obstacle_front_left_pub_->publish(obs_fl);
+          obstacle_front_right_pub_->publish(obs_fr);
+          obstacle_back_left_pub_->publish(obs_bl);
+          obstacle_back_right_pub_->publish(obs_br);
+
+          std_msgs::msg::Bool detected_msg;
+          detected_msg.data = telemetry.obstacle().any_obstacle();
+          obstacle_detected_pub_->publish(detected_msg);
+          break;
+        }
+
+      default: {
+          RCLCPP_DEBUG(get_logger(), "Received unhandled frame type: 0x%02X",
+                       static_cast<uint8_t>(rx_type));
+          break;
+        }
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(get_logger(), "Unhandled exception in timer_callback: %s", e.what());
+  } catch (...) {
+    RCLCPP_ERROR(get_logger(), "Unhandled non-standard exception in timer_callback");
   }
 }
 

--- a/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
+++ b/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
@@ -3,14 +3,21 @@
 #include "star_spi_bridge/star_spi_driver_node.hpp"
 
 #include <chrono>
+#include <cmath>
+#include <stdexcept>
 
+#include <std_msgs/msg/bool.hpp>
 #include <tf2/LinearMath/Quaternion.h>  // NOLINT(build/include_order)
+
+#include "star/v1/motor_control.pb.h"
+#include "star/v1/telemetry.pb.h"
 
 using namespace std::chrono_literals;
 
 namespace star_spi_bridge
 {
 static constexpr int kLogThrottleMs = 1000;
+static constexpr int kMaxRetries = 3;
 
 // IMU sensor noise model (variance = sigma^2, all diagonal).
 // sigma_orientation ~5.7 deg, sigma_angular_vel ~0.032 rad/s, sigma_accel ~0.1 m/s^2
@@ -69,10 +76,25 @@ StarSpiDriverNode::on_configure(const rclcpp_lifecycle::State &)
   joint_state_pub_ =
     create_publisher<sensor_msgs::msg::JointState>("joint_states", 10);
   imu_pub_ = create_publisher<sensor_msgs::msg::Imu>("imu/data", 10);
-  // Create subscription
+  obstacle_front_left_pub_ =
+    create_publisher<sensor_msgs::msg::Range>("star/obstacle/front_left", 10);
+  obstacle_front_right_pub_ =
+    create_publisher<sensor_msgs::msg::Range>("star/obstacle/front_right", 10);
+  obstacle_back_left_pub_ =
+    create_publisher<sensor_msgs::msg::Range>("star/obstacle/back_left", 10);
+  obstacle_back_right_pub_ =
+    create_publisher<sensor_msgs::msg::Range>("star/obstacle/back_right", 10);
+  obstacle_detected_pub_ =
+    create_publisher<std_msgs::msg::Bool>("star/obstacle_detected", 10);
+
+  // Create subscriptions
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
       "cmd_vel", 10,
       std::bind(&StarSpiDriverNode::cmd_vel_callback, this,
+                std::placeholders::_1));
+  emergency_stop_sub_ = create_subscription<std_msgs::msg::Bool>(
+      "emergency_stop", 10,
+      std::bind(&StarSpiDriverNode::emergency_stop_callback, this,
                 std::placeholders::_1));
 
   // Initialize state
@@ -90,6 +112,11 @@ StarSpiDriverNode::on_activate(const rclcpp_lifecycle::State &)
   odom_pub_->on_activate();
   joint_state_pub_->on_activate();
   imu_pub_->on_activate();
+  obstacle_front_left_pub_->on_activate();
+  obstacle_front_right_pub_->on_activate();
+  obstacle_back_left_pub_->on_activate();
+  obstacle_back_right_pub_->on_activate();
+  obstacle_detected_pub_->on_activate();
 
   // Start 100 Hz timer (10ms)
   timer_ = create_wall_timer(
@@ -104,22 +131,38 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
 {
   RCLCPP_INFO(get_logger(), "Deactivating StarSpiDriverNode...");
 
-  // Stop timer
+  // Stop timer first so no new transfers start
   timer_.reset();
 
-  // Send zero velocity for safety
-  // Construct zero command
-  star::v1::VelocityCommand cmd;
-  cmd.set_front_left_velocity_mps(0.0f);
-  cmd.set_front_right_velocity_mps(0.0f);
-  cmd.set_back_left_velocity_mps(0.0f);
-  cmd.set_back_right_velocity_mps(0.0f);
+  // Send zero-velocity with Priority flag for safety before deactivation
+  star::v1::SetVelocityRequest zero_req;
+  zero_req.mutable_command()->set_front_left_velocity_mps(0.0);
+  zero_req.mutable_command()->set_front_right_velocity_mps(0.0);
+  zero_req.mutable_command()->set_back_left_velocity_mps(0.0);
+  zero_req.mutable_command()->set_back_right_velocity_mps(0.0);
 
-  // TODO(safety): Send final zero-velocity frame before deactivation
+  std::vector<uint8_t> zero_payload(
+    static_cast<size_t>(zero_req.ByteSizeLong()));
+  zero_req.SerializeToArray(zero_payload.data(),
+                            static_cast<int>(zero_payload.size()));
+
+  const uint8_t zero_flags =
+    static_cast<uint8_t>(FrameFlags::RequiresAck) |
+    static_cast<uint8_t>(FrameFlags::Priority);
+  std::vector<uint8_t> zero_frame;
+  SpiDriver::encode_frame(tx_seq_++, FrameType::Command, zero_flags,
+                          zero_payload, zero_frame);
+  std::vector<uint8_t> dummy_rx;
+  (void)spi_driver_->transfer(zero_frame, dummy_rx);
 
   odom_pub_->on_deactivate();
   joint_state_pub_->on_deactivate();
   imu_pub_->on_deactivate();
+  obstacle_front_left_pub_->on_deactivate();
+  obstacle_front_right_pub_->on_deactivate();
+  obstacle_back_left_pub_->on_deactivate();
+  obstacle_back_right_pub_->on_deactivate();
+  obstacle_detected_pub_->on_deactivate();
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
          CallbackReturn::SUCCESS;
@@ -137,7 +180,13 @@ StarSpiDriverNode::on_cleanup(const rclcpp_lifecycle::State &)
   odom_pub_.reset();
   joint_state_pub_.reset();
   imu_pub_.reset();
+  obstacle_front_left_pub_.reset();
+  obstacle_front_right_pub_.reset();
+  obstacle_back_left_pub_.reset();
+  obstacle_back_right_pub_.reset();
+  obstacle_detected_pub_.reset();
   cmd_vel_sub_.reset();
+  emergency_stop_sub_.reset();
 
   return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::
          CallbackReturn::SUCCESS;
@@ -157,6 +206,104 @@ void StarSpiDriverNode::cmd_vel_callback(
   last_cmd_vel_time_ = get_clock()->now();
 }
 
+/**
+ * @brief Emergency stop subscription callback.
+ *
+ * @details
+ * Triggered on any message received on the "emergency_stop" topic.  When
+ * msg->data is true the callback serializes an EmergencyStopRequest protobuf,
+ * encodes a Priority + RequiresAck SPI frame, and performs a synchronous SPI
+ * transfer to the RX72N.  Any protobuf serialization or SPI error is caught,
+ * logged, and suppressed so the ROS2 executor is never terminated by an
+ * exception from an interrupt-style callback.
+ *
+ * tx_seq_ is only incremented when the frame encoding and SPI transfer both
+ * succeed, preserving the monotonic sequence counter invariant.
+ *
+ * @param[in] msg  Emergency stop flag; callback returns immediately if false.
+ *
+ * @pre  The ROS2 executor is running and the emergency_stop subscription is
+ *       active (on_configure() completed successfully).
+ * @pre  spi_driver_ is non-null and initialized; if null an error is logged
+ *       and the function returns without transmitting.
+ *
+ * @throw None  Any std::exception thrown during protobuf serialization
+ *              (star::v1::EmergencyStopRequest::SerializeToArray) or SPI
+ *              frame encoding (SpiDriver::encode_frame) is caught inside
+ *              this function, logged via RCLCPP_ERROR, and suppressed.
+ *              No exception propagates to the caller.
+ *
+ * @note Runs on the ROS2 executor thread; not re-entrant.
+ * @note spi_driver_ may be null if the node is deactivated; guarded with an
+ *       early return + RCLCPP_ERROR.
+ *
+ * @post If msg->data is true and spi_driver_ is valid, an EmergencyStop frame
+ *       is transmitted.  tx_seq_ is incremented only on success.
+ * @post No exceptions propagate out of this callback.
+ *
+ * @code
+ * // Published externally (e.g. from a safety monitor node):
+ * std_msgs::msg::Bool estop_msg;
+ * estop_msg.data = true;
+ * emergency_stop_pub->publish(estop_msg);
+ * // Internally, this callback will:
+ * //   1. Serialize EmergencyStopRequest with reason string.
+ * //   2. Encode as a Priority + RequiresAck SPI frame.
+ * //   3. Call spi_driver_->transfer(tx_frame, rx_frame).
+ * //   4. Increment tx_seq_ only on success.
+ * @endcode
+ *
+ * @see star::v1::EmergencyStopRequest  Protobuf message serialized in this callback.
+ * @see SpiDriver::encode_frame         Frame encoding used before transfer.
+ * @see StarSpiDriverNode::spi_driver_  SPI driver instance used for the transfer.
+ * @see StarSpiDriverNode::tx_seq_      Sequence counter incremented on success.
+ *
+ * @since Version 1.0.0
+ */
+void StarSpiDriverNode::emergency_stop_callback(
+  const std_msgs::msg::Bool::SharedPtr msg)
+{
+  if (!msg->data) {
+    return;
+  }
+
+  RCLCPP_ERROR(get_logger(), "Emergency stop requested via /emergency_stop topic");
+
+  if (!spi_driver_) {
+    RCLCPP_ERROR(get_logger(),
+                 "Emergency stop received but SPI driver is not initialized");
+    return;
+  }
+
+  try {
+    star::v1::EmergencyStopRequest estop;
+    estop.set_reason("Manual E-Stop via /emergency_stop topic");
+
+    std::vector<uint8_t> payload(static_cast<size_t>(estop.ByteSizeLong()));
+    if (!estop.SerializeToArray(payload.data(), static_cast<int>(payload.size()))) {
+      RCLCPP_ERROR(get_logger(), "Failed to serialize EmergencyStopRequest");
+      return;
+    }
+
+    const uint8_t flags =
+      static_cast<uint8_t>(FrameFlags::RequiresAck) |
+      static_cast<uint8_t>(FrameFlags::Priority);
+    std::vector<uint8_t> tx_frame;
+    SpiDriver::encode_frame(tx_seq_, FrameType::Command, flags, payload, tx_frame);
+
+    std::vector<uint8_t> rx_frame;
+    if (!spi_driver_->transfer(tx_frame, rx_frame)) {
+      RCLCPP_ERROR(get_logger(), "SPI transfer failed during emergency stop");
+      return;
+    }
+
+    // Only increment sequence after successful encode + transfer
+    tx_seq_++;
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(get_logger(), "Exception in emergency_stop_callback: %s", e.what());
+  }
+}
+
 void StarSpiDriverNode::timer_callback()
 {
   // Check for command velocity timeout (watchdog safety)
@@ -164,34 +311,55 @@ void StarSpiDriverNode::timer_callback()
   double time_since_cmd = (now - last_cmd_vel_time_).seconds();
 
   geometry_msgs::msg::Twist cmd_vel_to_send;
-  if (time_since_cmd > (cmd_vel_timeout_ms_ / 1000.0)) {
-    // Timeout expired: send zero velocity for safety
-  } else {
+  if (time_since_cmd <= (cmd_vel_timeout_ms_ / 1000.0)) {
     cmd_vel_to_send = current_cmd_vel_;
   }
+  // else: zero velocity (default-constructed Twist)
 
-  // Convert Twist to protobuf VelocityCommand
-  star::v1::VelocityCommand velocity_cmd;
-
-  if (!converter_->twist_to_velocity_command(cmd_vel_to_send, velocity_cmd)) {
-    RCLCPP_WARN(get_logger(),
-                "Failed to convert Twist to VelocityCommand (NaN/Inf?)");
-    // Send zero if conversion fails
-    velocity_cmd.set_front_left_velocity_mps(0.0f);
-    velocity_cmd.set_front_right_velocity_mps(0.0f);
-    velocity_cmd.set_back_left_velocity_mps(0.0f);
-    velocity_cmd.set_back_right_velocity_mps(0.0f);
-  }
-
-  // Encode protobuf payload into SPI frame
-  std::vector<uint8_t> payload(velocity_cmd.ByteSizeLong());
-  velocity_cmd.SerializeToArray(payload.data(), payload.size());
-
-  FrameType frame_type = FrameType::VelocityCommand;
-  uint8_t flags = 0x00;
-
+  // ACK/NACK flow control: retransmit cached frame on timeout/NACK
   std::vector<uint8_t> tx_frame;
-  SpiDriver::encode_frame(tx_seq_++, frame_type, flags, payload, tx_frame);
+  if (pending_ack_ && retry_count_ < kMaxRetries && !last_tx_frame_.empty()) {
+    // Retransmit the cached frame
+    tx_frame = last_tx_frame_;
+    retry_count_++;
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                         "Retransmitting frame (attempt %d/%d)", retry_count_,
+                         kMaxRetries);
+  } else {
+    if (pending_ack_ && retry_count_ >= kMaxRetries) {
+      RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                            "ACK timeout after %d retries; dropping frame",
+                            kMaxRetries);
+      pending_ack_ = false;
+      retry_count_ = 0;
+    }
+
+    // Convert Twist to protobuf VelocityCommand wrapped in SetVelocityRequest.
+    // Firmware expects SetVelocityRequest, not bare VelocityCommand.
+    star::v1::VelocityCommand velocity_cmd;
+    if (!converter_->twist_to_velocity_command(cmd_vel_to_send, velocity_cmd)) {
+      RCLCPP_WARN(get_logger(),
+                  "Failed to convert Twist to VelocityCommand (NaN/Inf?)");
+      velocity_cmd.set_front_left_velocity_mps(0.0);
+      velocity_cmd.set_front_right_velocity_mps(0.0);
+      velocity_cmd.set_back_left_velocity_mps(0.0);
+      velocity_cmd.set_back_right_velocity_mps(0.0);
+    }
+
+    star::v1::SetVelocityRequest request;
+    *request.mutable_command() = velocity_cmd;
+
+    std::vector<uint8_t> payload(static_cast<size_t>(request.ByteSizeLong()));
+    request.SerializeToArray(payload.data(), static_cast<int>(payload.size()));
+
+    const uint8_t flags = static_cast<uint8_t>(FrameFlags::RequiresAck);
+    last_tx_seq_ = tx_seq_;
+    SpiDriver::encode_frame(tx_seq_++, FrameType::Command, flags, payload,
+                            tx_frame);
+    last_tx_frame_ = tx_frame;
+    pending_ack_ = true;
+    retry_count_ = 0;
+  }
 
   // Perform full-duplex SPI transfer
   std::vector<uint8_t> rx_frame;
@@ -202,96 +370,136 @@ void StarSpiDriverNode::timer_callback()
   }
 
   // Decode received frame
+  uint16_t rx_seq = 0;
+  FrameType rx_type = FrameType::Ping;
+  uint8_t rx_flags = 0;
+  std::vector<uint8_t> rx_payload;
 
-  uint16_t rx_seq_;
-
-  FrameType rx_type_;
-
-  uint8_t rx_flags_;
-
-  std::vector<uint8_t> rx_payload_;
-
-  if (!SpiDriver::decode_frame(rx_frame, rx_seq_, rx_type_, rx_flags_,
-                               rx_payload_))
-  {
+  if (!SpiDriver::decode_frame(rx_frame, rx_seq, rx_type, rx_flags, rx_payload)) {
     RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), kLogThrottleMs,
         "SPI Frame Decode Failed (CRC mismatch or garbage)");
-
     return;
   }
 
-  // Parse telemetry and publish ROS2 messages
-  if (rx_type_ == FrameType::TelemetryData) {
-    star::v1::TelemetryData telemetry;
-    if (telemetry.ParseFromArray(rx_payload_.data(), rx_payload_.size())) {
-      // Check emergency stop flag from motor controller
-      if (telemetry.emergency_stop()) {
-        RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                              "RX72N EMERGENCY STOP ACTIVE");
+  // Dispatch on received frame type
+  switch (rx_type) {
+    case FrameType::Ack: {
+        if (rx_seq == last_tx_seq_) {
+          pending_ack_ = false;
+          retry_count_ = 0;
+        }
+        break;
       }
 
-      // Publish Odometry
-      nav_msgs::msg::Odometry odom;
-      odom.header.stamp = now;
-      converter_->telemetry_to_odometry(telemetry, odom);
-      odom_pub_->publish(odom);
-
-      // Publish Joint States
-      sensor_msgs::msg::JointState joint_state;
-      joint_state.header.stamp = now;
-      converter_->telemetry_to_joint_state(telemetry, joint_state);
-      joint_state_pub_->publish(joint_state);
-
-      // Publish IMU data
-      const auto & imu_data = telemetry.imu();
-      // Skip if firmware has not populated IMU fields (proto3 default = all zeros).
-      // A functioning IMU at rest reads ~9.81 m/s^2 on Z; zero indicates no data.
-      const bool imu_populated = (imu_data.accel_z_mps2() != 0.0 ||
-        imu_data.gyro_z_rad_per_s() != 0.0);
-      if (!imu_populated) {
-        return;  // wait for real IMU data
+    case FrameType::Nack: {
+        RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                             "NACK received for seq=%u", rx_seq);
+        // pending_ack_ stays true; retransmit will happen next tick
+        break;
       }
 
-      sensor_msgs::msg::Imu imu_msg;
-      imu_msg.header.stamp = now;
-      imu_msg.header.frame_id = "imu_link";
+    case FrameType::Ping: {
+        RCLCPP_DEBUG(get_logger(), "PING received from RX72N");
+        break;
+      }
 
-      tf2::Quaternion q;
-      q.setRPY(imu_data.roll_rad(), imu_data.pitch_rad(), imu_data.yaw_rad());
-      imu_msg.orientation.x = q.x();
-      imu_msg.orientation.y = q.y();
-      imu_msg.orientation.z = q.z();
-      imu_msg.orientation.w = q.w();
-      // Orientation covariance (3x3 row-major): sigma ~5.7 deg (rad^2)
-      imu_msg.orientation_covariance = {
-        kImuOrientationVar, 0.0, 0.0,
-        0.0, kImuOrientationVar, 0.0,
-        0.0, 0.0, kImuOrientationVar};
+    case FrameType::Response: {
+        // Response implies command was received; clear ACK state
+        pending_ack_ = false;
+        retry_count_ = 0;
 
-      imu_msg.angular_velocity.x = imu_data.gyro_x_rad_per_s();
-      imu_msg.angular_velocity.y = imu_data.gyro_y_rad_per_s();
-      imu_msg.angular_velocity.z = imu_data.gyro_z_rad_per_s();
-      // Angular velocity covariance (3x3 row-major): sigma ~0.032 rad/s
-      imu_msg.angular_velocity_covariance = {
-        kImuAngularVelocityVar, 0.0, 0.0,
-        0.0, kImuAngularVelocityVar, 0.0,
-        0.0, 0.0, kImuAngularVelocityVar};
+        star::v1::TelemetryData telemetry;
+        if (!telemetry.ParseFromArray(rx_payload.data(),
+                                      static_cast<int>(rx_payload.size())))
+        {
+          RCLCPP_WARN(get_logger(), "Failed to parse TelemetryData protobuf");
+          break;
+        }
 
-      imu_msg.linear_acceleration.x = imu_data.accel_x_mps2();
-      imu_msg.linear_acceleration.y = imu_data.accel_y_mps2();
-      imu_msg.linear_acceleration.z = imu_data.accel_z_mps2();
-      // Linear acceleration covariance (3x3 row-major): sigma ~0.1 m/s^2
-      imu_msg.linear_acceleration_covariance = {
-        kImuLinearAccelVar, 0.0, 0.0,
-        0.0, kImuLinearAccelVar, 0.0,
-        0.0, 0.0, kImuLinearAccelVar};
+        // Check emergency stop flag from motor controller
+        if (telemetry.emergency_stop()) {
+          RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
+                                "RX72N EMERGENCY STOP ACTIVE");
+        }
 
-      imu_pub_->publish(imu_msg);
+        // Publish Odometry
+        nav_msgs::msg::Odometry odom;
+        odom.header.stamp = now;
+        converter_->telemetry_to_odometry(telemetry, odom);
+        odom_pub_->publish(odom);
 
-    } else {
-      RCLCPP_WARN(get_logger(), "Failed to parse TelemetryData protobuf");
-    }
+        // Publish Joint States
+        sensor_msgs::msg::JointState joint_state;
+        joint_state.header.stamp = now;
+        converter_->telemetry_to_joint_state(telemetry, joint_state);
+        joint_state_pub_->publish(joint_state);
+
+        // Publish IMU data if populated
+        const auto & imu_data = telemetry.imu();
+        constexpr double kImuEpsilon = 1e-6;
+        const bool imu_populated =
+          (std::fabs(imu_data.accel_z_mps2()) > kImuEpsilon ||
+           std::fabs(imu_data.gyro_z_rad_per_s()) > kImuEpsilon);
+        if (imu_populated) {
+          sensor_msgs::msg::Imu imu_msg;
+          imu_msg.header.stamp = now;
+          imu_msg.header.frame_id = "imu_link";
+
+          tf2::Quaternion q;
+          q.setRPY(imu_data.roll_rad(), imu_data.pitch_rad(), imu_data.yaw_rad());
+          imu_msg.orientation.x = q.x();
+          imu_msg.orientation.y = q.y();
+          imu_msg.orientation.z = q.z();
+          imu_msg.orientation.w = q.w();
+          imu_msg.orientation_covariance = {
+            kImuOrientationVar, 0.0, 0.0,
+            0.0, kImuOrientationVar, 0.0,
+            0.0, 0.0, kImuOrientationVar};
+
+          imu_msg.angular_velocity.x = imu_data.gyro_x_rad_per_s();
+          imu_msg.angular_velocity.y = imu_data.gyro_y_rad_per_s();
+          imu_msg.angular_velocity.z = imu_data.gyro_z_rad_per_s();
+          imu_msg.angular_velocity_covariance = {
+            kImuAngularVelocityVar, 0.0, 0.0,
+            0.0, kImuAngularVelocityVar, 0.0,
+            0.0, 0.0, kImuAngularVelocityVar};
+
+          imu_msg.linear_acceleration.x = imu_data.accel_x_mps2();
+          imu_msg.linear_acceleration.y = imu_data.accel_y_mps2();
+          imu_msg.linear_acceleration.z = imu_data.accel_z_mps2();
+          imu_msg.linear_acceleration_covariance = {
+            kImuLinearAccelVar, 0.0, 0.0,
+            0.0, kImuLinearAccelVar, 0.0,
+            0.0, 0.0, kImuLinearAccelVar};
+
+          imu_pub_->publish(imu_msg);
+        }
+
+        // Publish obstacle ranges
+        sensor_msgs::msg::Range obs_fl, obs_fr, obs_bl, obs_br;
+        obs_fl.header.stamp = now;
+        obs_fr.header.stamp = now;
+        obs_bl.header.stamp = now;
+        obs_br.header.stamp = now;
+        converter_->telemetry_to_obstacle_ranges(telemetry, obs_fl, obs_fr,
+                                                 obs_bl, obs_br);
+        obstacle_front_left_pub_->publish(obs_fl);
+        obstacle_front_right_pub_->publish(obs_fr);
+        obstacle_back_left_pub_->publish(obs_bl);
+        obstacle_back_right_pub_->publish(obs_br);
+
+        std_msgs::msg::Bool detected_msg;
+        detected_msg.data = telemetry.obstacle().any_obstacle();
+        obstacle_detected_pub_->publish(detected_msg);
+        break;
+      }
+
+    default: {
+        RCLCPP_DEBUG(get_logger(), "Received unhandled frame type: 0x%02X",
+                     static_cast<uint8_t>(rx_type));
+        break;
+      }
   }
 }
 

--- a/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
+++ b/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
@@ -294,6 +294,14 @@ void StarSpiDriverNode::emergency_stop_callback(
   }
 
   try {
+    bool retransmit_timer_paused = false;
+    const auto resume_retransmit_timer = [&]() {
+        if (retransmit_timer_paused && timer_) {
+          timer_->reset();
+          retransmit_timer_paused = false;
+        }
+      };
+
     star::v1::EmergencyStopRequest estop;
     estop.set_reason("Manual E-Stop via /emergency_stop topic");
 
@@ -309,9 +317,22 @@ void StarSpiDriverNode::emergency_stop_callback(
     std::vector<uint8_t> tx_frame;
     SpiDriver::encode_frame(tx_seq_, FrameType::Command, flags, payload, tx_frame);
 
+    // Cancel any in-flight retransmit state so we don't resend stale commands.
+    // The retransmit logic is driven by timer_ via timer_callback().
+    if (pending_ack_) {
+      pending_ack_ = false;
+      last_tx_frame_.clear();
+      retry_count_ = 0;
+      if (timer_) {
+        timer_->cancel();
+        retransmit_timer_paused = true;
+      }
+    }
+
     std::vector<uint8_t> rx_frame;
     if (!spi_driver_->transfer(tx_frame, rx_frame)) {
       RCLCPP_ERROR(get_logger(), "SPI transfer failed during emergency stop");
+      resume_retransmit_timer();
       return;
     }
 
@@ -323,25 +344,33 @@ void StarSpiDriverNode::emergency_stop_callback(
     if (!SpiDriver::decode_frame(rx_frame, rx_seq, rx_type, rx_flags, rx_payload)) {
       RCLCPP_ERROR(get_logger(),
                    "Failed to decode ACK response during emergency stop");
+      resume_retransmit_timer();
       return;
     }
     if (rx_type == FrameType::Nack) {
       RCLCPP_ERROR(get_logger(),
                    "Emergency stop NACK received (seq=%u); command may not have been applied",
                    rx_seq);
+      resume_retransmit_timer();
       return;
     }
     if (rx_type != FrameType::Ack || rx_seq != tx_seq_) {
       RCLCPP_ERROR(get_logger(),
                    "Unexpected response during emergency stop: type=0x%02X seq=%u (expected Ack seq=%u)",
                    static_cast<uint8_t>(rx_type), rx_seq, tx_seq_);
+      resume_retransmit_timer();
       return;
     }
 
     // Only increment sequence after confirmed ACK
     tx_seq_++;
+
+    resume_retransmit_timer();
   } catch (const std::exception & e) {
     RCLCPP_ERROR(get_logger(), "Exception in emergency_stop_callback: %s", e.what());
+    if (timer_) {
+      timer_->reset();
+    }
   }
 }
 

--- a/star-ros2/src/star_spi_bridge/test/test_spi_driver.cpp
+++ b/star-ros2/src/star_spi_bridge/test/test_spi_driver.cpp
@@ -148,3 +148,106 @@ TEST_F(SpiDriverTest, EncodeRejectsOversizedPayload)
     SpiDriver::encode_frame(0, FrameType::Command, 0x00, oversized, frame),
     std::invalid_argument);
 }
+
+// ---------------------------------------------------------------------------
+// FrameFlags bitwise operator tests
+// ---------------------------------------------------------------------------
+// All valid flag bits are in [0, 4] (mask 0x1F). Bits 5-7 are reserved and
+// must remain 0.  These tests verify combining, masking, toggling, assignment,
+// and the unary complement semantics guaranteed by operator~.
+// ---------------------------------------------------------------------------
+
+class FrameFlagsTest : public ::testing::Test {};
+
+TEST_F(FrameFlagsTest, OrCombinesFlags)
+{
+  const FrameFlags combined = FrameFlags::RequiresAck | FrameFlags::Priority;
+  const auto raw = static_cast<uint8_t>(combined);
+
+  // RequiresAck=0x01, Priority=0x04 -> 0x05
+  EXPECT_EQ(raw, 0x05u);
+  // Both source bits are present
+  EXPECT_NE(static_cast<uint8_t>(combined & FrameFlags::RequiresAck), 0u);
+  EXPECT_NE(static_cast<uint8_t>(combined & FrameFlags::Priority), 0u);
+}
+
+TEST_F(FrameFlagsTest, AndMasksFlags)
+{
+  const FrameFlags combined = FrameFlags::RequiresAck | FrameFlags::Priority;
+  // Mask off RequiresAck
+  const FrameFlags masked = combined & FrameFlags::RequiresAck;
+  EXPECT_EQ(static_cast<uint8_t>(masked), static_cast<uint8_t>(FrameFlags::RequiresAck));
+  // Priority bit is not present after AND with RequiresAck
+  EXPECT_EQ(static_cast<uint8_t>(masked & FrameFlags::Priority), 0u);
+}
+
+TEST_F(FrameFlagsTest, XorTogglesFlags)
+{
+  // Start with RequiresAck | Priority, toggle RequiresAck off
+  const FrameFlags combined = FrameFlags::RequiresAck | FrameFlags::Priority;
+  const FrameFlags toggled = combined ^ FrameFlags::RequiresAck;
+
+  // RequiresAck should be cleared, Priority remains
+  EXPECT_EQ(static_cast<uint8_t>(toggled), static_cast<uint8_t>(FrameFlags::Priority));
+}
+
+TEST_F(FrameFlagsTest, NotComplementsDefinedBitsOnly)
+{
+  // ~RequiresAck (0x01) should have bits 1-4 set but bit 0 cleared,
+  // and reserved bits 5-7 must always be 0.
+  const FrameFlags result = ~FrameFlags::RequiresAck;
+  const auto raw = static_cast<uint8_t>(result);
+
+  // Bit 0 (RequiresAck) is cleared
+  EXPECT_EQ(raw & 0x01u, 0u);
+  // Bits 1-4 (Retransmit, Priority, FecEnabled, SoftNack) are set
+  EXPECT_EQ(raw & 0x1Eu, 0x1Eu);
+  // Reserved bits 5-7 must be zero
+  EXPECT_EQ(raw & 0xE0u, 0u);
+}
+
+TEST_F(FrameFlagsTest, NotClearsReservedBitsForAllSingleFlags)
+{
+  // Verify reserved bits are always 0 regardless of input
+  constexpr uint8_t kReservedMask = 0xE0u;
+  for (const auto flag : {
+    FrameFlags::None, FrameFlags::RequiresAck, FrameFlags::Retransmit,
+    FrameFlags::Priority, FrameFlags::FecEnabled, FrameFlags::SoftNack})
+  {
+    const auto raw = static_cast<uint8_t>(~flag);
+    EXPECT_EQ(raw & kReservedMask, 0u)
+        << "Reserved bits 5-7 set for ~flag with underlying value "
+        << static_cast<int>(static_cast<uint8_t>(flag));
+  }
+}
+
+TEST_F(FrameFlagsTest, OrAssignmentAccumulatesFlags)
+{
+  FrameFlags flags = FrameFlags::None;
+  flags |= FrameFlags::RequiresAck;
+  flags |= FrameFlags::FecEnabled;
+
+  // RequiresAck=0x01, FecEnabled=0x08 -> 0x09
+  EXPECT_EQ(static_cast<uint8_t>(flags), 0x09u);
+}
+
+TEST_F(FrameFlagsTest, AndAssignmentClearsFlags)
+{
+  FrameFlags flags = FrameFlags::RequiresAck | FrameFlags::Retransmit | FrameFlags::Priority;
+  // Keep only Priority
+  flags &= FrameFlags::Priority;
+  EXPECT_EQ(static_cast<uint8_t>(flags), static_cast<uint8_t>(FrameFlags::Priority));
+}
+
+TEST_F(FrameFlagsTest, XorAssignmentTogglesFlags)
+{
+  FrameFlags flags = FrameFlags::RequiresAck | FrameFlags::Retransmit;
+  // Toggle Retransmit off and SoftNack on
+  flags ^= (FrameFlags::Retransmit | FrameFlags::SoftNack);
+
+  // Retransmit cleared, RequiresAck kept, SoftNack added
+  const auto raw = static_cast<uint8_t>(flags);
+  EXPECT_EQ(raw & static_cast<uint8_t>(FrameFlags::Retransmit), 0u);
+  EXPECT_NE(raw & static_cast<uint8_t>(FrameFlags::RequiresAck), 0u);
+  EXPECT_NE(raw & static_cast<uint8_t>(FrameFlags::SoftNack), 0u);
+}

--- a/star-ros2/src/star_spi_bridge/test/test_spi_driver.cpp
+++ b/star-ros2/src/star_spi_bridge/test/test_spi_driver.cpp
@@ -139,6 +139,34 @@ TEST_F(SpiDriverTest, DecodeRejectsCRCCorruption)
   EXPECT_FALSE(SpiDriver::decode_frame(frame, seq, type, flags, decoded_payload));
 }
 
+TEST_F(SpiDriverTest, DecodeRejectsUnknownFrameType)
+{
+  // Build a frame with a valid TYPE byte, then replace it with a reserved value
+  // (0x05 is not a valid FrameType) and recompute the CRC so it is valid.
+  // decode_frame must reject the frame because the type is unknown.
+  std::vector<uint8_t> payload = {0x01};
+  std::vector<uint8_t> frame;
+  SpiDriver::encode_frame(1, FrameType::Command, 0x00, payload, frame);
+
+  // Corrupt the TYPE byte (offset 6) to a reserved/invalid value
+  frame[6] = 0x05;
+
+  // Recompute CRC over header + payload (all bytes except the last 4)
+  std::vector<uint8_t> to_crc(frame.begin(), frame.end() - 4);
+  const uint32_t new_crc = SpiDriver::calculate_crc32(to_crc);
+  frame[frame.size() - 4] = static_cast<uint8_t>(new_crc & 0xFFu);
+  frame[frame.size() - 3] = static_cast<uint8_t>((new_crc >> 8u) & 0xFFu);
+  frame[frame.size() - 2] = static_cast<uint8_t>((new_crc >> 16u) & 0xFFu);
+  frame[frame.size() - 1] = static_cast<uint8_t>((new_crc >> 24u) & 0xFFu);
+
+  uint16_t seq = 0;
+  FrameType type = FrameType::Command;
+  uint8_t flags = 0;
+  std::vector<uint8_t> decoded_payload;
+
+  EXPECT_FALSE(SpiDriver::decode_frame(frame, seq, type, flags, decoded_payload));
+}
+
 TEST_F(SpiDriverTest, EncodeRejectsOversizedPayload)
 {
   std::vector<uint8_t> oversized(SpiDriver::MAX_PAYLOAD_SIZE + 1, 0xAA);

--- a/star-ros2/src/star_spi_bridge/test/test_spi_driver.cpp
+++ b/star-ros2/src/star_spi_bridge/test/test_spi_driver.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>  // NOLINT
 
+using star_spi_bridge::FrameFlags;
 using star_spi_bridge::FrameType;
 using star_spi_bridge::SpiDriver;
 
@@ -29,10 +30,10 @@ TEST_F(SpiDriverTest, FrameEncoding)
 {
   std::vector<uint8_t> payload = {0x01, 0x02, 0x03};
   std::vector<uint8_t> frame;
-  SpiDriver::encode_frame(100, FrameType::VelocityCommand, 0x00, payload, frame);
+  SpiDriver::encode_frame(100, FrameType::Command, 0x00, payload, frame);
 
   // Header (8) + Payload (3) + CRC (4) = 15 bytes
-  EXPECT_EQ(frame.size(), 15);
+  EXPECT_EQ(frame.size(), 15u);
 
   // Check SYNC word (Little Endian: [0xAA, 0x55] for 0x55AA)
   EXPECT_EQ(frame[0], 0xAA);  // LSB first
@@ -47,21 +48,37 @@ TEST_F(SpiDriverTest, FrameEncoding)
   EXPECT_EQ(frame[5], 0x00);  // LEN MSB
 
   // Check TYPE and FLAGS
-  EXPECT_EQ(frame[6], 0x01);  // TYPE: VelocityCommand
+  EXPECT_EQ(frame[6], static_cast<uint8_t>(FrameType::Command));  // TYPE: Command
   EXPECT_EQ(frame[7], 0x00);  // FLAGS: none
+}
+
+TEST_F(SpiDriverTest, FrameEncodingAck)
+{
+  std::vector<uint8_t> empty_payload;
+  std::vector<uint8_t> frame;
+  SpiDriver::encode_frame(7, FrameType::Ack, 0x00, empty_payload, frame);
+
+  // Header (8) + Payload (0) + CRC (4) = 12 bytes
+  EXPECT_EQ(frame.size(), 12u);
+  EXPECT_EQ(frame[6], static_cast<uint8_t>(FrameType::Ack));  // TYPE: Ack
+}
+
+TEST_F(SpiDriverTest, FrameEncodingPing)
+{
+  std::vector<uint8_t> empty_payload;
+  std::vector<uint8_t> frame;
+  SpiDriver::encode_frame(0, FrameType::Ping, 0x00, empty_payload, frame);
+
+  EXPECT_EQ(frame.size(), 12u);
+  EXPECT_EQ(frame[6], static_cast<uint8_t>(FrameType::Ping));  // TYPE: Ping
 }
 
 TEST_F(SpiDriverTest, FrameDecoding)
 {
-  // Construct a valid frame manually
-  // SYNC(55AA) SEQ(0001) LEN(0001) TYPE(01) FLAGS(00) PAYLOAD(A5) CRC(...)
-  // CRC for header+payload needs to be correct for decode to succeed
-
-  // We can't easily test decode without a working encode or pre-calculated frame
-  // For Red Phase, we just assert that decode fails on garbage
+  // Verify that decode fails on garbage
   std::vector<uint8_t> garbage = {0x00, 0x00, 0x00};
   uint16_t seq = 0;
-  FrameType type = FrameType::TelemetryData;
+  FrameType type = FrameType::Response;
   uint8_t flags = 0x00;
   std::vector<uint8_t> payload = {};
 
@@ -72,17 +89,36 @@ TEST_F(SpiDriverTest, EncodeDecodeRoundTrip)
 {
   std::vector<uint8_t> payload_in = {0xDE, 0xAD, 0xBE, 0xEF};
   std::vector<uint8_t> frame;
-  SpiDriver::encode_frame(42, FrameType::TelemetryData, 0x03, payload_in, frame);
+  SpiDriver::encode_frame(42, FrameType::Response, 0x03, payload_in, frame);
 
   uint16_t seq = 0;
-  FrameType type = FrameType::VelocityCommand;
+  FrameType type = FrameType::Command;
   uint8_t flags = 0;
   std::vector<uint8_t> payload_out;
 
   ASSERT_TRUE(SpiDriver::decode_frame(frame, seq, type, flags, payload_out));
-  EXPECT_EQ(seq, 42);
-  EXPECT_EQ(type, FrameType::TelemetryData);
+  EXPECT_EQ(seq, 42u);
+  EXPECT_EQ(type, FrameType::Response);
   EXPECT_EQ(flags, 0x03);
+  EXPECT_EQ(payload_out, payload_in);
+}
+
+TEST_F(SpiDriverTest, EncodeDecodeRoundTripCommand)
+{
+  std::vector<uint8_t> payload_in = {0x01, 0x02, 0x03, 0x04};
+  std::vector<uint8_t> frame;
+  const uint8_t flags = static_cast<uint8_t>(FrameFlags::RequiresAck);
+  SpiDriver::encode_frame(10, FrameType::Command, flags, payload_in, frame);
+
+  uint16_t seq = 0;
+  FrameType type = FrameType::Ping;
+  uint8_t decoded_flags = 0;
+  std::vector<uint8_t> payload_out;
+
+  ASSERT_TRUE(SpiDriver::decode_frame(frame, seq, type, decoded_flags, payload_out));
+  EXPECT_EQ(seq, 10u);
+  EXPECT_EQ(type, FrameType::Command);
+  EXPECT_EQ(decoded_flags, flags);
   EXPECT_EQ(payload_out, payload_in);
 }
 
@@ -90,13 +126,13 @@ TEST_F(SpiDriverTest, DecodeRejectsCRCCorruption)
 {
   std::vector<uint8_t> payload = {0x01};
   std::vector<uint8_t> frame;
-  SpiDriver::encode_frame(1, FrameType::VelocityCommand, 0x00, payload, frame);
+  SpiDriver::encode_frame(1, FrameType::Command, 0x00, payload, frame);
 
   // Corrupt the last byte (CRC)
   frame.back() ^= 0xFF;
 
   uint16_t seq = 0;
-  FrameType type = FrameType::TelemetryData;
+  FrameType type = FrameType::Response;
   uint8_t flags = 0;
   std::vector<uint8_t> decoded_payload;
 
@@ -109,6 +145,6 @@ TEST_F(SpiDriverTest, EncodeRejectsOversizedPayload)
   std::vector<uint8_t> frame;
 
   EXPECT_THROW(
-    SpiDriver::encode_frame(0, FrameType::VelocityCommand, 0x00, oversized, frame),
+    SpiDriver::encode_frame(0, FrameType::Command, 0x00, oversized, frame),
     std::invalid_argument);
 }


### PR DESCRIPTION
## Summary
- Add `FrameFlags` bitwise operator overloads (`|`, `&`, `^`, `~`, `|=`, `&=`, `^=`) with full Doxygen; mask `operator~` to `0x1F` so undefined upper bits (5-7) are never set
- Harden `StarSpiDriverNode` with null guards, try/catch exception handling around SPI transfers, `tx_seq_` only incremented on success, and an epsilon-based IMU zero check replacing a direct float comparison
- Add frame-type validation in `decode_frame` with a 1 s throttled `RCLCPP_WARN_THROTTLE` to prevent log flooding on corrupt/unknown frames

## Test plan
- [ ] `colcon build --packages-select star_spi_bridge` passes with zero warnings
- [ ] `colcon test --packages-select star_spi_bridge` — all GTest cases pass (CRC-32, encode/decode round-trip, CRC corruption rejection)
- [ ] Manual review: `operator~(FrameFlags::RequiresAck | FrameFlags::Priority)` returns only bits 0-4 complemented; bits 5-7 are cleared
- [ ] Code review checklist:
  - [ ] NASA Power of 10 rules followed
  - [ ] SOLID principles applied
  - [ ] Doxygen documentation complete across all headers and source files
  - [ ] No magic numbers (magic byte literals in tests replaced with typed `FrameType` casts)
  - [ ] Inclusive terminology used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Obstacle detection: publishes four directional range sensors and an obstacle_detected flag.
  * Emergency stop: subscriber that sends prioritized stop frames requiring acknowledgement.
  * Telemetry-to-range conversion: converts telemetry into four sensor Range messages.
  * SPI reliability: added frame flags, ACK/NACK flow with retransmission, priority on shutdown and emergency transmissions.

* **Tests**
  * Updated and expanded tests for new frame types, flag operations, encoding/decoding, and retransmission scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->