### PR TITLE
fix(imu): rename I2C bus "i2c1" to "i2c1_imu" for consistency (issue #415)

### DIFF
--- a/star-rx72n-firmware/libs/rx_bno055/inc/rx_bno055.h
+++ b/star-rx72n-firmware/libs/rx_bno055/inc/rx_bno055.h
@@ -28,7 +28,7 @@
  * - **Module**: DFRobot BNO055 breakout
  * - **I2C Address**: 0x28 (COM3/ADR pulled LOW)
  * - **I2C Bus**: RIIC1 (SCL1=P2.1, SDA1=P2.0)
- * - **Bus name in bus manager**: "i2c1"
+ * - **Bus name in bus manager**: "i2c1_imu"
  * - **Reset pin**: P8.3 (active-low, driven HIGH by hardware_init)
  *
  * # Operating Mode
@@ -253,7 +253,7 @@ typedef struct {
  * BNO055 instance (no multi-instance support needed for STAR hardware).
  *
  * @param[in] manager Pointer to initialized bus manager.
- *                    Must have "i2c1" bus registered and initialized.
+ *                    Must have "i2c1_imu" bus registered and initialized.
  *                    Must not be NULL.
  *
  * @return rx_err_t Initialization result
@@ -264,7 +264,7 @@ typedef struct {
  * @retval k_rx_err_timeout I2C transaction timeout
  *
  * @pre manager must be initialized via rx_bus_manager_init()
- * @pre "i2c1" bus must be registered and initialized in manager
+ * @pre "i2c1_imu" bus must be registered and initialized in manager
  * @pre RIIC1 hardware initialized by hardware_init() (riic_init)
  * @pre BNO055 powered and connected to I2C bus
  *

--- a/star-rx72n-firmware/libs/rx_bno055/src/rx_bno055.c
+++ b/star-rx72n-firmware/libs/rx_bno055/src/rx_bno055.c
@@ -20,8 +20,8 @@
  * - internal_write_reg(): Writes a single byte to a register
  * - internal_read_regs(): Burst reads N consecutive registers
  *
- * Both helpers use the bus manager abstraction with bus name "i2c1".
- * The device address 0x28 is embedded in the "i2c1" bus configuration
+ * Both helpers use the bus manager abstraction with bus name "i2c1_imu".
+ * The device address 0x28 is embedded in the "i2c1_imu" bus configuration
  * registered by main.c.
  *
  * # Data Flow
@@ -175,12 +175,12 @@ static bool s_initialized = false;
  * The name must match the bus name registered in main.c via rx_bus_manager_register().
  * Passed to rx_bus_manager_get_i2c() to obtain the I2C bus handle.
  *
- * @note Must match the name registered in main.c (currently "i2c1")
+ * @note Must match the name registered in main.c (currently "i2c1_imu")
  * @warning Do not modify; changing the name at runtime will cause bus lookup failures
  *
  * @since Version 1.0.0
  */
-static const char* const s_bus_name = "i2c1";
+static const char* const s_bus_name = "i2c1_imu";
 
 /* =============================================================================
  * Module-level Offset Constants
@@ -355,7 +355,7 @@ static rx_err_t       internal_verify_chip_id(void);
  *
  * @details
  * Sends a 2-byte I2C write transaction [reg, val] to the BNO055 at
- * device address 0x28 (embedded in the "i2c1" bus configuration).
+ * device address 0x28 (embedded in the "i2c1_imu" bus configuration).
  *
  * @param[in] reg Register address (from bno055_reg_t)
  * @param[in] val Byte value to write to the register
@@ -366,7 +366,7 @@ static rx_err_t       internal_verify_chip_id(void);
  * @retval k_rx_err_timeout Transaction timeout
  *
  * @pre s_manager must be non-NULL (set by rx_bno055_init)
- * @pre "i2c1" bus must be initialized
+ * @pre "i2c1_imu" bus must be initialized
  * @post Register at address reg contains value val (if k_rx_ok)
  * @post Bus transaction completes before function returns
  *
@@ -405,7 +405,7 @@ static rx_err_t internal_write_reg(uint8_t reg, uint8_t val)
  * @retval k_rx_err_timeout Transaction timeout
  *
  * @pre s_manager must be non-NULL (set by rx_bno055_init)
- * @pre "i2c1" bus must be initialized
+ * @pre "i2c1_imu" bus must be initialized
  * @pre buf must have capacity for len bytes
  * @post buf[0..len-1] contain register data starting at reg (if k_rx_ok)
  * @post Bus transaction completes before function returns
@@ -479,7 +479,7 @@ static inline int16_t internal_assemble_int16_le(uint8_t low, uint8_t high)
  * @retval k_rx_err_timeout I2C timeout
  *
  * @pre s_manager non-NULL
- * @pre "i2c1" bus initialized
+ * @pre "i2c1_imu" bus initialized
  * @post Sensor in CONFIG mode, ready for configuration register writes
  * @post ~670 ms elapsed (650 ms POR + 20 ms CONFIG transition)
  *
@@ -702,7 +702,7 @@ static rx_err_t internal_verify_chip_id(void)
  * - 19 ms config: 19/10 + 1 = 2 ticks (20 ms, rounded up for margin)
  * - 7 ms NDOF: 1 tick (10 ms, rounded up for margin)
  *
- * @param[in] manager Pointer to initialized bus manager with "i2c1" registered
+ * @param[in] manager Pointer to initialized bus manager with "i2c1_imu" registered
  *
  * @return rx_err_t Initialization result
  * @retval k_rx_ok Sensor initialized, NDOF mode active
@@ -710,7 +710,7 @@ static rx_err_t internal_verify_chip_id(void)
  * @retval k_rx_err_nack I2C NACK (device not found)
  * @retval k_rx_err_invalid_state CHIP_ID != 0xA0
  *
- * @pre manager non-NULL with "i2c1" bus registered and initialized
+ * @pre manager non-NULL with "i2c1_imu" bus registered and initialized
  * @pre BNO055 powered (3.3V)
  * @post s_initialized == true on success
  * @post Sensor running NDOF fusion

--- a/star-rx72n-firmware/src/main.c
+++ b/star-rx72n-firmware/src/main.c
@@ -404,7 +404,7 @@ static rx_bus_config_t s_adc0_config;
  * @pre RIIC1 hardware initialized before any driver uses this config
  * @post rx_bus_config_init_i2c() populates all fields before bus registration
  *
- * @note Bus name "i2c1" matches s_bus_name in rx_bno055.c
+ * @note Bus name "i2c1_imu" matches s_bus_name in rx_bno055.c
  * @note Static allocation follows NASA Power of 10 Rule 3
  *
  * @see rx_bno055.h BNO055 driver that uses this bus
@@ -1735,7 +1735,7 @@ static void internal_register_system_buses(void)
 
   /* Register i2c1 - BNO055 IMU (RIIC1, addr 0x28, SDA=P2.0, SCL=P2.1) */
   err = rx_bus_config_init_i2c(&s_i2c1_imu_config,
-                               "i2c1",                  /* name: matches rx_bno055.c s_bus_name */
+                               "i2c1_imu",                  /* name: matches rx_bno055.c s_bus_name */
                                k_riic_channel_1,        /* channel: RIIC1 */
                                k_i2c_addr_bno055,       /* device_addr: BNO055 (COM3/ADR=LOW) */
                                k_rx_p2_0,               /* sda_pin: P2.0 = SDA1 */
@@ -1744,7 +1744,7 @@ static void internal_register_system_buses(void)
   RX_ASSERT(err == k_rx_ok, "i2c1 (IMU) config init must succeed");
   err = rx_bus_manager_add_bus(&g_bus_manager, &s_i2c1_imu_config);
   RX_ASSERT(err == k_rx_ok, "i2c1 (IMU) registration must succeed");
-  err = rx_bus_i2c_init(&g_bus_manager, "i2c1");
+  err = rx_bus_i2c_init(&g_bus_manager, "i2c1_imu");
   RX_ASSERT(err == k_rx_ok, "i2c1 (IMU) I2C init must succeed");
 
   /* Register i2c1_baro - BMP280 barometric sensor (RIIC1, addr 0x76, SDA=P2.0, SCL=P2.1) */

--- a/star-rx72n-firmware/src/main.c
+++ b/star-rx72n-firmware/src/main.c
@@ -1733,24 +1733,24 @@ static void internal_register_system_buses(void)
   err = rx_bus_manager_add_bus(&g_bus_manager, &s_adc0_config);
   RX_ASSERT(err == k_rx_ok, "adc0 registration must succeed");
 
-  /* Register i2c1 - BNO055 IMU (RIIC1, addr 0x28, SDA=P2.0, SCL=P2.1) */
+  /* Register i2c1_imu - BNO055 IMU (RIIC1, addr 0x28, SDA=P2.0, SCL=P2.1) */
   err = rx_bus_config_init_i2c(&s_i2c1_imu_config,
-                               "i2c1_imu",                  /* name: matches rx_bno055.c s_bus_name */
+                               "i2c1_imu",              /* name: matches rx_bno055.c s_bus_name */
                                k_riic_channel_1,        /* channel: RIIC1 */
                                k_i2c_addr_bno055,       /* device_addr: BNO055 (COM3/ADR=LOW) */
                                k_rx_p2_0,               /* sda_pin: P2.0 = SDA1 */
                                k_rx_p2_1,               /* scl_pin: P2.1 = SCL1 */
                                k_i2c_frequency_400khz); /* frequency_hz: 400 kHz fast mode */
-  RX_ASSERT(err == k_rx_ok, "i2c1 (IMU) config init must succeed");
+  RX_ASSERT(err == k_rx_ok, "i2c1_imu config init must succeed");
   err = rx_bus_manager_add_bus(&g_bus_manager, &s_i2c1_imu_config);
-  RX_ASSERT(err == k_rx_ok, "i2c1 (IMU) registration must succeed");
+  RX_ASSERT(err == k_rx_ok, "i2c1_imu registration must succeed");
   err = rx_bus_i2c_init(&g_bus_manager, "i2c1_imu");
-  RX_ASSERT(err == k_rx_ok, "i2c1 (IMU) I2C init must succeed");
+  RX_ASSERT(err == k_rx_ok, "i2c1_imu I2C init must succeed");
 
   /* Register i2c1_baro - BMP280 barometric sensor (RIIC1, addr 0x76, SDA=P2.0, SCL=P2.1) */
   err = rx_bus_config_init_i2c(&s_i2c1_baro_config,
                                "i2c1_baro",             /* name: matches rx_bmp280.c s_bus_name */
-                               k_riic_channel_1,        /* channel: RIIC1 (same as i2c1) */
+                               k_riic_channel_1,        /* channel: RIIC1 (same as i2c1_imu) */
                                k_i2c_addr_bmp280,       /* device_addr: BMP280 (SDO=LOW) */
                                k_rx_p2_0,               /* sda_pin: P2.0 = SDA1 */
                                k_rx_p2_1,               /* scl_pin: P2.1 = SCL1 */

--- a/star-rx72n-firmware/src/tasks/imu_task.c
+++ b/star-rx72n-firmware/src/tasks/imu_task.c
@@ -13,7 +13,7 @@
  * # Hardware
  *
  * Both sensors use RIIC1 I2C hardware (P2.0=SDA1, P2.1=SCL1):
- * - **BNO055**: I2C addr 0x28, bus "i2c1", NDOF fusion mode (heading, quaternion, linear accel)
+ * - **BNO055**: I2C addr 0x28, bus "i2c1_imu", NDOF fusion mode (heading, quaternion, linear accel)
  * - **BMP280**: I2C addr 0x76, bus "i2c1_baro", forced mode (pressure Pa, temperature cC)
  *
  * # Task Lifecycle
@@ -203,7 +203,7 @@ static char s_task_name[] = "ImuTask"; /* char[] (not const) satisfies ThreadX C
 
 /**
  * @var g_bus_manager
- * @brief External bus manager defined in shared_data.c; registered buses include "i2c1" and "i2c1_baro"
+ * @brief External bus manager defined in shared_data.c; registered buses include "i2c1_imu" and "i2c1_baro"
  *
  * @details
  * Declared extern here because main.h does not export g_bus_manager.
@@ -576,7 +576,7 @@ static void internal_read_and_publish_baro(void)
  *
  * @pre ThreadX scheduler running
  * @pre s_imu_created == true (imu_task_create() completed)
- * @pre "i2c1" bus registered in g_bus_manager (registered by main.c)
+ * @pre "i2c1_imu" bus registered in g_bus_manager (registered by main.c)
  * @pre RIIC1 initialized at 400 kHz (by hardware_init.c i2c_init)
  * @pre shared_data_init() completed (imu_mutex and baro_mutex available)
  * @pre BNO055 powered on RIIC1 I2C bus, RST pin driven HIGH (not in reset)

--- a/star-rx72n-firmware/src/tasks/inc/imu_task.h
+++ b/star-rx72n-firmware/src/tasks/inc/imu_task.h
@@ -12,7 +12,7 @@
  * # Hardware
  *
  * Both sensors share the RIIC1 I2C bus (SCL1=P2.1, SDA1=P2.0):
- * - **BNO055**: 9-DOF IMU @ I2C address 0x28, bus name "i2c1"
+ * - **BNO055**: 9-DOF IMU @ I2C address 0x28, bus name "i2c1_imu"
  * - **BMP280**: Barometric pressure @ I2C address 0x76, bus name "i2c1_baro"
  *
  * # Task Configuration
@@ -145,7 +145,7 @@ typedef enum : uint16_t {
  * @retval k_rx_err_rtos_thread_create ThreadX task creation failed
  *
  * @pre ThreadX kernel initialized; task created in tx_application_define and will run after the scheduler starts (tx_kernel_enter)
- * @pre "i2c1" bus registered in bus manager via main.c (BNO055 sensor)
+ * @pre "i2c1_imu" bus registered in bus manager via main.c (BNO055 sensor)
  * @pre "i2c1_baro" bus registered in bus manager via main.c (BMP280 sensor)
  * @pre shared_data_init() called (mutexes created)
  * @pre hardware_init() completed (RIIC1 initialized at 400 kHz)

--- a/star-rx72n-firmware/tests/test_rx_bno055.c
+++ b/star-rx72n-firmware/tests/test_rx_bno055.c
@@ -8,12 +8,12 @@
  * public API: init, read, and calibration check.
  *
  * All hardware interaction is intercepted by mock_riic_hal (channel 1, the
- * RIIC channel used by "i2c1"). The real rx_bus_i2c.c and mock bus manager
+ * RIIC channel used by "i2c1_imu"). The real rx_bus_i2c.c and mock bus manager
  * are linked so bus resolution and RIIC calls exercise the full software stack.
  *
  * @par Test Architecture
  *
- * The BNO055 driver uses bus name "i2c1" on RIIC channel 1 (address 0x28).
+ * The BNO055 driver uses bus name "i2c1_imu" on RIIC channel 1 (address 0x28).
  * setUp() registers this bus with the mock bus manager and initialises RIIC
  * channel 1 via rx_bus_i2c_init(). Tests then pre-load mock RX data and/or
  * inject errors to steer the driver through all code paths.
@@ -94,7 +94,7 @@
  *
  * @details
  * The BNO055 is connected to RIIC channel 1 (P2.0=SDA1, P2.1=SCL1) at
- * address 0x28. The bus name "i2c1" must match the string hardcoded in
+ * address 0x28. The bus name "i2c1_imu" must match the string hardcoded in
  * rx_bno055.c (s_bus_name).
  *
  * @since Version 1.0.0
@@ -291,7 +291,7 @@ static rx_bus_manager_t s_test_manager;
 /**
  * @var s_i2c_config
  * @brief I2C bus configuration for BNO055 (channel 1, addr 0x28)
- * @details Configured in setUp() to match the "i2c1" bus expected by rx_bno055.c.
+ * @details Configured in setUp() to match the "i2c1_imu" bus expected by rx_bno055.c.
  * @since Version 1.0.0
  */
 static rx_bus_config_t s_i2c_config;
@@ -467,7 +467,7 @@ static void internal_load_lia_read_data(void)
  * 2. Reset mock RIIC HAL state (mock_riic_init)
  * 3. Initialize bus manager
  * 4. Create I2C bus config (channel 1, addr 0x28, 400 kHz, P2.0/P2.1)
- * 5. Register bus with manager as "i2c1"
+ * 5. Register bus with manager as "i2c1_imu"
  * 6. Initialize RIIC channel 1 via rx_bus_i2c_init()
  *
  * The driver statics s_initialized and s_manager are reset to their
@@ -476,7 +476,7 @@ static void internal_load_lia_read_data(void)
  *
  * @pre None - called by Unity before each test
  * @pre s_initialized may be any value (reset by rx_bno055_test_reset_state())
- * @post s_initialized == false; s_test_manager ready with "i2c1" registered
+ * @post s_initialized == false; s_test_manager ready with "i2c1_imu" registered
  * @post RIIC channel 1 initialized and ready for mock transactions
  *
  * @since Version 1.0.0
@@ -490,7 +490,7 @@ void setUp(void)
   TEST_ASSERT_EQUAL(k_rx_ok, err);
 
   err = rx_bus_config_init_i2c(&s_i2c_config,
-                               "i2c1",
+                               "i2c1_imu",
                                (uint8_t)k_test_bno055_riic_ch,
                                (uint8_t)k_test_bno055_i2c_addr,
                                k_rx_p2_0,
@@ -501,7 +501,7 @@ void setUp(void)
   err = rx_bus_manager_add_bus(&s_test_manager, &s_i2c_config);
   TEST_ASSERT_EQUAL(k_rx_ok, err);
 
-  err = rx_bus_i2c_init(&s_test_manager, "i2c1");
+  err = rx_bus_i2c_init(&s_test_manager, "i2c1_imu");
   TEST_ASSERT_EQUAL(k_rx_ok, err);
 }
 
@@ -674,7 +674,7 @@ void test_bno055_read_before_init(void)
  * All subsequent tests that require s_initialized == true depend on this.
  *
  * @pre s_initialized == false
- * @pre setUp() has registered "i2c1" bus and chip ID mock loaded via internal_load_valid_chip_id()
+ * @pre setUp() has registered "i2c1_imu" bus and chip ID mock loaded via internal_load_valid_chip_id()
  * @post s_initialized == true
  * @post rx_bno055_read() returns k_rx_ok confirming driver is operational
  *


### PR DESCRIPTION
## Summary

- Renames the BNO055 IMU bus from `"i2c1"` to `"i2c1_imu"` across all sites
- The BMP280 barometer already used `"i2c1_baro"` — this makes the naming consistent: both IMU buses now follow the `"i2c1_<sensor>"` pattern
- Pure rename, no logic changes

## Files changed

| File | Change |
|------|--------|
| `libs/rx_bno055/src/rx_bno055.c` | `s_bus_name` value updated |
| `libs/rx_bno055/inc/rx_bno055.h` | Doxygen references updated |
| `src/main.c` | Bus registration name + `rx_bus_i2c_init()` call updated |
| `src/tasks/imu_task.c` | Doxygen references updated |
| `src/tasks/inc/imu_task.h` | Doxygen references updated |
| `tests/test_rx_bno055.c` | Test setup bus name updated |

## Test plan

- [x] GNURX cross-compile: clean (`build.sh`)
- [x] Unit tests: 51/51 pass (`ctest`)

Closes #415

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal I2C bus identifier naming across firmware modules for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->