### PR TITLE
fix(imu): perform hardware reset via P83 before BNO055 init (issue #420)

### DIFF
--- a/star-rx72n-firmware/libs/rx_bno055/inc/rx_bno055.h
+++ b/star-rx72n-firmware/libs/rx_bno055/inc/rx_bno055.h
@@ -268,6 +268,9 @@ typedef struct {
  * @retval k_rx_err_invalid_state CHIP_ID mismatch (wrong device or I2C issue)
  * @retval k_rx_err_timeout I2C transaction timeout
  *
+ * @pre Caller must have completed hardware reset via P83 (IMU RST, active-low):
+ *      assert LOW for >= 10 ms, deassert HIGH, wait >= 650 ms for POR to complete.
+ *      See internal_imu_hardware_reset() in imu_task.c.
  * @pre manager must be initialized via rx_bus_manager_init()
  * @pre "i2c1" bus must be registered and initialized in manager
  * @pre RIIC1 hardware initialized by hardware_init() (riic_init)

--- a/star-rx72n-firmware/libs/rx_bno055/inc/rx_bno055.h
+++ b/star-rx72n-firmware/libs/rx_bno055/inc/rx_bno055.h
@@ -40,9 +40,14 @@
  *
  * # Initialization Sequence
  *
- * The rx_bno055_init() function performs the following steps:
+ * Before calling rx_bno055_init(), the caller (imu_task.c) performs a hardware
+ * reset via P83 (IMU RST, active-low): assert LOW for >= 10 ms, then deassert
+ * HIGH and wait 650 ms for the BNO055 POR sequence to complete. See
+ * internal_imu_hardware_reset() in imu_task.c.
  *
- * 1. Software reset (SYS_TRIGGER = 0x20), wait 650 ms
+ * The rx_bno055_init() function then performs the following steps:
+ *
+ * 1. Software reset (SYS_TRIGGER = 0x20), wait 650 ms (belt-and-suspenders)
  * 2. Set CONFIG mode (OPR_MODE = 0x00), wait 19 ms
  * 3. Set normal power mode (PWR_MODE = 0x00)
  * 4. Set default units (UNIT_SEL = 0x00)

--- a/star-rx72n-firmware/src/tasks/imu_task.c
+++ b/star-rx72n-firmware/src/tasks/imu_task.c
@@ -66,11 +66,13 @@
 
 #include "imu_task.h"
 
+#include "hardware.h"
 #include "rx_bmp280.h"
 #include "rx_bno055.h"
 #include "rx_check.h"
 #include "rx_iwdt.h"
 #include "rx_log.h"
+#include "rx_port_constants.h"
 #include "shared_data.h"
 #include "tx_api.h"
 
@@ -128,6 +130,33 @@ typedef enum : uint8_t {
 typedef enum : uint16_t {
   k_imu_ms_per_second = 1000U, /**< Milliseconds per second (conversion factor for tick->ms) */
 } imu_task_time_t;
+
+/**
+ * @enum imu_task_hw_rst_t
+ * @brief BNO055 hardware reset timing constants (P83/IMU RST, active-low)
+ *
+ * @details
+ * Defines the ThreadX tick counts for the two delays in the BNO055 hardware
+ * reset sequence performed via P83 (IMU RST, active-low, pin 58):
+ *
+ * 1. Assert RST LOW for k_imu_hw_rst_assert_ticks ticks (>= 10 ms per BNO055 datasheet)
+ * 2. Deassert RST HIGH, then wait k_imu_hw_rst_por_ticks ticks for POR to complete (650 ms)
+ *
+ * At 100 Hz tick rate: 1 tick = 10 ms, 65 ticks = 650 ms.
+ *
+ * @invariant k_imu_hw_rst_assert_ticks >= 1 (minimum 10 ms hold)
+ * @invariant k_imu_hw_rst_por_ticks >= 65 (BNO055 POR requires 650 ms)
+ *
+ * @see internal_imu_hardware_reset() Consumer of these constants
+ * @see hardware_config.h k_imu_rst_port, k_imu_rst_pin for P83 pin assignment
+ *
+ * @since Version 1.0.0
+ */
+typedef enum : uint8_t {
+  k_imu_hw_rst_assert_ticks = 1U,  /**< RST assert duration: 1 tick = 10 ms (>= 10 ms minimum) */
+  k_imu_hw_rst_por_ticks    = 65U, /**< POR wait after deassert: 65 ticks = 650 ms */
+} imu_task_hw_rst_t;
+
 static_assert(TX_TIMER_TICKS_PER_SECOND != 0U, "TX_TIMER_TICKS_PER_SECOND must be non-zero");
 static_assert(k_imu_ms_per_second > 0U, "k_imu_ms_per_second must be positive");
 static_assert(((uint32_t)k_imu_task_period_ms * (uint32_t)TX_TIMER_TICKS_PER_SECOND) %
@@ -229,6 +258,7 @@ static void internal_retry_sensor_init(bool* bno_ready, bool* bmp_ready);
 static void internal_handle_loop_sleep(ULONG start_tick);
 static void internal_read_and_publish_imu(void);
 static void internal_read_and_publish_baro(void);
+static void internal_imu_hardware_reset(void);
 static void internal_imu_task_entry(ULONG input);
 
 /* =============================================================================
@@ -554,13 +584,76 @@ static void internal_read_and_publish_baro(void)
 }
 
 /**
+ * @brief Assert hardware reset on BNO055 via P83 (IMU RST, active-low) before I2C init
+ *
+ * @details
+ * Performs a hardware reset of the BNO055 by toggling P83 (IMU RST, active-low, pin 58)
+ * per the BNO055 datasheet and the STAR hardware pinout specification. This guarantees a
+ * clean sensor state regardless of the MCU reset type (power-on, warm reset, watchdog).
+ *
+ * ## Reset Sequence
+ *
+ * 1. Assert RST LOW (P83 = 0) -- BNO055 enters reset
+ * 2. Wait k_imu_hw_rst_assert_ticks ticks (1 tick = 10 ms, satisfies >= 10 ms minimum)
+ * 3. Deassert RST HIGH (P83 = 1) -- BNO055 released from reset
+ * 4. Wait k_imu_hw_rst_por_ticks ticks (65 ticks = 650 ms) for BNO055 POR to complete
+ *
+ * After this function returns, rx_bno055_init() may proceed immediately with I2C
+ * communication. The internal software reset inside rx_bno055_init() is kept as
+ * belt-and-suspenders but the hardware reset here is the authoritative reset.
+ *
+ * @pre s_imu_created == true (imu_task_create() completed)
+ * @pre P83 configured as GPIO output by hardware_init.c internal_gpio_init_imu()
+ * @post BNO055 has completed POR sequence, ready for I2C communication
+ * @post P83 is HIGH (deasserted, BNO055 running)
+ *
+ * @note Blocks ~660 ms total: 10 ms assert + 650 ms POR wait
+ * @note Not thread-safe; called only from internal_imu_task_entry()
+ *
+ * @warning Must be called before rx_bno055_init(); calling after will disrupt I2C
+ *
+ * @see hardware_config.h k_imu_rst_port / k_imu_rst_pin for P83 pin assignment
+ * @see rx_port_constants.h k_rx_p8_3 for the combined port/pin constant
+ * @see imu_task_hw_rst_t Timing constants for assert and POR delays
+ * @see rx_bno055_init() Called immediately after this function in internal_imu_task_entry()
+ *
+ * @since Version 1.0.0
+ */
+static void internal_imu_hardware_reset(void)
+{
+  RX_ASSERT(s_imu_created, "IMU task must be created before hardware reset");
+  RX_ASSERT(s_tag != NULL, "s_tag must not be NULL");
+
+  /* Assert RST LOW -- BNO055 enters hardware reset (active-low) */
+  const rx_err_t err_low = gpio_write_low((rx_port_pin_t)k_rx_p8_3);
+  if (err_low != k_rx_ok) {
+    rx_log_error_val(s_tag, "IMU RST assert low failed", (uint32_t)err_low);
+  }
+
+  /* Hold RST LOW for >= 10 ms (1 tick = 10 ms at 100 Hz tick rate) */
+  (void)tx_thread_sleep((ULONG)k_imu_hw_rst_assert_ticks);
+
+  /* Deassert RST HIGH -- BNO055 released from reset, POR sequence begins */
+  const rx_err_t err_high = gpio_write_high((rx_port_pin_t)k_rx_p8_3);
+  if (err_high != k_rx_ok) {
+    rx_log_error_val(s_tag, "IMU RST deassert high failed", (uint32_t)err_high);
+  }
+
+  /* Wait 650 ms for BNO055 POR sequence to complete before I2C communication */
+  (void)tx_thread_sleep((ULONG)k_imu_hw_rst_por_ticks);
+
+  rx_log_info(s_tag, "BNO055 hardware reset complete");
+}
+
+/**
  * @brief IMU task entry point - initialize sensors then poll at 20 Hz
  *
  * @details
  * Task startup sequence:
- * 1. Initialize BNO055 via rx_bno055_init() (~700 ms for POR)
- * 2. Initialize BMP280 via rx_bmp280_init() (~2 ms for calib read)
- * 3. Enter 50 ms periodic loop:
+ * 1. Hardware reset BNO055 via P83 (IMU RST, active-low) -- 10 ms assert + 650 ms POR
+ * 2. Initialize BNO055 via rx_bno055_init() (~700 ms for software reset + config)
+ * 3. Initialize BMP280 via rx_bmp280_init() (~2 ms for calib read)
+ * 4. Enter 50 ms periodic loop:
  *    a. Feed IWDT heartbeat FIRST (must precede any blocking sensor re-init)
  *    b. Retry init for any sensor that failed startup (until success)
  *    c. internal_read_and_publish_imu() if bno_ready - BNO055 -> shared_data_update_imu()
@@ -579,7 +672,7 @@ static void internal_read_and_publish_baro(void)
  * @pre "i2c1" bus registered in g_bus_manager (registered by main.c)
  * @pre RIIC1 initialized at 400 kHz (by hardware_init.c i2c_init)
  * @pre shared_data_init() completed (imu_mutex and baro_mutex available)
- * @pre BNO055 powered on RIIC1 I2C bus, RST pin driven HIGH (not in reset)
+ * @pre BNO055 powered on RIIC1 I2C bus, RST pin (P83) configured as GPIO output
  * @pre BMP280 powered on RIIC1 I2C bus
  *
  * @post imu_state_t updated via shared_data_update_imu() at 20 Hz on success
@@ -589,7 +682,7 @@ static void internal_read_and_publish_baro(void)
  *
  * @note Not thread-safe; runs as single dedicated ThreadX task
  * @note Sensor init failures do not halt the task; valid flag stays false
- * @note BNO055 POR delay (~700 ms) blocks this task during startup only
+ * @note BNO055 hardware reset (~660 ms) + software POR (~700 ms) block at startup only
  * @note Does not preempt motor control (priority 8) or obstacle detect (12)
  *
  * @warning Do not call directly; use imu_task_create() to register with ThreadX
@@ -597,6 +690,7 @@ static void internal_read_and_publish_baro(void)
  * @see imu_task_create() Creates this task
  * @see internal_read_and_publish_imu() BNO055 read and publish helper
  * @see internal_read_and_publish_baro() BMP280 read and publish helper
+ * @see internal_imu_hardware_reset() Hardware reset helper (step 1)
  * @see rx_bno055_init() BNO055 initialization
  * @see rx_bmp280_init() BMP280 initialization
  *
@@ -611,7 +705,11 @@ static void internal_imu_task_entry(ULONG input)
 
   rx_log_info(s_tag, "IMU task starting - initializing sensors");
 
-  /* Step 1: Initialize BNO055 (blocks ~700 ms for POR sequence) */
+  /* Step 1: Hardware reset BNO055 via P83 (IMU RST, active-low) to guarantee clean state.
+   * Asserts RST LOW for 10 ms then releases; waits 650 ms for POR to complete. */
+  internal_imu_hardware_reset();
+
+  /* Step 2: Initialize BNO055 (software reset + config, blocks ~700 ms) */
   bool           bno_ready = false;
   const rx_err_t err_bno   = rx_bno055_init(&g_bus_manager);
   if (err_bno != k_rx_ok) {
@@ -621,7 +719,7 @@ static void internal_imu_task_entry(ULONG input)
     rx_log_info(s_tag, "BNO055 initialized in NDOF mode");
   }
 
-  /* Step 2: Initialize BMP280 (~2 ms for calibration burst read) */
+  /* Step 3: Initialize BMP280 (~2 ms for calibration burst read) */
   bool           bmp_ready = false;
   const rx_err_t err_bmp   = rx_bmp280_init(&g_bus_manager);
   if (err_bmp != k_rx_ok) {
@@ -633,7 +731,7 @@ static void internal_imu_task_entry(ULONG input)
 
   rx_log_info(s_tag, "IMU polling at 20 Hz");
 
-  /* Step 3: Periodic poll loop at 20 Hz (50 ms period = 5 ticks @ 100 Hz) */
+  /* Step 4: Periodic poll loop at 20 Hz (50 ms period = 5 ticks @ 100 Hz) */
   while (1) {
     const ULONG start_tick = tx_time_get();
 

--- a/star-rx72n-firmware/src/tasks/imu_task.c
+++ b/star-rx72n-firmware/src/tasks/imu_task.c
@@ -132,29 +132,60 @@ typedef enum : uint16_t {
 } imu_task_time_t;
 
 /**
+ * @enum imu_task_hw_rst_ms_t
+ * @brief BNO055 hardware reset minimum durations in milliseconds (from datasheet)
+ *
+ * @details
+ * Source values in milliseconds for the two delays in the BNO055 hardware
+ * reset sequence, used to compute the tick counts in imu_task_hw_rst_t.
+ *
+ * | Constant                  | Value | Source |
+ * |---------------------------|-------|--------|
+ * | k_imu_hw_rst_assert_ms    | 10    | BNO055 datasheet: RST active-low min hold |
+ * | k_imu_hw_rst_por_ms       | 650   | BNO055 datasheet: POR completion time |
+ *
+ * @see imu_task_hw_rst_t Derived tick counts (with +1 slack per tick)
+ * @since Version 1.0.0
+ */
+typedef enum : uint16_t {
+  k_imu_hw_rst_assert_ms = 10U,  /**< Min RST assert duration: 10 ms per BNO055 datasheet */
+  k_imu_hw_rst_por_ms    = 650U, /**< Min POR completion wait: 650 ms per BNO055 datasheet */
+} imu_task_hw_rst_ms_t;
+
+/**
  * @enum imu_task_hw_rst_t
- * @brief BNO055 hardware reset timing constants (P83/IMU RST, active-low)
+ * @brief BNO055 hardware reset timing constants in ThreadX ticks (P83/IMU RST, active-low)
  *
  * @details
  * Defines the ThreadX tick counts for the two delays in the BNO055 hardware
- * reset sequence performed via P83 (IMU RST, active-low, pin 58):
+ * reset sequence performed via P83 (IMU RST, active-low, pin 58).
  *
- * 1. Assert RST LOW for k_imu_hw_rst_assert_ticks ticks (>= 10 ms per BNO055 datasheet)
- * 2. Deassert RST HIGH, then wait k_imu_hw_rst_por_ticks ticks for POR to complete (650 ms)
+ * tx_thread_sleep() may complete up to one full tick early, so each value adds
+ * one extra tick of slack using the formula:
+ *   ticks = ceil(ms * TX_TIMER_TICKS_PER_SECOND / 1000) + 1
+ *         = (ms * TX_TIMER_TICKS_PER_SECOND + 999) / 1000 + 1
  *
- * At 100 Hz tick rate: 1 tick = 10 ms, 65 ticks = 650 ms.
+ * At TX_TIMER_TICKS_PER_SECOND = 100 Hz:
+ * | Constant                  | Formula result | Guaranteed minimum |
+ * |---------------------------|----------------|--------------------|
+ * | k_imu_hw_rst_assert_ticks | 2 ticks        | 10 ms              |
+ * | k_imu_hw_rst_por_ticks    | 66 ticks       | 650 ms             |
  *
- * @invariant k_imu_hw_rst_assert_ticks >= 1 (minimum 10 ms hold)
- * @invariant k_imu_hw_rst_por_ticks >= 65 (BNO055 POR requires 650 ms)
+ * @invariant k_imu_hw_rst_assert_ticks >= 2 (ceil(10 ms / tick) + 1 slack)
+ * @invariant k_imu_hw_rst_por_ticks >= 66 (ceil(650 ms / tick) + 1 slack)
  *
+ * @see imu_task_hw_rst_ms_t Source millisecond values
  * @see internal_imu_hardware_reset() Consumer of these constants
  * @see hardware_config.h k_imu_rst_port, k_imu_rst_pin for P83 pin assignment
  *
  * @since Version 1.0.0
  */
 typedef enum : uint8_t {
-  k_imu_hw_rst_assert_ticks = 1U,  /**< RST assert duration: 1 tick = 10 ms (>= 10 ms minimum) */
-  k_imu_hw_rst_por_ticks    = 65U, /**< POR wait after deassert: 65 ticks = 650 ms */
+  /** @brief RST assert duration: ceil(10 ms * 100 Hz / 1000) + 1 = 2 ticks */
+  k_imu_hw_rst_assert_ticks =
+    (k_imu_hw_rst_assert_ms * TX_TIMER_TICKS_PER_SECOND + 999U) / 1000U + 1U,
+  /** @brief POR wait after deassert: ceil(650 ms * 100 Hz / 1000) + 1 = 66 ticks */
+  k_imu_hw_rst_por_ticks = (k_imu_hw_rst_por_ms * TX_TIMER_TICKS_PER_SECOND + 999U) / 1000U + 1U,
 } imu_task_hw_rst_t;
 
 static_assert(TX_TIMER_TICKS_PER_SECOND != 0U, "TX_TIMER_TICKS_PER_SECOND must be non-zero");
@@ -253,13 +284,13 @@ extern rx_bus_manager_t
  * =============================================================================
  */
 
-static void internal_send_iwdt_heartbeat(void);
-static void internal_retry_sensor_init(bool* bno_ready, bool* bmp_ready);
-static void internal_handle_loop_sleep(ULONG start_tick);
-static void internal_read_and_publish_imu(void);
-static void internal_read_and_publish_baro(void);
-static void internal_imu_hardware_reset(void);
-static void internal_imu_task_entry(ULONG input);
+static void     internal_send_iwdt_heartbeat(void);
+static void     internal_retry_sensor_init(bool* bno_ready, bool* bmp_ready);
+static void     internal_handle_loop_sleep(ULONG start_tick);
+static void     internal_read_and_publish_imu(void);
+static void     internal_read_and_publish_baro(void);
+static rx_err_t internal_imu_hardware_reset(void);
+static void     internal_imu_task_entry(ULONG input);
 
 /* =============================================================================
  * Static Inline Helpers
@@ -593,33 +624,43 @@ static void internal_read_and_publish_baro(void)
  *
  * ## Reset Sequence
  *
- * 1. Assert RST LOW (P83 = 0) -- BNO055 enters reset
- * 2. Wait k_imu_hw_rst_assert_ticks ticks (1 tick = 10 ms, satisfies >= 10 ms minimum)
- * 3. Deassert RST HIGH (P83 = 1) -- BNO055 released from reset
- * 4. Wait k_imu_hw_rst_por_ticks ticks (65 ticks = 650 ms) for BNO055 POR to complete
+ * 1. Assert RST LOW (P83 = 0) -- BNO055 enters reset; abort on GPIO failure
+ * 2. Wait k_imu_hw_rst_assert_ticks ticks (2 ticks, guaranteed >= 10 ms with +1 slack)
+ * 3. Deassert RST HIGH (P83 = 1) -- BNO055 released from reset; abort on GPIO failure
+ * 4. Wait k_imu_hw_rst_por_ticks ticks (66 ticks, guaranteed >= 650 ms with +1 slack)
  *
- * After this function returns, rx_bno055_init() may proceed immediately with I2C
+ * Returns k_rx_ok after step 4. Returns the GPIO error code immediately if either
+ * gpio_write_low or gpio_write_high fails (steps 1 or 3 respectively).
+ *
+ * After this function returns k_rx_ok, rx_bno055_init() may proceed immediately with I2C
  * communication. The internal software reset inside rx_bno055_init() is kept as
  * belt-and-suspenders but the hardware reset here is the authoritative reset.
  *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok Reset sequence completed; BNO055 POR done, ready for I2C
+ * @retval k_rx_err_hw_init_failed GPIO drive low failed (RST stuck HIGH)
+ * @retval k_rx_err_timeout GPIO drive high failed (RST stuck LOW, BNO055 held in reset)
+ *
  * @pre s_imu_created == true (imu_task_create() completed)
  * @pre P83 configured as GPIO output by hardware_init.c internal_gpio_init_imu()
- * @post BNO055 has completed POR sequence, ready for I2C communication
- * @post P83 is HIGH (deasserted, BNO055 running)
+ * @post On k_rx_ok: BNO055 has completed POR sequence, ready for I2C communication
+ * @post On k_rx_ok: P83 is HIGH (deasserted, BNO055 running)
+ * @post On error: P83 state undefined; BNO055 init should be skipped
  *
- * @note Blocks ~660 ms total: 10 ms assert + 650 ms POR wait
+ * @note Blocks ~670 ms total on success: 20 ms assert + 660 ms POR wait (+1 slack each)
  * @note Not thread-safe; called only from internal_imu_task_entry()
  *
  * @warning Must be called before rx_bno055_init(); calling after will disrupt I2C
+ * @warning Caller must check return value before proceeding to rx_bno055_init()
  *
  * @see hardware_config.h k_imu_rst_port / k_imu_rst_pin for P83 pin assignment
  * @see rx_port_constants.h k_rx_p8_3 for the combined port/pin constant
- * @see imu_task_hw_rst_t Timing constants for assert and POR delays
+ * @see imu_task_hw_rst_t Timing constants for assert and POR delays (with +1 slack)
  * @see rx_bno055_init() Called immediately after this function in internal_imu_task_entry()
  *
  * @since Version 1.0.0
  */
-static void internal_imu_hardware_reset(void)
+static rx_err_t internal_imu_hardware_reset(void)
 {
   RX_ASSERT(s_imu_created, "IMU task must be created before hardware reset");
   RX_ASSERT(s_tag != NULL, "s_tag must not be NULL");
@@ -628,21 +669,24 @@ static void internal_imu_hardware_reset(void)
   const rx_err_t err_low = gpio_write_low((rx_port_pin_t)k_rx_p8_3);
   if (err_low != k_rx_ok) {
     rx_log_error_val(s_tag, "IMU RST assert low failed", (uint32_t)err_low);
+    return err_low;
   }
 
-  /* Hold RST LOW for >= 10 ms (1 tick = 10 ms at 100 Hz tick rate) */
+  /* Hold RST LOW for guaranteed >= 10 ms (+1 tick slack for early wake) */
   (void)tx_thread_sleep((ULONG)k_imu_hw_rst_assert_ticks);
 
   /* Deassert RST HIGH -- BNO055 released from reset, POR sequence begins */
   const rx_err_t err_high = gpio_write_high((rx_port_pin_t)k_rx_p8_3);
   if (err_high != k_rx_ok) {
     rx_log_error_val(s_tag, "IMU RST deassert high failed", (uint32_t)err_high);
+    return err_high;
   }
 
-  /* Wait 650 ms for BNO055 POR sequence to complete before I2C communication */
+  /* Wait guaranteed >= 650 ms for BNO055 POR to complete (+1 tick slack) */
   (void)tx_thread_sleep((ULONG)k_imu_hw_rst_por_ticks);
 
   rx_log_info(s_tag, "BNO055 hardware reset complete");
+  return k_rx_ok;
 }
 
 /**
@@ -650,10 +694,15 @@ static void internal_imu_hardware_reset(void)
  *
  * @details
  * Task startup sequence:
- * 1. Hardware reset BNO055 via P83 (IMU RST, active-low) -- 10 ms assert + 650 ms POR
- * 2. Initialize BNO055 via rx_bno055_init() (~700 ms for software reset + config)
- * 3. Initialize BMP280 via rx_bmp280_init() (~2 ms for calib read)
- * 4. Enter 50 ms periodic loop:
+ * 1. Feed IWDT heartbeat before the long startup sequence (~1.37 s total)
+ * 2. Hardware reset BNO055 via P83 (IMU RST, active-low):
+ *    >= 10 ms assert + >= 650 ms POR (with +1 tick slack each)
+ * 3. Feed IWDT heartbeat after hardware reset
+ * 4. Initialize BNO055 via rx_bno055_init() (~700 ms for software reset + config)
+ *    (skipped if hardware reset failed)
+ * 5. Feed IWDT heartbeat after BNO055 init
+ * 6. Initialize BMP280 via rx_bmp280_init() (~2 ms for calib read)
+ * 7. Enter 50 ms periodic loop:
  *    a. Feed IWDT heartbeat FIRST (must precede any blocking sensor re-init)
  *    b. Retry init for any sensor that failed startup (until success)
  *    c. internal_read_and_publish_imu() if bno_ready - BNO055 -> shared_data_update_imu()
@@ -682,7 +731,7 @@ static void internal_imu_hardware_reset(void)
  *
  * @note Not thread-safe; runs as single dedicated ThreadX task
  * @note Sensor init failures do not halt the task; valid flag stays false
- * @note BNO055 hardware reset (~660 ms) + software POR (~700 ms) block at startup only
+ * @note BNO055 hardware reset (~670 ms) + software init (~700 ms) block at startup only; IWDT fed between each
  * @note Does not preempt motor control (priority 8) or obstacle detect (12)
  *
  * @warning Do not call directly; use imu_task_create() to register with ThreadX
@@ -705,19 +754,35 @@ static void internal_imu_task_entry(ULONG input)
 
   rx_log_info(s_tag, "IMU task starting - initializing sensors");
 
+  /* Feed watchdog before the long startup sequence (~1.37 s total) so the IWDT
+   * registration window is refreshed and the system does not reset during init. */
+  internal_send_iwdt_heartbeat();
+
   /* Step 1: Hardware reset BNO055 via P83 (IMU RST, active-low) to guarantee clean state.
-   * Asserts RST LOW for 10 ms then releases; waits 650 ms for POR to complete. */
-  internal_imu_hardware_reset();
+   * Asserts RST LOW for >= 10 ms then releases; waits >= 650 ms for POR to complete. */
+  bool           bno_ready = false;
+  const rx_err_t err_rst   = internal_imu_hardware_reset();
+  if (err_rst != k_rx_ok) {
+    rx_log_error_val(s_tag, "BNO055 HW reset failed - will skip init", (uint32_t)err_rst);
+  }
+
+  /* Feed watchdog after the hardware reset block (~670 ms) before BNO055 software
+   * init (~700 ms) to prevent IWDT expiry during the combined ~1.37 s startup. */
+  internal_send_iwdt_heartbeat();
 
   /* Step 2: Initialize BNO055 (software reset + config, blocks ~700 ms) */
-  bool           bno_ready = false;
-  const rx_err_t err_bno   = rx_bno055_init(&g_bus_manager);
-  if (err_bno != k_rx_ok) {
-    rx_log_error_val(s_tag, "BNO055 init failed - will retry in loop", (uint32_t)err_bno);
-  } else {
-    bno_ready = true;
-    rx_log_info(s_tag, "BNO055 initialized in NDOF mode");
+  if (err_rst == k_rx_ok) {
+    const rx_err_t err_bno = rx_bno055_init(&g_bus_manager);
+    if (err_bno != k_rx_ok) {
+      rx_log_error_val(s_tag, "BNO055 init failed - will retry in loop", (uint32_t)err_bno);
+    } else {
+      bno_ready = true;
+      rx_log_info(s_tag, "BNO055 initialized in NDOF mode");
+    }
   }
+
+  /* Feed watchdog after BNO055 init before BMP280 init */
+  internal_send_iwdt_heartbeat();
 
   /* Step 3: Initialize BMP280 (~2 ms for calibration burst read) */
   bool           bmp_ready = false;


### PR DESCRIPTION
## Summary

- Adds `internal_imu_hardware_reset()` to `imu_task.c` that asserts P83 (IMU RST, active-low) LOW for 10 ms then deasserts HIGH and waits 650 ms for the BNO055 POR sequence to complete
- Called before `rx_bno055_init()` in `internal_imu_task_entry()`, guaranteeing a clean sensor state on every boot regardless of MCU reset type
- Adds `imu_task_hw_rst_t` C23 typed enum for the assert/POR tick constants (no magic numbers)
- Updates `rx_bno055.h` init sequence docs to document the hardware reset as a prerequisite step

## Why

Previously `hardware_init.c` only set P83 HIGH at boot and never toggled it. `rx_bno055_init()` relied solely on a SYS_TRIGGER software reset which can fail if the BNO055 is in an undefined state (e.g. after a warm reset or watchdog reset of the RX72N without cycling IMU power). The hardware pinout spec explicitly requires: *"Assert RST low for >= 10 ms at startup to perform a hardware reset before initialisation."*

## Test plan

- [x] GNURX cross-compile: clean (`build.sh`)
- [x] Unit tests: 51/51 pass (`ctest`)
- [ ] Hardware validation: confirm BNO055 initialises reliably after warm reset on target board

Closes #420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented hardware reset procedure for the IMU sensor during system startup.

* **Documentation**
  * Clarified pre-initialization and initialization steps for the IMU module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->