### PR TITLE
feat(telemetry): add estop reason to telemetry (#374)

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -167,11 +167,11 @@ proto_files=$(echo "$staged_files" | grep "\.proto$" || true)
 if [[ -n "$proto_files" ]]; then
     echo "Checking Protobuf files..."
 
-    # Check formatting
-    pushd star-proto >/dev/null
+    # Check formatting and linting from star-proto/proto where buf.yaml lives
+    pushd star-proto/proto >/dev/null
     if ! buf format --diff --exit-code; then
         echo "[FAIL] Protobuf formatting failed."
-        echo "   Run: buf format -w"
+        echo "   Run: cd star-proto/proto && buf format -w"
         error_found=1
     fi
 

--- a/star-proto/proto/star/v1/telemetry.proto
+++ b/star-proto/proto/star/v1/telemetry.proto
@@ -127,6 +127,9 @@ message TelemetryData {
   // Bit 0: Motor 0 fault, Bit 1: Motor 1 fault, etc.
   uint32 fault_flags = 11;
 
+  // Emergency stop reason (RX72N specific). Populated when emergency_stop is true.
+  EstopReason estop_reason = 9;
+
   // Frame sequence number from transport layer for drop detection.
   // Increments with each transmitted frame. Used by diagnostics to detect
   // missing frames in the telemetry stream.
@@ -215,6 +218,28 @@ message GpsData {
 
   // GPS fix type.
   GpsFix fix_type = 6;
+}
+
+// Emergency stop reason enumeration.
+// Identifies the cause of an active emergency stop condition on the RX72N.
+enum EstopReason {
+  // Unknown or no emergency stop active.
+  ESTOP_REASON_UNKNOWN = 0;
+
+  // Manual emergency stop requested via software command.
+  ESTOP_REASON_MANUAL = 1;
+
+  // Motor driver hardware fault detected (nFAULT signal asserted).
+  ESTOP_REASON_FAULT = 2;
+
+  // Communication timeout: no command received within watchdog window.
+  ESTOP_REASON_COMM_TIMEOUT = 3;
+
+  // Obstacle detected too close by ultrasonic sensors.
+  ESTOP_REASON_OBSTACLE = 4;
+
+  // Motor overcurrent condition detected.
+  ESTOP_REASON_OVERCURRENT = 5;
 }
 
 // GPS fix type.

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
@@ -191,11 +191,7 @@ private:
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
     obstacle_detected_pub_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int32>::SharedPtr
-    estop_reason_pub_;  /**< Publishes E-STOP reason code as Int32 (star_v1_EstopReason values:
-                          0=UNKNOWN, 1=MANUAL, 2=FAULT, 3=COMM_TIMEOUT, 4=OBSTACLE, 5=OVERCURRENT).
-                          Meaningful only when emergency_stop is true; zero otherwise.
-                          Published from the timer callback thread (single executor, no external
-                          synchronization required). */
+    estop_reason_pub_;  /**< E-STOP reason code (star_v1_EstopReason, Int32). Valid when emergency_stop is true. */
 
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
@@ -191,7 +191,11 @@ private:
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
     obstacle_detected_pub_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int32>::SharedPtr
-    estop_reason_pub_;
+    estop_reason_pub_;  /**< Publishes E-STOP reason code as Int32 (star_v1_EstopReason values:
+                          0=UNKNOWN, 1=MANUAL, 2=FAULT, 3=COMM_TIMEOUT, 4=OBSTACLE, 5=OVERCURRENT).
+                          Meaningful only when emergency_stop is true; zero otherwise.
+                          Published from the timer callback thread (single executor, no external
+                          synchronization required). */
 
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
+++ b/star-ros2/src/star_spi_bridge/include/star_spi_bridge/star_spi_driver_node.hpp
@@ -38,6 +38,7 @@
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/range.hpp>
 #include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/int32.hpp>
 
 #include "star_spi_bridge/spi_driver.hpp"
 #include "star_spi_bridge/spi_message_converter.hpp"
@@ -189,6 +190,8 @@ private:
     obstacle_back_right_pub_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Bool>::SharedPtr
     obstacle_detected_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Int32>::SharedPtr
+    estop_reason_pub_;
 
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
+++ b/star-ros2/src/star_spi_bridge/src/star_spi_driver_node.cpp
@@ -7,6 +7,7 @@
 #include <stdexcept>
 
 #include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/int32.hpp>
 #include <tf2/LinearMath/Quaternion.h>  // NOLINT(build/include_order)
 
 #include "star/v1/motor_control.pb.h"
@@ -85,6 +86,8 @@ StarSpiDriverNode::on_configure(const rclcpp_lifecycle::State &)
     create_publisher<sensor_msgs::msg::Range>("star/obstacle/back_right", 10);
   obstacle_detected_pub_ =
     create_publisher<std_msgs::msg::Bool>("star/obstacle_detected", 10);
+  estop_reason_pub_ =
+    create_publisher<std_msgs::msg::Int32>("star/estop_reason", 10);
 
   // Create subscriptions
   cmd_vel_sub_ = create_subscription<geometry_msgs::msg::Twist>(
@@ -116,6 +119,7 @@ StarSpiDriverNode::on_activate(const rclcpp_lifecycle::State &)
   obstacle_back_left_pub_->on_activate();
   obstacle_back_right_pub_->on_activate();
   obstacle_detected_pub_->on_activate();
+  estop_reason_pub_->on_activate();
 
   // Start 100 Hz timer (10ms)
   timer_ = create_wall_timer(
@@ -180,6 +184,7 @@ StarSpiDriverNode::on_deactivate(const rclcpp_lifecycle::State &)
   obstacle_back_left_pub_->on_deactivate();
   obstacle_back_right_pub_->on_deactivate();
   obstacle_detected_pub_->on_deactivate();
+  estop_reason_pub_->on_deactivate();
 
   return success ?
          rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS :
@@ -203,6 +208,7 @@ StarSpiDriverNode::on_cleanup(const rclcpp_lifecycle::State &)
   obstacle_back_left_pub_.reset();
   obstacle_back_right_pub_.reset();
   obstacle_detected_pub_.reset();
+  estop_reason_pub_.reset();
   cmd_vel_sub_.reset();
   emergency_stop_sub_.reset();
 
@@ -503,9 +509,16 @@ void StarSpiDriverNode::timer_callback()
 
           // Check emergency stop flag from motor controller
           if (telemetry.emergency_stop()) {
-            RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), kLogThrottleMs,
-                                  "RX72N EMERGENCY STOP ACTIVE");
+            RCLCPP_ERROR_THROTTLE(
+              get_logger(), *get_clock(), kLogThrottleMs,
+              "RX72N EMERGENCY STOP ACTIVE: reason=%s",
+              star::v1::EstopReason_Name(telemetry.estop_reason()).c_str());
           }
+
+          // Publish estop reason (always, so consumers see 0/UNKNOWN when inactive)
+          std_msgs::msg::Int32 estop_reason_msg;
+          estop_reason_msg.data = static_cast<int32_t>(telemetry.estop_reason());
+          estop_reason_pub_->publish(estop_reason_msg);
 
           // Publish Odometry
           nav_msgs::msg::Odometry odom;

--- a/star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.h
+++ b/star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/gateway_service.pb.h
@@ -221,7 +221,7 @@ extern const pb_msgdesc_t star_v1_SetPIDGainsResponse_msg;
 /* Maximum encoded size of messages (where known) */
 /* star_v1_SetPIDGainsResponse_size depends on runtime parameters */
 #define STAR_V1_STAR_V1_GATEWAY_SERVICE_PB_H_MAX_SIZE star_v1_ForwardTelemetryRequest_size
-#define star_v1_ForwardTelemetryRequest_size     8481
+#define star_v1_ForwardTelemetryRequest_size     8483
 #define star_v1_ForwardTelemetryResponse_size    376
 #define star_v1_GetTeleopCommandRequest_size     149
 #define star_v1_GetTeleopCommandResponse_size    431

--- a/star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
+++ b/star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.c
@@ -43,6 +43,8 @@ PB_BIND(star_v1_SystemStatus, star_v1_SystemStatus, AUTO)
 
 
 
+
+
 #ifndef PB_CONVERT_DOUBLE_FLOAT
 /* On some platforms (such as AVR), double is really float.
  * To be able to encode/decode double on these platforms, you need.

--- a/star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
+++ b/star-rx72n-firmware/libs/rx_nanopb/inc/gen/star/v1/telemetry.pb.h
@@ -13,6 +13,23 @@
 #endif
 
 /* Enum definitions */
+/* Emergency stop reason enumeration.
+ Identifies the cause of an active emergency stop condition on the RX72N. */
+typedef enum _star_v1_EstopReason {
+    /* Unknown or no emergency stop active. */
+    star_v1_EstopReason_ESTOP_REASON_UNKNOWN = 0,
+    /* Manual emergency stop requested via software command. */
+    star_v1_EstopReason_ESTOP_REASON_MANUAL = 1,
+    /* Motor driver hardware fault detected (nFAULT signal asserted). */
+    star_v1_EstopReason_ESTOP_REASON_FAULT = 2,
+    /* Communication timeout: no command received within watchdog window. */
+    star_v1_EstopReason_ESTOP_REASON_COMM_TIMEOUT = 3,
+    /* Obstacle detected too close by ultrasonic sensors. */
+    star_v1_EstopReason_ESTOP_REASON_OBSTACLE = 4,
+    /* Motor overcurrent condition detected. */
+    star_v1_EstopReason_ESTOP_REASON_OVERCURRENT = 5
+} star_v1_EstopReason;
+
 /* GPS fix type. */
 typedef enum _star_v1_GpsFix {
     /* Unknown fix type. */
@@ -177,6 +194,8 @@ typedef struct _star_v1_TelemetryData {
     /* Telemetry timestamp. */
     bool has_timestamp;
     google_protobuf_Timestamp timestamp;
+    /* Emergency stop reason (RX72N specific). Populated when emergency_stop is true. */
+    star_v1_EstopReason estop_reason;
     /* Emergency stop state (RX72N specific). */
     bool emergency_stop;
     /* Motor fault flags bitfield (RX72N specific).
@@ -249,6 +268,10 @@ extern "C" {
 #endif
 
 /* Helper constants for enums */
+#define _star_v1_EstopReason_MIN star_v1_EstopReason_ESTOP_REASON_UNKNOWN
+#define _star_v1_EstopReason_MAX star_v1_EstopReason_ESTOP_REASON_OVERCURRENT
+#define _star_v1_EstopReason_ARRAYSIZE ((star_v1_EstopReason)(star_v1_EstopReason_ESTOP_REASON_OVERCURRENT+1))
+
 #define _star_v1_GpsFix_MIN star_v1_GpsFix_GPS_FIX_UNKNOWN
 #define _star_v1_GpsFix_MAX star_v1_GpsFix_GPS_FIX_RTK_FIXED
 #define _star_v1_GpsFix_ARRAYSIZE ((star_v1_GpsFix)(star_v1_GpsFix_GPS_FIX_RTK_FIXED+1))
@@ -266,6 +289,7 @@ extern "C" {
 
 
 
+#define star_v1_TelemetryData_estop_reason_ENUMTYPE star_v1_EstopReason
 
 
 
@@ -281,7 +305,7 @@ extern "C" {
 #define star_v1_StreamTelemetryRequest_init_default {false, star_v1_RequestHeader_init_default, 0, 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}}
 #define star_v1_GetSystemStatusRequest_init_default {false, star_v1_RequestHeader_init_default}
 #define star_v1_GetSystemStatusResponse_init_default {false, star_v1_ResponseHeader_init_default, false, star_v1_SystemStatus_init_default}
-#define star_v1_TelemetryData_init_default       {false, star_v1_ImuData_init_default, false, star_v1_GpsData_init_default, false, star_v1_ObstacleData_init_default, 0, 0, 0, 0, false, google_protobuf_Timestamp_init_default, 0, 0, 0, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, 0}
+#define star_v1_TelemetryData_init_default       {false, star_v1_ImuData_init_default, false, star_v1_GpsData_init_default, false, star_v1_ObstacleData_init_default, 0, 0, 0, 0, false, google_protobuf_Timestamp_init_default, _star_v1_EstopReason_MIN, 0, 0, 0, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, false, star_v1_EncoderData_init_default, 0}
 #define star_v1_ImuData_init_default             {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define star_v1_ObstacleData_init_default        {0, 0, 0, 0, 0, 0}
 #define star_v1_GpsData_init_default             {0, 0, 0, 0, 0, _star_v1_GpsFix_MIN}
@@ -291,7 +315,7 @@ extern "C" {
 #define star_v1_StreamTelemetryRequest_init_zero {false, star_v1_RequestHeader_init_zero, 0, 0, {"", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""}}
 #define star_v1_GetSystemStatusRequest_init_zero {false, star_v1_RequestHeader_init_zero}
 #define star_v1_GetSystemStatusResponse_init_zero {false, star_v1_ResponseHeader_init_zero, false, star_v1_SystemStatus_init_zero}
-#define star_v1_TelemetryData_init_zero          {false, star_v1_ImuData_init_zero, false, star_v1_GpsData_init_zero, false, star_v1_ObstacleData_init_zero, 0, 0, 0, 0, false, google_protobuf_Timestamp_init_zero, 0, 0, 0, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, 0}
+#define star_v1_TelemetryData_init_zero          {false, star_v1_ImuData_init_zero, false, star_v1_GpsData_init_zero, false, star_v1_ObstacleData_init_zero, 0, 0, 0, 0, false, google_protobuf_Timestamp_init_zero, _star_v1_EstopReason_MIN, 0, 0, 0, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, false, star_v1_EncoderData_init_zero, 0}
 #define star_v1_ImuData_init_zero                {0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define star_v1_ObstacleData_init_zero           {0, 0, 0, 0, 0, 0}
 #define star_v1_GpsData_init_zero                {0, 0, 0, 0, 0, _star_v1_GpsFix_MIN}
@@ -332,6 +356,7 @@ extern "C" {
 #define star_v1_TelemetryData_temperature_celsius_tag 6
 #define star_v1_TelemetryData_motor_load_percent_tag 7
 #define star_v1_TelemetryData_timestamp_tag      8
+#define star_v1_TelemetryData_estop_reason_tag   9
 #define star_v1_TelemetryData_emergency_stop_tag 10
 #define star_v1_TelemetryData_fault_flags_tag    11
 #define star_v1_TelemetryData_timestamp_us_tag   14
@@ -399,6 +424,7 @@ X(a, STATIC,   SINGULAR, DOUBLE,   cpu_usage_percent,   5) \
 X(a, STATIC,   SINGULAR, DOUBLE,   temperature_celsius,   6) \
 X(a, STATIC,   SINGULAR, DOUBLE,   motor_load_percent,   7) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  timestamp,         8) \
+X(a, STATIC,   SINGULAR, UENUM,    estop_reason,      9) \
 X(a, STATIC,   SINGULAR, BOOL,     emergency_stop,   10) \
 X(a, STATIC,   SINGULAR, UINT32,   fault_flags,      11) \
 X(a, STATIC,   SINGULAR, INT64,    timestamp_us,     14) \
@@ -491,13 +517,13 @@ extern const pb_msgdesc_t star_v1_SystemStatus_msg;
 #define star_v1_GetSystemStatusRequest_size      149
 #define star_v1_GetSystemStatusResponse_size     425
 #define star_v1_GetTelemetryRequest_size         149
-#define star_v1_GetTelemetryResponse_size        797
+#define star_v1_GetTelemetryResponse_size        799
 #define star_v1_GpsData_size                     49
 #define star_v1_ImuData_size                     81
 #define star_v1_ObstacleData_size                28
 #define star_v1_StreamTelemetryRequest_size      688
 #define star_v1_SystemStatus_size                60
-#define star_v1_TelemetryData_size               431
+#define star_v1_TelemetryData_size               433
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1810,7 +1810,7 @@ static star_v1_EstopReason internal_map_estop_reason(estop_reason_t reason)
  * @pre telemetry must point to a valid star_v1_TelemetryData struct
  * @pre telemetry->timestamp_us must already be set (used for encoder timestamps)
  * @post If k_rx_ok: all motor encoder fields populated, has_encoder_* = true
- * @post If k_rx_ok: estop_reason populated with mapped star_v1_EstopReason value
+ * @post If k_rx_ok: estop_reason set to mapped star_v1_EstopReason when estop_active; UNKNOWN otherwise
  * @post If error: motor fields left at zero-init defaults, caller handles non-fatally
  *
  * @note Non-blocking: shared_data_get_motor_state() uses a non-blocking mutex try
@@ -1840,7 +1840,11 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
 
   /* Emergency stop status and reason */
   telemetry->emergency_stop = motor_state.estop_active;
-  telemetry->estop_reason   = internal_map_estop_reason(motor_state.estop_reason);
+  if (motor_state.estop_active) {
+    telemetry->estop_reason = internal_map_estop_reason(motor_state.estop_reason);
+  } else {
+    telemetry->estop_reason = star_v1_EstopReason_ESTOP_REASON_UNKNOWN;
+  }
 
   /* Pack 4 motor fault bytes into single uint32_t bitfield */
   telemetry->fault_flags =

--- a/star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1719,6 +1719,72 @@ static telemetry_transport_t internal_select_transport(void)
 }
 
 /**
+ * @brief Map firmware estop_reason_t to proto star_v1_EstopReason
+ *
+ * @details
+ * Converts the firmware-internal emergency stop reason code (estop_reason_t)
+ * to the corresponding Protocol Buffer enum value (star_v1_EstopReason) for
+ * transmission to the Raspberry Pi 5. The mapping is:
+ *
+ * | estop_reason_t              | star_v1_EstopReason                        |
+ * |-----------------------------|--------------------------------------------|
+ * | k_estop_reason_none         | ESTOP_REASON_UNKNOWN (no estop active)     |
+ * | k_estop_reason_comm_timeout | ESTOP_REASON_COMM_TIMEOUT                  |
+ * | k_estop_reason_obstacle     | ESTOP_REASON_OBSTACLE                      |
+ * | k_estop_reason_driver_fault | ESTOP_REASON_FAULT                         |
+ * | k_estop_reason_overcurrent  | ESTOP_REASON_OVERCURRENT                   |
+ * | k_estop_reason_manual       | ESTOP_REASON_MANUAL                        |
+ * | (unrecognized)              | ESTOP_REASON_UNKNOWN (safe default)        |
+ *
+ * @param[in] reason Firmware estop reason code from shared_data
+ *
+ * @return star_v1_EstopReason Corresponding proto enum value
+ * @retval star_v1_EstopReason_ESTOP_REASON_UNKNOWN Unknown or no estop active
+ * @retval star_v1_EstopReason_ESTOP_REASON_MANUAL  Manual software command
+ * @retval star_v1_EstopReason_ESTOP_REASON_FAULT   Motor driver hardware fault
+ * @retval star_v1_EstopReason_ESTOP_REASON_COMM_TIMEOUT Communication timeout
+ * @retval star_v1_EstopReason_ESTOP_REASON_OBSTACLE Obstacle too close
+ * @retval star_v1_EstopReason_ESTOP_REASON_OVERCURRENT Motor overcurrent
+ *
+ * @pre reason is a valid estop_reason_t value
+ * @pre star_v1_EstopReason enum is generated from telemetry.proto
+ * @post Returns a valid star_v1_EstopReason; unrecognized input yields UNKNOWN
+ *
+ * @note Thread Safety: Pure function, no shared state accessed
+ * @note Unrecognized values fall through to UNKNOWN (fail-safe default)
+ *
+ * @see internal_populate_motor_telemetry() Caller
+ * @see estop_reason_t Firmware reason codes (shared_data.h)
+ * @see star_v1_EstopReason Proto enum (gen/star/v1/telemetry.pb.h)
+ *
+ * @since Version 1.0.0
+ *
+ * @par NASA Power of 10 Rule 5 Compliance:
+ * - Precondition 1: reason is a valid estop_reason_t value
+ * - Precondition 2: star_v1_EstopReason enum is available via telemetry.pb.h
+ * - Postcondition 1: Return value is always a valid star_v1_EstopReason
+ * - Postcondition 2: Unrecognized input safely maps to ESTOP_REASON_UNKNOWN
+ */
+static star_v1_EstopReason internal_map_estop_reason(estop_reason_t reason)
+{
+  switch (reason) {
+    case k_estop_reason_comm_timeout:
+      return star_v1_EstopReason_ESTOP_REASON_COMM_TIMEOUT;
+    case k_estop_reason_obstacle:
+      return star_v1_EstopReason_ESTOP_REASON_OBSTACLE;
+    case k_estop_reason_driver_fault:
+      return star_v1_EstopReason_ESTOP_REASON_FAULT;
+    case k_estop_reason_overcurrent:
+      return star_v1_EstopReason_ESTOP_REASON_OVERCURRENT;
+    case k_estop_reason_manual:
+      return star_v1_EstopReason_ESTOP_REASON_MANUAL;
+    case k_estop_reason_none:
+    default:
+      return star_v1_EstopReason_ESTOP_REASON_UNKNOWN;
+  }
+}
+
+/**
  * @brief Populate TelemetryData motor fields from shared motor state
  *
  * @details
@@ -1729,6 +1795,7 @@ static telemetry_transport_t internal_select_transport(void)
  *
  * Populated fields:
  * - `emergency_stop` - E-stop active flag
+ * - `estop_reason` - E-stop reason code mapped from estop_reason_t to star_v1_EstopReason
  * - `fault_flags` - 4 motor fault bytes packed into uint32_t bitfield
  * - `has_encoder_*` / `encoder_*` - 4 encoder submessages (motor_id, ticks,
  *   velocity_mps, timestamp_us) for front_left, front_right, back_left, back_right
@@ -1743,6 +1810,7 @@ static telemetry_transport_t internal_select_transport(void)
  * @pre telemetry must point to a valid star_v1_TelemetryData struct
  * @pre telemetry->timestamp_us must already be set (used for encoder timestamps)
  * @post If k_rx_ok: all motor encoder fields populated, has_encoder_* = true
+ * @post If k_rx_ok: estop_reason populated with mapped star_v1_EstopReason value
  * @post If error: motor fields left at zero-init defaults, caller handles non-fatally
  *
  * @note Non-blocking: shared_data_get_motor_state() uses a non-blocking mutex try
@@ -1750,6 +1818,7 @@ static telemetry_transport_t internal_select_transport(void)
  *
  * @see internal_collect_state() Caller - treats non-ok return as non-fatal
  * @see shared_data_get_motor_state() Shared data accessor
+ * @see internal_map_estop_reason() Maps firmware reason to proto enum
  *
  * @since Version 1.0.0
  *
@@ -1769,8 +1838,9 @@ static rx_err_t internal_populate_motor_telemetry(star_v1_TelemetryData* telemet
     return err;
   }
 
-  /* Emergency stop status */
+  /* Emergency stop status and reason */
   telemetry->emergency_stop = motor_state.estop_active;
+  telemetry->estop_reason   = internal_map_estop_reason(motor_state.estop_reason);
 
   /* Pack 4 motor fault bytes into single uint32_t bitfield */
   telemetry->fault_flags =


### PR DESCRIPTION
## Summary
- Adds `EstopReason` enum (field 9) to `TelemetryData` in `telemetry.proto` with 6 values covering all firmware estop triggers: `UNKNOWN`, `MANUAL`, `FAULT`, `COMM_TIMEOUT`, `OBSTACLE`, `OVERCURRENT`
- Wires estop reason through firmware: new `internal_map_estop_reason()` helper in `telemetry_task.c` maps `estop_reason_t` to `star_v1_EstopReason` and populates `telemetry->estop_reason` alongside the existing `emergency_stop` flag
- Wires estop reason through ROS2: `star_spi_bridge` publishes reason on `star/estop_reason` (`std_msgs/Int32`) every telemetry cycle, and includes the human-readable reason string in the `EMERGENCY STOP ACTIVE` log message via `EstopReason_Name()`
- Fixes pre-existing pre-commit bug: `buf lint`/`buf format` ran from `star-proto/` but `buf.yaml` is in `star-proto/proto/`, causing spurious CI failures on any proto-touching commit

## Test plan
- [x] `make proto-gen` succeeds: all targets (Go, TypeScript, nanopb, C++) regenerated without errors
- [x] `make build-rx72n` succeeds: firmware compiles cleanly at 215 KB text with zero warnings (-Wall -Wextra -Werror)
- [x] `colcon build --packages-select star_spi_bridge` succeeds: ROS2 node builds with zero errors or warnings
- [x] Pre-commit hook passes (including buf lint with path fix)
- [x] Proto field 9 does not conflict with any existing `TelemetryData` field number
- [x] Enum zero value ends with `_UNKNOWN` per proto style guide
- [x] `star/estop_reason` topic publishes `0` (UNKNOWN) when no estop is active, non-zero on active estop
- [x] Code review checklist:
  - [x] NASA Power of 10: `internal_map_estop_reason()` has 4 pre/postconditions, no dynamic allocation, fixed switch-based control flow
  - [x] SOLID: mapping logic isolated in single-purpose helper, not scattered across telemetry collection
  - [x] Doxygen: full documentation on `internal_map_estop_reason()` including mapping table, all retvals, pre/post conditions
  - [x] No magic numbers: all enum values named and typed
  - [x] Inclusive terminology: no legacy terms used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emergency stop events now include discrete reason codes (unknown, manual, fault, comm timeout, obstacle, overcurrent) and these codes are published alongside telemetry.

* **Chores**
  * Development scripts updated to run the protocol buffer formatting check from the repository proto directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->