### PR TITLE
fix(hal): add __RX__ guards to 9 unprotected HAL drivers (issue #406)

### DIFF
--- a/star-rx72n-firmware/libs/rx_hal/src/adc.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/adc.c
@@ -151,6 +151,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include <string.h>
 
 #include "hardware.h"
@@ -992,3 +994,5 @@ rx_err_t adc_read_voltage_mv(const adc_unit_t unit,
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/gpio.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/gpio.c
@@ -155,6 +155,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include <stddef.h>
 
 #include "hardware.h"
@@ -870,3 +872,5 @@ rx_err_t gpio_read(const rx_port_pin_t pin, bool* value)
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/riic.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/riic.c
@@ -206,6 +206,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+#ifdef __RX__
+
 #include <string.h>
 
 #include "hardware.h"
@@ -1985,3 +1987,5 @@ rx_err_t riic_write_read(const riic_channel_t    channel,
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/rspi.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/rspi.c
@@ -140,6 +140,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include <stdint.h>
 #include <string.h>
 
@@ -1779,3 +1781,5 @@ rx_err_t rspi_controller_deinit(const rspi_channel_t channel)
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/rx_cmt.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/rx_cmt.c
@@ -139,6 +139,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include "rx_cmt.h"
 
 #include <stddef.h>
@@ -1500,3 +1502,5 @@ rx_err_t rx_cmt_deinit(const rx_cmt_channel_t channel)
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/rx_gptw.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/rx_gptw.c
@@ -109,6 +109,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include "rx_gptw.h"
 
 #include <stddef.h>
@@ -2029,3 +2031,5 @@ rx_err_t rx_gptw_deinit(const rx_gptw_channel_t channel)
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/rx_mtu.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/rx_mtu.c
@@ -103,6 +103,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include "rx_mtu.h"
 
 #include <stddef.h>
@@ -1214,3 +1216,5 @@ rx_err_t rx_mtu_deinit(const rx_mtu_channel_t channel)
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/timer.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/timer.c
@@ -185,6 +185,8 @@
  * SPDX-License-Identifier: MIT
  */
 
+#ifdef __RX__
+
 #include <stdint.h>
 
 #include "hardware.h"
@@ -1024,3 +1026,5 @@ rx_err_t timer_get_count(uint16_t* count)
 
   return k_rx_ok;
 }
+
+#endif /* __RX__ */

--- a/star-rx72n-firmware/libs/rx_hal/src/uart.c
+++ b/star-rx72n-firmware/libs/rx_hal/src/uart.c
@@ -201,6 +201,8 @@
  * @since Version 1.0.0
  */
 
+#ifdef __RX__
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -2196,3 +2198,5 @@ void uart_debug_puthex(const uint32_t value, uint8_t digits)
 }
 
 #endif /* !RX_IS_SIMULATOR */
+
+#endif /* __RX__ */


### PR DESCRIPTION
## Summary

- Wraps the entire body of each hardware-only HAL source file in `#ifdef __RX__` / `#endif /* __RX__ */` to prevent accidental host-side inclusion from pulling in RX72N memory-mapped register definitions
- Pattern mirrors the existing `rx_crc_hw.c` approach; host builds continue to use the already-present mocks (`mock_gpio_hal`, `mock_adc_hal`, `mock_riic_hal`, `mock_uart_hw`, `mock_rx_gptw`, `mock_rspi`, `mock_rx_mtu_encoder`)
- Implements Option A from the issue (fast, defensive); all 9 files covered in a single commit

**Affected files:**
`adc.c`, `gpio.c`, `riic.c`, `rspi.c`, `rx_cmt.c`, `rx_gptw.c`, `rx_mtu.c`, `timer.c`, `uart.c`

Closes #406

## Test plan

- [x] GNURX cross-compile clean (`bash build.sh`)
- [x] All 51 unit tests pass (`ctest --output-on-failure`)
- [x] `make format-rx72n` — no changes needed
- [x] Code review checklist:
  - [x] NASA Power of 10 rules followed
  - [x] Pattern consistent with existing guarded files (`rx_crc_hw.c`, `rx_irq_filter.c`, `rx_iwdt.c`)
  - [x] No functional changes — guard-only addition
  - [x] Mocks already handle host builds; no new mocks required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Applied conditional compilation guards to hardware abstraction layer modules, enabling selective compilation based on build configuration. No functional or API behavior changes; code logic remains unchanged when compiled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->