### PR TITLE
feat(motor): implement ADC current sensing for all 4 motors (issue #421)

### DIFF
--- a/star-rx72n-firmware/src/main.c
+++ b/star-rx72n-firmware/src/main.c
@@ -173,6 +173,7 @@
 #include "hardware.h"
 #include "hardware_init.h"
 #include "rx72n_system_regs.h"
+#include "rx_bus_adc.h"
 #include "rx_bus_config.h"
 #include "rx_bus_i2c.h"
 #include "rx_bus_manager.h"
@@ -349,42 +350,97 @@ static rx_bus_config_t s_onewire0_config;
 static rx_bus_config_t s_gpio_config;
 
 /**
- * @var s_adc0_config
- * @brief ADC configuration for motor current sensing
+ * @var s_motor0_current_config
+ * @brief ADC bus configuration for Motor 0 (FL) current sensing via DRV8263H IPROPI
  *
  * @details
- * Configures ADC Unit 0 (S12AD0) as generic ADC bus for motor current monitoring.
- * The initial channel (0) is required by the API but not significant - motor control
- * task specifies actual channels (AN004-AN007) at runtime for each motor.
+ * Configures S12AD0 channel 7 (AN007, P47) for Motor 0 (Front-Left) IPROPI
+ * current sense output. The DRV8263H mirrors 202 uA/A of motor current into
+ * a 5100 Ohm sense resistor: V_IPROPI = I_motor * 1.0302 V/A.
  *
- * **Hardware Configuration:**
- * - Bus type: ADC (generic abstraction)
- * - Unit: ADC Unit 0 (S12AD0)
- * - Initial channel: 0 (API requirement, not actually used)
- * - Resolution: 12-bit (0-4095 counts)
- * - Actual channels: Specified by motor_control_task at runtime
- *
- * **Motor Current Sensing Channels:**
- * | Motor | ADC Channel | Pin    |
- * |-------|-------------|--------|
- * | Motor 0 | AN007 (ch 7) | P40.7  |
- * | Motor 1 | AN006 (ch 6) | P40.6  |
- * | Motor 2 | AN005 (ch 5) | P40.5  |
- * | Motor 3 | AN004 (ch 4) | P40.4  |
+ * | Parameter  | Value          |
+ * |------------|----------------|
+ * | Unit       | S12AD0         |
+ * | Channel    | AN007 (ch 7)   |
+ * | Pin        | P47            |
+ * | Resolution | 12-bit         |
+ * | Bus name   | motor0_current |
  *
  * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
- * @note Registered with bus manager in tx_application_define() before task creation.
- * @note This is a generic bus abstraction - one "adc0" bus serves all 4 motor drivers.
- * @note Each current reading specifies the actual ADC channel to sample.
- * @note 12-bit resolution provides 1 mV per count with 3.3V reference.
- *
  * @see rx_bus_config_init_adc() Bus configuration function
- * @see motor_control_task.c Task that uses this bus for current monitoring
- * @see rx_bus_adc_read_voltage_mv() Runtime ADC read with channel specification
- *
+ * @see motor_control_task.c internal_update_motor_state() Consumer
  * @since Version 1.0.0
  */
-static rx_bus_config_t s_adc0_config;
+static rx_bus_config_t s_motor0_current_config;
+
+/**
+ * @var s_motor1_current_config
+ * @brief ADC bus configuration for Motor 1 (FR) current sensing via DRV8263H IPROPI
+ *
+ * @details
+ * Configures S12AD0 channel 6 (AN006, P46) for Motor 1 (Front-Right) IPROPI
+ * current sense output.
+ *
+ * | Parameter  | Value          |
+ * |------------|----------------|
+ * | Unit       | S12AD0         |
+ * | Channel    | AN006 (ch 6)   |
+ * | Pin        | P46            |
+ * | Resolution | 12-bit         |
+ * | Bus name   | motor1_current |
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @see rx_bus_config_init_adc() Bus configuration function
+ * @see motor_control_task.c internal_update_motor_state() Consumer
+ * @since Version 1.0.0
+ */
+static rx_bus_config_t s_motor1_current_config;
+
+/**
+ * @var s_motor2_current_config
+ * @brief ADC bus configuration for Motor 2 (BL) current sensing via DRV8263H IPROPI
+ *
+ * @details
+ * Configures S12AD0 channel 5 (AN005, P45) for Motor 2 (Back-Left) IPROPI
+ * current sense output.
+ *
+ * | Parameter  | Value          |
+ * |------------|----------------|
+ * | Unit       | S12AD0         |
+ * | Channel    | AN005 (ch 5)   |
+ * | Pin        | P45            |
+ * | Resolution | 12-bit         |
+ * | Bus name   | motor2_current |
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @see rx_bus_config_init_adc() Bus configuration function
+ * @see motor_control_task.c internal_update_motor_state() Consumer
+ * @since Version 1.0.0
+ */
+static rx_bus_config_t s_motor2_current_config;
+
+/**
+ * @var s_motor3_current_config
+ * @brief ADC bus configuration for Motor 3 (BR) current sensing via DRV8263H IPROPI
+ *
+ * @details
+ * Configures S12AD0 channel 4 (AN004, P44) for Motor 3 (Back-Right) IPROPI
+ * current sense output.
+ *
+ * | Parameter  | Value          |
+ * |------------|----------------|
+ * | Unit       | S12AD0         |
+ * | Channel    | AN004 (ch 4)   |
+ * | Pin        | P44            |
+ * | Resolution | 12-bit         |
+ * | Bus name   | motor3_current |
+ *
+ * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @see rx_bus_config_init_adc() Bus configuration function
+ * @see motor_control_task.c internal_update_motor_state() Consumer
+ * @since Version 1.0.0
+ */
+static rx_bus_config_t s_motor3_current_config;
 
 /**
  * @var s_i2c1_imu_config
@@ -1686,10 +1742,15 @@ static void internal_init_bus_manager(void)
  * Registered buses:
  * - **onewire0** (P51): DS18B20 temperature sensor, 1-Wire bit-banging
  * - **gpio** (P00): Generic GPIO for motor driver control signals
- * - **adc0** (S12AD0, ch0): Motor current sensing, 12-bit resolution
+ * - **motor0_current** (S12AD0, ch7, AN007, P47): Motor 0 (FL) IPROPI current sense
+ * - **motor1_current** (S12AD0, ch6, AN006, P46): Motor 1 (FR) IPROPI current sense
+ * - **motor2_current** (S12AD0, ch5, AN005, P45): Motor 2 (BL) IPROPI current sense
+ * - **motor3_current** (S12AD0, ch4, AN004, P44): Motor 3 (BR) IPROPI current sense
  *
  * @pre internal_init_bus_manager() completed successfully
- * @pre Static bus config structs (s_onewire0_config, s_gpio_config, s_adc0_config) are zeroed (BSS)
+ * @pre Static bus config structs zeroed (BSS): s_onewire0_config, s_gpio_config,
+ *      s_motor0_current_config, s_motor1_current_config,
+ *      s_motor2_current_config, s_motor3_current_config
  *
  * @post All three buses registered and accessible via bus manager
  * @post Static config structs populated with bus parameters
@@ -1723,15 +1784,53 @@ static void internal_register_system_buses(void)
   err = rx_bus_manager_add_bus(&g_bus_manager, &s_gpio_config);
   RX_ASSERT(err == k_rx_ok, "gpio registration must succeed");
 
-  /* Register adc0 - Motor Current Sensing (ADC Unit 0) */
-  err = rx_bus_config_init_adc(&s_adc0_config,
-                               "adc0",                  /* name */
-                               k_adc_unit_0,            /* unit = ADC0 (S12AD0) */
-                               k_adc_channel_0,         /* channel = 0 (generic bus) */
-                               k_adc_resolution_12bit); /* bits = 12-bit resolution */
-  RX_ASSERT(err == k_rx_ok, "adc0 config init must succeed");
-  err = rx_bus_manager_add_bus(&g_bus_manager, &s_adc0_config);
-  RX_ASSERT(err == k_rx_ok, "adc0 registration must succeed");
+  /* Register motor0_current - Motor 0 (FL) current sense: AN007, ch 7, P47 */
+  err = rx_bus_config_init_adc(&s_motor0_current_config,
+                               "motor0_current",        /* name */
+                               k_adc_unit_0,            /* unit = S12AD0 */
+                               k_adc_channel_7,         /* channel = AN007 = Motor 0 (FL) */
+                               k_adc_resolution_12bit); /* bits = 12-bit */
+  RX_ASSERT(err == k_rx_ok, "motor0_current config init must succeed");
+  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor0_current_config);
+  RX_ASSERT(err == k_rx_ok, "motor0_current registration must succeed");
+  err = rx_bus_adc_init(&g_bus_manager, "motor0_current");
+  RX_ASSERT(err == k_rx_ok, "motor0_current ADC init must succeed");
+
+  /* Register motor1_current - Motor 1 (FR) current sense: AN006, ch 6, P46 */
+  err = rx_bus_config_init_adc(&s_motor1_current_config,
+                               "motor1_current",        /* name */
+                               k_adc_unit_0,            /* unit = S12AD0 */
+                               k_adc_channel_6,         /* channel = AN006 = Motor 1 (FR) */
+                               k_adc_resolution_12bit); /* bits = 12-bit */
+  RX_ASSERT(err == k_rx_ok, "motor1_current config init must succeed");
+  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor1_current_config);
+  RX_ASSERT(err == k_rx_ok, "motor1_current registration must succeed");
+  err = rx_bus_adc_init(&g_bus_manager, "motor1_current");
+  RX_ASSERT(err == k_rx_ok, "motor1_current ADC init must succeed");
+
+  /* Register motor2_current - Motor 2 (BL) current sense: AN005, ch 5, P45 */
+  err = rx_bus_config_init_adc(&s_motor2_current_config,
+                               "motor2_current",        /* name */
+                               k_adc_unit_0,            /* unit = S12AD0 */
+                               k_adc_channel_5,         /* channel = AN005 = Motor 2 (BL) */
+                               k_adc_resolution_12bit); /* bits = 12-bit */
+  RX_ASSERT(err == k_rx_ok, "motor2_current config init must succeed");
+  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor2_current_config);
+  RX_ASSERT(err == k_rx_ok, "motor2_current registration must succeed");
+  err = rx_bus_adc_init(&g_bus_manager, "motor2_current");
+  RX_ASSERT(err == k_rx_ok, "motor2_current ADC init must succeed");
+
+  /* Register motor3_current - Motor 3 (BR) current sense: AN004, ch 4, P44 */
+  err = rx_bus_config_init_adc(&s_motor3_current_config,
+                               "motor3_current",        /* name */
+                               k_adc_unit_0,            /* unit = S12AD0 */
+                               k_adc_channel_4,         /* channel = AN004 = Motor 3 (BR) */
+                               k_adc_resolution_12bit); /* bits = 12-bit */
+  RX_ASSERT(err == k_rx_ok, "motor3_current config init must succeed");
+  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor3_current_config);
+  RX_ASSERT(err == k_rx_ok, "motor3_current registration must succeed");
+  err = rx_bus_adc_init(&g_bus_manager, "motor3_current");
+  RX_ASSERT(err == k_rx_ok, "motor3_current ADC init must succeed");
 
   /* Register i2c1 - BNO055 IMU (RIIC1, addr 0x28, SDA=P2.0, SCL=P2.1) */
   err = rx_bus_config_init_i2c(&s_i2c1_imu_config,

--- a/star-rx72n-firmware/src/main.c
+++ b/star-rx72n-firmware/src/main.c
@@ -364,52 +364,32 @@ typedef enum : uint8_t {
 } motor_current_adc_count_t;
 
 /**
- * @struct motor_current_adc_desc_t
- * @brief Per-motor ADC descriptor: bus name and S12AD0 channel
+ * @var k_motor_current_adc_channels
+ * @brief S12AD0 channel for each motor current-sense input, indexed by motor index
  *
  * @details
- * Pairs each motor's bus manager name with its ADC channel so that
- * internal_register_system_buses() can register all four channels with a
- * single loop instead of four copy-pasted blocks.
+ * Maps motor index (0-3) to its S12AD0 channel. Bus names are obtained from
+ * g_motor_current_bus_names (declared in motor_control_task.h) so there is a
+ * single authoritative name table shared between bus registration here and
+ * ADC reads in motor_control_task.c.
  *
- * @invariant name must be a non-NULL string literal
- * @invariant channel must be a valid adc_channel_t value for S12AD0
+ * | Index | Motor | Channel | Pin |
+ * |-------|-------|---------|-----|
+ * | 0     | FL    | AN007   | P47 |
+ * | 1     | FR    | AN006   | P46 |
+ * | 2     | BL    | AN005   | P45 |
+ * | 3     | BR    | AN004   | P44 |
  *
- * @see k_motor_current_adc_descs Compile-time table of all four descriptors
- * @since Version 1.0.0
- */
-typedef struct {
-  const char*   name;    /**< Bus manager name (e.g. "motor0_current") */
-  adc_channel_t channel; /**< S12AD0 channel (AN004-AN007) */
-} motor_current_adc_desc_t;
-
-/**
- * @var k_motor_current_adc_descs
- * @brief Compile-time descriptor table for all four motor current-sense ADC channels
- *
- * @details
- * Maps motor index (0-3) to its bus name and S12AD0 channel. All four motors
- * share ADC unit S12AD0 and 12-bit resolution; only the channel and name differ.
- *
- * | Index | Motor | Bus name       | Channel | Pin |
- * |-------|-------|----------------|---------|-----|
- * | 0     | FL    | motor0_current | AN007   | P47 |
- * | 1     | FR    | motor1_current | AN006   | P46 |
- * | 2     | BL    | motor2_current | AN005   | P45 |
- * | 3     | BR    | motor3_current | AN004   | P44 |
- *
- * @note String literals reside in .rodata (no dynamic allocation).
- * @note Names must match motor_control_task.c s_motor_current_bus_names[].
  * @warning Array size must match k_motor_current_adc_count.
+ * @see g_motor_current_bus_names Shared bus name array (motor_control_task.h)
  * @see internal_register_system_buses() Iterates over this table
- * @see motor_control_task.c s_motor_current_bus_names Consumer bus name list
  * @since Version 1.0.0
  */
-static const motor_current_adc_desc_t k_motor_current_adc_descs[k_motor_current_adc_count] = {
-  {"motor0_current", k_adc_channel_7}, /* Motor 0 (FL): AN007, P47 */
-  {"motor1_current", k_adc_channel_6}, /* Motor 1 (FR): AN006, P46 */
-  {"motor2_current", k_adc_channel_5}, /* Motor 2 (BL): AN005, P45 */
-  {"motor3_current", k_adc_channel_4}, /* Motor 3 (BR): AN004, P44 */
+static const adc_channel_t k_motor_current_adc_channels[k_motor_current_adc_count] = {
+  k_adc_channel_7, /* Motor 0 (FL): AN007, P47 */
+  k_adc_channel_6, /* Motor 1 (FR): AN006, P46 */
+  k_adc_channel_5, /* Motor 2 (BL): AN005, P45 */
+  k_adc_channel_4, /* Motor 3 (BR): AN004, P44 */
 };
 
 /**
@@ -423,7 +403,7 @@ static const motor_current_adc_desc_t k_motor_current_adc_descs[k_motor_current_
  * lifetime and BSS-zero initialisation guarantees.
  *
  * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
- * @see k_motor_current_adc_descs Descriptor table supplying name and channel
+ * @see k_motor_current_adc_channels Channel table supplying S12AD0 channel per motor
  * @see rx_bus_config_init_adc() Bus configuration function
  * @see motor_control_task.c internal_update_motor_state() Consumer
  * @since Version 1.0.0
@@ -1774,14 +1754,14 @@ static void internal_register_system_buses(void)
   /* Register motor current-sense ADC channels (S12AD0, 12-bit, 4 motors) */
   for (uint8_t i = 0; i < k_motor_current_adc_count; i++) {
     err = rx_bus_config_init_adc(&s_motor_current_configs[i],
-                                 k_motor_current_adc_descs[i].name,    /* name */
-                                 k_adc_unit_0,                         /* unit = S12AD0 */
-                                 k_motor_current_adc_descs[i].channel, /* channel = AN004-7 */
-                                 k_adc_resolution_12bit);              /* bits = 12-bit */
+                                 g_motor_current_bus_names[i],    /* name (shared) */
+                                 k_adc_unit_0,                    /* unit = S12AD0 */
+                                 k_motor_current_adc_channels[i], /* channel = AN004-7 */
+                                 k_adc_resolution_12bit);         /* bits = 12-bit */
     RX_ASSERT(err == k_rx_ok, "motor_current config init must succeed");
     err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor_current_configs[i]);
     RX_ASSERT(err == k_rx_ok, "motor_current registration must succeed");
-    err = rx_bus_adc_init(&g_bus_manager, k_motor_current_adc_descs[i].name);
+    err = rx_bus_adc_init(&g_bus_manager, g_motor_current_bus_names[i]);
     RX_ASSERT(err == k_rx_ok, "motor_current ADC init must succeed");
   }
 

--- a/star-rx72n-firmware/src/main.c
+++ b/star-rx72n-firmware/src/main.c
@@ -350,97 +350,85 @@ static rx_bus_config_t s_onewire0_config;
 static rx_bus_config_t s_gpio_config;
 
 /**
- * @var s_motor0_current_config
- * @brief ADC bus configuration for Motor 0 (FL) current sensing via DRV8263H IPROPI
+ * @enum motor_current_adc_count_t
+ * @brief Number of motor current-sense ADC channels
  *
  * @details
- * Configures S12AD0 channel 7 (AN007, P47) for Motor 0 (Front-Left) IPROPI
- * current sense output. The DRV8263H mirrors 202 uA/A of motor current into
- * a 5100 Ohm sense resistor: V_IPROPI = I_motor * 1.0302 V/A.
+ * One ADC channel per motor (S12AD0 channels 4-7). Matches the physical
+ * number of DRV8263H IPROPI outputs wired to the RX72N ADC.
  *
- * | Parameter  | Value          |
- * |------------|----------------|
- * | Unit       | S12AD0         |
- * | Channel    | AN007 (ch 7)   |
- * | Pin        | P47            |
- * | Resolution | 12-bit         |
- * | Bus name   | motor0_current |
- *
- * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
- * @see rx_bus_config_init_adc() Bus configuration function
- * @see motor_control_task.c internal_update_motor_state() Consumer
  * @since Version 1.0.0
  */
-static rx_bus_config_t s_motor0_current_config;
+typedef enum : uint8_t {
+  k_motor_current_adc_count = 4U, /**< 4 motors -> 4 current-sense channels */
+} motor_current_adc_count_t;
 
 /**
- * @var s_motor1_current_config
- * @brief ADC bus configuration for Motor 1 (FR) current sensing via DRV8263H IPROPI
+ * @struct motor_current_adc_desc_t
+ * @brief Per-motor ADC descriptor: bus name and S12AD0 channel
  *
  * @details
- * Configures S12AD0 channel 6 (AN006, P46) for Motor 1 (Front-Right) IPROPI
- * current sense output.
+ * Pairs each motor's bus manager name with its ADC channel so that
+ * internal_register_system_buses() can register all four channels with a
+ * single loop instead of four copy-pasted blocks.
  *
- * | Parameter  | Value          |
- * |------------|----------------|
- * | Unit       | S12AD0         |
- * | Channel    | AN006 (ch 6)   |
- * | Pin        | P46            |
- * | Resolution | 12-bit         |
- * | Bus name   | motor1_current |
+ * @invariant name must be a non-NULL string literal
+ * @invariant channel must be a valid adc_channel_t value for S12AD0
  *
- * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
- * @see rx_bus_config_init_adc() Bus configuration function
- * @see motor_control_task.c internal_update_motor_state() Consumer
+ * @see k_motor_current_adc_descs Compile-time table of all four descriptors
  * @since Version 1.0.0
  */
-static rx_bus_config_t s_motor1_current_config;
+typedef struct {
+  const char*   name;    /**< Bus manager name (e.g. "motor0_current") */
+  adc_channel_t channel; /**< S12AD0 channel (AN004-AN007) */
+} motor_current_adc_desc_t;
 
 /**
- * @var s_motor2_current_config
- * @brief ADC bus configuration for Motor 2 (BL) current sensing via DRV8263H IPROPI
+ * @var k_motor_current_adc_descs
+ * @brief Compile-time descriptor table for all four motor current-sense ADC channels
  *
  * @details
- * Configures S12AD0 channel 5 (AN005, P45) for Motor 2 (Back-Left) IPROPI
- * current sense output.
+ * Maps motor index (0-3) to its bus name and S12AD0 channel. All four motors
+ * share ADC unit S12AD0 and 12-bit resolution; only the channel and name differ.
  *
- * | Parameter  | Value          |
- * |------------|----------------|
- * | Unit       | S12AD0         |
- * | Channel    | AN005 (ch 5)   |
- * | Pin        | P45            |
- * | Resolution | 12-bit         |
- * | Bus name   | motor2_current |
+ * | Index | Motor | Bus name       | Channel | Pin |
+ * |-------|-------|----------------|---------|-----|
+ * | 0     | FL    | motor0_current | AN007   | P47 |
+ * | 1     | FR    | motor1_current | AN006   | P46 |
+ * | 2     | BL    | motor2_current | AN005   | P45 |
+ * | 3     | BR    | motor3_current | AN004   | P44 |
  *
- * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
- * @see rx_bus_config_init_adc() Bus configuration function
- * @see motor_control_task.c internal_update_motor_state() Consumer
+ * @note String literals reside in .rodata (no dynamic allocation).
+ * @note Names must match motor_control_task.c s_motor_current_bus_names[].
+ * @warning Array size must match k_motor_current_adc_count.
+ * @see internal_register_system_buses() Iterates over this table
+ * @see motor_control_task.c s_motor_current_bus_names Consumer bus name list
  * @since Version 1.0.0
  */
-static rx_bus_config_t s_motor2_current_config;
+static const motor_current_adc_desc_t k_motor_current_adc_descs[k_motor_current_adc_count] = {
+  {"motor0_current", k_adc_channel_7}, /* Motor 0 (FL): AN007, P47 */
+  {"motor1_current", k_adc_channel_6}, /* Motor 1 (FR): AN006, P46 */
+  {"motor2_current", k_adc_channel_5}, /* Motor 2 (BL): AN005, P45 */
+  {"motor3_current", k_adc_channel_4}, /* Motor 3 (BR): AN004, P44 */
+};
 
 /**
- * @var s_motor3_current_config
- * @brief ADC bus configuration for Motor 3 (BR) current sensing via DRV8263H IPROPI
+ * @var s_motor_current_configs
+ * @brief ADC bus configuration storage for all four motor current-sense channels
  *
  * @details
- * Configures S12AD0 channel 4 (AN004, P44) for Motor 3 (Back-Right) IPROPI
- * current sense output.
- *
- * | Parameter  | Value          |
- * |------------|----------------|
- * | Unit       | S12AD0         |
- * | Channel    | AN004 (ch 4)   |
- * | Pin        | P44            |
- * | Resolution | 12-bit         |
- * | Bus name   | motor3_current |
+ * Provides static storage for the four rx_bus_config_t structs populated by
+ * internal_register_system_buses() via rx_bus_config_init_adc(). Using an
+ * array eliminates four separate per-motor variables while retaining the same
+ * lifetime and BSS-zero initialisation guarantees.
  *
  * @note Static allocation follows NASA Power of 10 Rule 3 (no dynamic memory).
+ * @see k_motor_current_adc_descs Descriptor table supplying name and channel
  * @see rx_bus_config_init_adc() Bus configuration function
  * @see motor_control_task.c internal_update_motor_state() Consumer
  * @since Version 1.0.0
  */
-static rx_bus_config_t s_motor3_current_config;
+static rx_bus_config_t s_motor_current_configs[k_motor_current_adc_count];
 
 /**
  * @var s_i2c1_imu_config
@@ -1749,8 +1737,7 @@ static void internal_init_bus_manager(void)
  *
  * @pre internal_init_bus_manager() completed successfully
  * @pre Static bus config structs zeroed (BSS): s_onewire0_config, s_gpio_config,
- *      s_motor0_current_config, s_motor1_current_config,
- *      s_motor2_current_config, s_motor3_current_config
+ *      s_motor_current_configs[]
  *
  * @post All three buses registered and accessible via bus manager
  * @post Static config structs populated with bus parameters
@@ -1784,53 +1771,19 @@ static void internal_register_system_buses(void)
   err = rx_bus_manager_add_bus(&g_bus_manager, &s_gpio_config);
   RX_ASSERT(err == k_rx_ok, "gpio registration must succeed");
 
-  /* Register motor0_current - Motor 0 (FL) current sense: AN007, ch 7, P47 */
-  err = rx_bus_config_init_adc(&s_motor0_current_config,
-                               "motor0_current",        /* name */
-                               k_adc_unit_0,            /* unit = S12AD0 */
-                               k_adc_channel_7,         /* channel = AN007 = Motor 0 (FL) */
-                               k_adc_resolution_12bit); /* bits = 12-bit */
-  RX_ASSERT(err == k_rx_ok, "motor0_current config init must succeed");
-  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor0_current_config);
-  RX_ASSERT(err == k_rx_ok, "motor0_current registration must succeed");
-  err = rx_bus_adc_init(&g_bus_manager, "motor0_current");
-  RX_ASSERT(err == k_rx_ok, "motor0_current ADC init must succeed");
-
-  /* Register motor1_current - Motor 1 (FR) current sense: AN006, ch 6, P46 */
-  err = rx_bus_config_init_adc(&s_motor1_current_config,
-                               "motor1_current",        /* name */
-                               k_adc_unit_0,            /* unit = S12AD0 */
-                               k_adc_channel_6,         /* channel = AN006 = Motor 1 (FR) */
-                               k_adc_resolution_12bit); /* bits = 12-bit */
-  RX_ASSERT(err == k_rx_ok, "motor1_current config init must succeed");
-  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor1_current_config);
-  RX_ASSERT(err == k_rx_ok, "motor1_current registration must succeed");
-  err = rx_bus_adc_init(&g_bus_manager, "motor1_current");
-  RX_ASSERT(err == k_rx_ok, "motor1_current ADC init must succeed");
-
-  /* Register motor2_current - Motor 2 (BL) current sense: AN005, ch 5, P45 */
-  err = rx_bus_config_init_adc(&s_motor2_current_config,
-                               "motor2_current",        /* name */
-                               k_adc_unit_0,            /* unit = S12AD0 */
-                               k_adc_channel_5,         /* channel = AN005 = Motor 2 (BL) */
-                               k_adc_resolution_12bit); /* bits = 12-bit */
-  RX_ASSERT(err == k_rx_ok, "motor2_current config init must succeed");
-  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor2_current_config);
-  RX_ASSERT(err == k_rx_ok, "motor2_current registration must succeed");
-  err = rx_bus_adc_init(&g_bus_manager, "motor2_current");
-  RX_ASSERT(err == k_rx_ok, "motor2_current ADC init must succeed");
-
-  /* Register motor3_current - Motor 3 (BR) current sense: AN004, ch 4, P44 */
-  err = rx_bus_config_init_adc(&s_motor3_current_config,
-                               "motor3_current",        /* name */
-                               k_adc_unit_0,            /* unit = S12AD0 */
-                               k_adc_channel_4,         /* channel = AN004 = Motor 3 (BR) */
-                               k_adc_resolution_12bit); /* bits = 12-bit */
-  RX_ASSERT(err == k_rx_ok, "motor3_current config init must succeed");
-  err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor3_current_config);
-  RX_ASSERT(err == k_rx_ok, "motor3_current registration must succeed");
-  err = rx_bus_adc_init(&g_bus_manager, "motor3_current");
-  RX_ASSERT(err == k_rx_ok, "motor3_current ADC init must succeed");
+  /* Register motor current-sense ADC channels (S12AD0, 12-bit, 4 motors) */
+  for (uint8_t i = 0; i < k_motor_current_adc_count; i++) {
+    err = rx_bus_config_init_adc(&s_motor_current_configs[i],
+                                 k_motor_current_adc_descs[i].name,    /* name */
+                                 k_adc_unit_0,                         /* unit = S12AD0 */
+                                 k_motor_current_adc_descs[i].channel, /* channel = AN004-7 */
+                                 k_adc_resolution_12bit);              /* bits = 12-bit */
+    RX_ASSERT(err == k_rx_ok, "motor_current config init must succeed");
+    err = rx_bus_manager_add_bus(&g_bus_manager, &s_motor_current_configs[i]);
+    RX_ASSERT(err == k_rx_ok, "motor_current registration must succeed");
+    err = rx_bus_adc_init(&g_bus_manager, k_motor_current_adc_descs[i].name);
+    RX_ASSERT(err == k_rx_ok, "motor_current ADC init must succeed");
+  }
 
   /* Register i2c1 - BNO055 IMU (RIIC1, addr 0x28, SDA=P2.0, SCL=P2.1) */
   err = rx_bus_config_init_i2c(&s_i2c1_imu_config,

--- a/star-rx72n-firmware/src/shared/shared_data.h
+++ b/star-rx72n-firmware/src/shared/shared_data.h
@@ -28,12 +28,13 @@
  * @brief Emergency stop reason codes
  */
 typedef enum : uint8_t {
-  k_estop_reason_none         = 0, /**< No e-stop active */
-  k_estop_reason_comm_timeout = 1, /**< Communication timeout */
-  k_estop_reason_obstacle     = 2, /**< Obstacle too close */
-  k_estop_reason_driver_fault = 3, /**< Motor driver hardware fault */
-  k_estop_reason_overcurrent  = 4, /**< Motor overcurrent */
-  k_estop_reason_manual       = 5, /**< Manual request */
+  k_estop_reason_none           = 0, /**< No e-stop active */
+  k_estop_reason_comm_timeout   = 1, /**< Communication timeout */
+  k_estop_reason_obstacle       = 2, /**< Obstacle too close */
+  k_estop_reason_driver_fault   = 3, /**< Motor driver hardware fault */
+  k_estop_reason_overcurrent    = 4, /**< Motor overcurrent */
+  k_estop_reason_manual         = 5, /**< Manual request */
+  k_estop_reason_sensor_failure = 6, /**< ADC or sensor read failure */
 
 } estop_reason_t;
 

--- a/star-rx72n-firmware/src/tasks/inc/motor_control_task.h
+++ b/star-rx72n-firmware/src/tasks/inc/motor_control_task.h
@@ -39,6 +39,23 @@
 #include "rx_motor.h"
 
 /**
+ * @var g_motor_current_bus_names
+ * @brief Shared ADC bus-name table for motor current sensing (motor index -> bus name)
+ *
+ * @details
+ * Single definition lives in motor_control_task.c. Declared here so that
+ * main.c can use the same names for bus registration without duplicating the
+ * table. Array has one entry per motor (4 total: FL, FR, BL, BR).
+ *
+ * @note Consumers must not take sizeof() through this declaration; use the
+ *       authoritative size constant from motor_control_task.c (k_motor_count = 4).
+ * @see motor_control_task.c g_motor_current_bus_names Definition
+ * @see main.c internal_register_system_buses() Bus registration consumer
+ * @since Version 1.0.0
+ */
+extern const char* const g_motor_current_bus_names[];
+
+/**
  * @enum motor_count_t
  * @brief Motor count sentinels for motor_control_task_get_motors()
  *

--- a/star-rx72n-firmware/src/tasks/inc/motor_control_task.h
+++ b/star-rx72n-firmware/src/tasks/inc/motor_control_task.h
@@ -39,33 +39,17 @@
 #include "rx_motor.h"
 
 /**
- * @var g_motor_current_bus_names
- * @brief Shared ADC bus-name table for motor current sensing (motor index -> bus name)
- *
- * @details
- * Single definition lives in motor_control_task.c. Declared here so that
- * main.c can use the same names for bus registration without duplicating the
- * table. Array has one entry per motor (4 total: FL, FR, BL, BR).
- *
- * @note Consumers must not take sizeof() through this declaration; use the
- *       authoritative size constant from motor_control_task.c (k_motor_count = 4).
- * @see motor_control_task.c g_motor_current_bus_names Definition
- * @see main.c internal_register_system_buses() Bus registration consumer
- * @since Version 1.0.0
- */
-extern const char* const g_motor_current_bus_names[];
-
-/**
  * @enum motor_count_t
- * @brief Motor count sentinels for motor_control_task_get_motors()
+ * @brief Authoritative motor-count constants shared across the motor subsystem
  *
  * @details
- * Named constants for motor count return values. Used to avoid magic
- * number 0 in callers checking whether motors are ready. Callers should
- * compare the out_count value returned by motor_control_task_get_motors()
- * against k_motor_count_none to determine whether motors are available.
+ * Provides the authoritative motor count (k_motor_count) used to size arrays in
+ * motor_control_task.c and the extern declaration of g_motor_current_bus_names.
+ * Also provides the sentinel k_motor_count_none for callers of
+ * motor_control_task_get_motors().
  *
  * @invariant k_motor_count_none == 0 (sentinel value, never a valid motor count)
+ * @invariant k_motor_count == 4 (one entry per wheel: FL, FR, BL, BR)
  *
  * @code
  * uint8_t motor_count = k_motor_count_none;
@@ -76,13 +60,30 @@ extern const char* const g_motor_current_bus_names[];
  * @endcode
  *
  * @see motor_control_task_get_motors() Returns k_motor_count_none when not ready
+ * @see g_motor_current_bus_names Sized by k_motor_count
  *
  * @since Version 1.0.0
  */
 typedef enum : uint8_t {
   k_motor_count_none =
     0, /**< Zero motors available -- motor_control_task_create() has not yet been called */
+  k_motor_count = 4U, /**< Number of motors: FL, FR, BL, BR */
 } motor_count_t;
+
+/**
+ * @var g_motor_current_bus_names
+ * @brief Shared ADC bus-name table for motor current sensing (motor index -> bus name)
+ *
+ * @details
+ * Single definition lives in motor_control_task.c. Declared here so that
+ * main.c can use the same names for bus registration without duplicating the
+ * table. Array has k_motor_count entries (one per motor).
+ *
+ * @see motor_control_task.c g_motor_current_bus_names Definition
+ * @see main.c internal_register_system_buses() Bus registration consumer
+ * @since Version 1.0.0
+ */
+extern const char* const g_motor_current_bus_names[k_motor_count];
 
 /**
  * @brief Create and start the motor control task

--- a/star-rx72n-firmware/src/tasks/motor_control_task.c
+++ b/star-rx72n-firmware/src/tasks/motor_control_task.c
@@ -375,6 +375,8 @@
 
 #include "motor_control_task.h"
 
+#include <math.h>
+
 #include "hardware_config.h"
 #include "rx_bus_adc.h"
 #include "rx_bus_manager.h"
@@ -2855,13 +2857,16 @@ static void internal_check_comm_timeout(void)
  * 6. **Read Current:** rx_bus_adc_read_voltage_mv() + rx_drv8263_adc_to_amps()
  *    -> state.current_ma[i]  (DRV8263H IPROPI: V = I * 202e-6 * 5100 = I * 1.0302)
  *
- * 7. **Aggregate E-Stop:** state.estop_active = shared_data_is_estop_active()
+ * 7. **Overcurrent Check:** if |state.current_ma[i]| > k_motor_current_limit_ma (2 A)
+ *    -> call shared_data_trigger_estop(k_estop_reason_overcurrent)
  *
- * 8. **E-Stop Reason:** state.estop_reason = shared_data_get_estop_reason()
+ * 8. **Aggregate E-Stop:** state.estop_active = shared_data_is_estop_active()
  *
- * 9. **Mode:** state.mode = estop ? k_motor_mode_estop : k_motor_mode_velocity
+ * 9. **E-Stop Reason:** state.estop_reason = shared_data_get_estop_reason()
  *
- * 10. **Write to Shared Data:** shared_data_update_motor_state(&state)
+ * 10. **Mode:** state.mode = estop ? k_motor_mode_estop : k_motor_mode_velocity
+ *
+ * 11. **Write to Shared Data:** shared_data_update_motor_state(&state)
  *
  * @return void Function always completes (no error return)
  *
@@ -2870,12 +2875,14 @@ static void internal_check_comm_timeout(void)
  *
  * @post shared_data.motor_state updated with latest values
  * @post Telemetry task can read updated state
+ * @post E-stop triggered if any motor exceeds k_motor_current_limit_ma
  *
  * @note **Thread Safety:** Mutex-protected via shared_data API
  * @note **Performance:** ~100 us (reads + mutex write)
  * @note **Error Handling:** Read errors result in 0 values (safe fallback)
  *
  * @see shared_data_update_motor_state() Write aggregated state
+ * @see shared_data_trigger_estop() Trigger emergency stop on overcurrent
  * @see rx_encoder_read_velocity() Read motor velocity
  * @see rx_motor_get_duty() Read PWM duty cycle
  * @see rx_encoder_read_count() Read encoder position
@@ -2915,6 +2922,11 @@ static void internal_update_motor_state(void)
     if (err == k_rx_ok) {
       const float voltage_v = (float)voltage_mv / 1000.0F;
       state.current_ma[i]   = rx_drv8263_adc_to_amps(voltage_v) * 1000.0F;
+
+      /* Overcurrent protection: trigger e-stop if |current| exceeds 2 A limit */
+      if (fabsf(state.current_ma[i]) > (float)k_motor_current_limit_ma) {
+        (void)shared_data_trigger_estop(k_estop_reason_overcurrent);
+      }
     }
   }
 

--- a/star-rx72n-firmware/src/tasks/motor_control_task.c
+++ b/star-rx72n-firmware/src/tasks/motor_control_task.c
@@ -376,6 +376,7 @@
 #include "motor_control_task.h"
 
 #include "hardware_config.h"
+#include "rx_bus_adc.h"
 #include "rx_bus_manager.h"
 #include "rx_check.h"
 #include "rx_drv8263.h"
@@ -826,6 +827,35 @@ static bool s_active_brake_in_progress = false;
 
 /** @brief Log tag for this module */
 static const char* const s_tag = "MOTOR";
+
+/**
+ * @var s_motor_current_bus_names
+ * @brief ADC bus names for motor current sensing, indexed by motor index
+ *
+ * @details
+ * Maps motor index [0..3] to the bus manager name for its IPROPI current
+ * sense channel. Each entry corresponds to one DRV8263H-Q1 IPROPI output
+ * sampled by S12AD0. Channel-to-motor assignment follows PCB schematic:
+ *
+ * | Motor | Index | Bus Name       | ADC Ch | Pin |
+ * |-------|-------|----------------|--------|-----|
+ * | FL    | 0     | motor0_current | AN007  | P47 |
+ * | FR    | 1     | motor1_current | AN006  | P46 |
+ * | BL    | 2     | motor2_current | AN005  | P45 |
+ * | BR    | 3     | motor3_current | AN004  | P44 |
+ *
+ * @note String literals reside in .rodata (no dynamic allocation).
+ * @warning Array size must match k_motor_count (4). Do not modify independently.
+ * @see internal_update_motor_state() Consumer of this array
+ * @see main.c internal_register_system_buses() Bus registrations
+ * @since Version 1.0.0
+ */
+static const char* const s_motor_current_bus_names[k_motor_count] = {
+  "motor0_current", /* Motor 0 (FL): AN007, ch 7, P47 */
+  "motor1_current", /* Motor 1 (FR): AN006, ch 6, P46 */
+  "motor2_current", /* Motor 2 (BL): AN005, ch 5, P45 */
+  "motor3_current", /* Motor 3 (BR): AN004, ch 4, P44 */
+};
 
 /**
  * @var s_task_name
@@ -2822,13 +2852,16 @@ static void internal_check_comm_timeout(void)
  *
  * 5. **Read Encoder Count:** rx_encoder_read_count() -> state.encoder_counts[i]
  *
- * 6. **Aggregate E-Stop:** state.estop_active = shared_data_is_estop_active()
+ * 6. **Read Current:** rx_bus_adc_read_voltage_mv() + rx_drv8263_adc_to_amps()
+ *    -> state.current_ma[i]  (DRV8263H IPROPI: V = I * 202e-6 * 5100 = I * 1.0302)
  *
- * 7. **E-Stop Reason:** state.estop_reason = shared_data_get_estop_reason()
+ * 7. **Aggregate E-Stop:** state.estop_active = shared_data_is_estop_active()
  *
- * 8. **Mode:** state.mode = estop ? k_motor_mode_estop : k_motor_mode_velocity
+ * 8. **E-Stop Reason:** state.estop_reason = shared_data_get_estop_reason()
  *
- * 9. **Write to Shared Data:** shared_data_update_motor_state(&state)
+ * 9. **Mode:** state.mode = estop ? k_motor_mode_estop : k_motor_mode_velocity
+ *
+ * 10. **Write to Shared Data:** shared_data_update_motor_state(&state)
  *
  * @return void Function always completes (no error return)
  *
@@ -2846,6 +2879,8 @@ static void internal_check_comm_timeout(void)
  * @see rx_encoder_read_velocity() Read motor velocity
  * @see rx_motor_get_duty() Read PWM duty cycle
  * @see rx_encoder_read_count() Read encoder position
+ * @see rx_bus_adc_read_voltage_mv() Read IPROPI voltage for current sensing
+ * @see rx_drv8263_adc_to_amps() Convert IPROPI voltage to motor current (A)
  *
  * @since Version 1.0.0
  *
@@ -2872,6 +2907,14 @@ static void internal_update_motor_state(void)
     err = internal_read_encoder_count(i, &s_encoder_state[i]);
     if (err == k_rx_ok) {
       state.encoder_counts[i] = s_encoder_state[i].total_count;
+    }
+
+    /* Motor current (DRV8263H IPROPI -> S12AD0): V = I * 202e-6 * 5100 = I * 1.0302 */
+    uint32_t voltage_mv = 0U;
+    err = rx_bus_adc_read_voltage_mv(&g_bus_manager, s_motor_current_bus_names[i], &voltage_mv);
+    if (err == k_rx_ok) {
+      const float voltage_v = (float)voltage_mv / 1000.0F;
+      state.current_ma[i]   = rx_drv8263_adc_to_amps(voltage_v) * 1000.0F;
     }
   }
 

--- a/star-rx72n-firmware/src/tasks/motor_control_task.c
+++ b/star-rx72n-firmware/src/tasks/motor_control_task.c
@@ -455,8 +455,7 @@ typedef enum : uint16_t {
  * 341 pulses per revolution (PPR) x 4 (quadrature decoding edges) = 1364
  * counts per revolution. This provides ~0.26deg angular resolution.
  *
- * @invariant k_motor_count must match the number of H-bridge channels
- *            physically wired on the PCB (4 channels fixed)
+ * @invariant k_motor_count is authoritative in motor_control_task.h (motor_count_t)
  * @invariant k_control_period_us must match the ThreadX tick period in
  *            microseconds (10 ticks/s x 1000 us/tick = 10000 us)
  *
@@ -469,12 +468,11 @@ typedef enum : uint16_t {
  *
  * @see motor_hw_constants_t Hardware-level PWM and current parameters
  * @see motor_task_constants_t Task scheduling constants
+ * @see motor_count_t Authoritative k_motor_count (motor_control_task.h)
  *
  * @since Version 1.0.0
  */
 typedef enum : uint16_t {
-  k_motor_count =
-    4, /**< Number of motors: 4 wheels (front-left, front-right, back-left, back-right) */
   k_control_period_us = 10000, /**< Control period: 10000 us = 10ms = 100 Hz control loop rate */
   k_active_brake_ms   = 50, /**< Active brake duration: 50ms short-circuit braking before coast */
   k_active_brake_duty = 30, /**< Active brake PWM duty: 30% duty cycle during braking phase */
@@ -836,17 +834,37 @@ static bool s_timeout_estop_triggered = false;
  *
  * @details
  * Preserved across control loop iterations so that a transient ADC read
- * failure does not silently zero the current value used for overcurrent
- * protection. On the first iteration this is 0 mA (BSS zero-init), which
- * is safe -- the overcurrent check cannot false-trigger at 0 mA.
+ * failure does not discard the most recent valid measurement. Only used
+ * when s_last_good_current_valid[i] == true; BSS zero-init is NOT treated
+ * as a valid 0 mA sample.
  *
  * @note Static allocation: no dynamic memory (NASA Rule 3).
  * @note Written only on successful rx_bus_adc_read_voltage_mv() calls.
  * @warning Direct modification outside internal_update_motor_state() is
  *          forbidden -- read path owns this state.
+ * @see s_last_good_current_valid Validity flag that guards access to this array
  * @since Version 1.0.0
  */
 static float s_last_good_current_ma[k_motor_count];
+
+/**
+ * @var s_last_good_current_valid
+ * @brief Per-channel validity flag for s_last_good_current_ma[]
+ *
+ * @details
+ * Set to true only after the first successful rx_bus_adc_read_voltage_mv()
+ * call for each channel. When false the BSS-zero value in
+ * s_last_good_current_ma[i] must not be published or used for safety checks;
+ * internal_update_motor_state() trips the overcurrent e-stop as a fail-safe
+ * until a valid sample arrives.
+ *
+ * @note BSS zero-init means all channels start as invalid (false). This is
+ *       intentional: unsampled current must not be assumed to be 0 mA.
+ * @note Written only by internal_update_motor_state().
+ * @see s_last_good_current_ma Values guarded by this array
+ * @since Version 1.0.0
+ */
+static bool s_last_good_current_valid[k_motor_count];
 
 /** @brief Flag to track if currently in active brake sequence */
 static bool s_active_brake_in_progress = false;
@@ -2885,7 +2903,10 @@ static void internal_check_comm_timeout(void)
  * 6. **Read Current:** rx_bus_adc_read_voltage_mv() + rx_drv8263_adc_to_amps()
  *    -> state.current_ma[i]  (DRV8263H IPROPI: V = I * 202e-6 * 5100 = I * 1.0302)
  *
- * 7. **Overcurrent Check:** if |state.current_ma[i]| > k_motor_current_limit_ma (2 A)
+ * 7. **Validity gate:** if !s_last_good_current_valid[i]
+ *    -> trigger overcurrent e-stop as fail-safe; skip publishing for this channel
+ *
+ * 7b. **Overcurrent Check:** if |state.current_ma[i]| > k_motor_current_limit_ma (2 A)
  *    -> call shared_data_trigger_estop(k_estop_reason_overcurrent)
  *
  * 8. **Aggregate E-Stop:** state.estop_active = shared_data_is_estop_active()
@@ -2948,8 +2969,15 @@ static void internal_update_motor_state(void)
     uint32_t voltage_mv = 0U;
     err = rx_bus_adc_read_voltage_mv(&g_bus_manager, g_motor_current_bus_names[i], &voltage_mv);
     if (err == k_rx_ok) {
-      const float voltage_v     = (float)voltage_mv / s_mv_per_v;
-      s_last_good_current_ma[i] = rx_drv8263_adc_to_amps(voltage_v) * s_ma_per_a;
+      const float voltage_v        = (float)voltage_mv / s_mv_per_v;
+      s_last_good_current_ma[i]    = rx_drv8263_adc_to_amps(voltage_v) * s_ma_per_a;
+      s_last_good_current_valid[i] = true;
+    }
+
+    /* Fail-safe: treat unsampled channel as unsafe until first valid read */
+    if (!s_last_good_current_valid[i]) {
+      (void)shared_data_trigger_estop(k_estop_reason_overcurrent);
+      continue;
     }
 
     /* Safety check on last-good current (preserved across ADC read failures) */

--- a/star-rx72n-firmware/src/tasks/motor_control_task.c
+++ b/star-rx72n-firmware/src/tasks/motor_control_task.c
@@ -620,6 +620,12 @@ static const float s_pid_output_min_percent = -100.0F;
 /** @brief PID output maximum (percent duty) */
 static const float s_pid_output_max_percent = 100.0F;
 
+/** @brief Millivolts per volt: converts ADC millivolt reading to volts */
+static const float s_mv_per_v = 1000.0F;
+
+/** @brief Milliamps per amp: converts rx_drv8263_adc_to_amps() result to mA */
+static const float s_ma_per_a = 1000.0F;
+
 /** @brief PID integral minimum (percent, anti-windup clamp) */
 static const float s_pid_integral_min_percent = -50.0F;
 
@@ -824,6 +830,24 @@ static const float s_dt_sec = 0.004f;
 /** @brief Flag to track if timeout e-stop was already triggered */
 static bool s_timeout_estop_triggered = false;
 
+/**
+ * @var s_last_good_current_ma
+ * @brief Last successfully read motor current for each channel (mA)
+ *
+ * @details
+ * Preserved across control loop iterations so that a transient ADC read
+ * failure does not silently zero the current value used for overcurrent
+ * protection. On the first iteration this is 0 mA (BSS zero-init), which
+ * is safe -- the overcurrent check cannot false-trigger at 0 mA.
+ *
+ * @note Static allocation: no dynamic memory (NASA Rule 3).
+ * @note Written only on successful rx_bus_adc_read_voltage_mv() calls.
+ * @warning Direct modification outside internal_update_motor_state() is
+ *          forbidden -- read path owns this state.
+ * @since Version 1.0.0
+ */
+static float s_last_good_current_ma[k_motor_count];
+
 /** @brief Flag to track if currently in active brake sequence */
 static bool s_active_brake_in_progress = false;
 
@@ -831,13 +855,15 @@ static bool s_active_brake_in_progress = false;
 static const char* const s_tag = "MOTOR";
 
 /**
- * @var s_motor_current_bus_names
+ * @var g_motor_current_bus_names
  * @brief ADC bus names for motor current sensing, indexed by motor index
  *
  * @details
- * Maps motor index [0..3] to the bus manager name for its IPROPI current
- * sense channel. Each entry corresponds to one DRV8263H-Q1 IPROPI output
- * sampled by S12AD0. Channel-to-motor assignment follows PCB schematic:
+ * Single authoritative mapping from motor index [0..3] to the bus manager
+ * name for its IPROPI current-sense channel. Shared with main.c so that
+ * bus registration and ADC reads always reference the same string -- a
+ * rename only needs to happen here. Channel-to-motor assignment follows
+ * the PCB schematic:
  *
  * | Motor | Index | Bus Name       | ADC Ch | Pin |
  * |-------|-------|----------------|--------|-----|
@@ -847,12 +873,14 @@ static const char* const s_tag = "MOTOR";
  * | BR    | 3     | motor3_current | AN004  | P44 |
  *
  * @note String literals reside in .rodata (no dynamic allocation).
+ * @note Declared extern in motor_control_task.h; main.c uses it for
+ *       bus registration so the two files share one definition.
  * @warning Array size must match k_motor_count (4). Do not modify independently.
  * @see internal_update_motor_state() Consumer of this array
  * @see main.c internal_register_system_buses() Bus registrations
  * @since Version 1.0.0
  */
-static const char* const s_motor_current_bus_names[k_motor_count] = {
+const char* const g_motor_current_bus_names[k_motor_count] = {
   "motor0_current", /* Motor 0 (FL): AN007, ch 7, P47 */
   "motor1_current", /* Motor 1 (FR): AN006, ch 6, P46 */
   "motor2_current", /* Motor 2 (BL): AN005, ch 5, P45 */
@@ -2918,15 +2946,16 @@ static void internal_update_motor_state(void)
 
     /* Motor current (DRV8263H IPROPI -> S12AD0): V = I * 202e-6 * 5100 = I * 1.0302 */
     uint32_t voltage_mv = 0U;
-    err = rx_bus_adc_read_voltage_mv(&g_bus_manager, s_motor_current_bus_names[i], &voltage_mv);
+    err = rx_bus_adc_read_voltage_mv(&g_bus_manager, g_motor_current_bus_names[i], &voltage_mv);
     if (err == k_rx_ok) {
-      const float voltage_v = (float)voltage_mv / 1000.0F;
-      state.current_ma[i]   = rx_drv8263_adc_to_amps(voltage_v) * 1000.0F;
+      const float voltage_v     = (float)voltage_mv / s_mv_per_v;
+      s_last_good_current_ma[i] = rx_drv8263_adc_to_amps(voltage_v) * s_ma_per_a;
+    }
 
-      /* Overcurrent protection: trigger e-stop if |current| exceeds 2 A limit */
-      if (fabsf(state.current_ma[i]) > (float)k_motor_current_limit_ma) {
-        (void)shared_data_trigger_estop(k_estop_reason_overcurrent);
-      }
+    /* Safety check on last-good current (preserved across ADC read failures) */
+    state.current_ma[i] = s_last_good_current_ma[i];
+    if (fabsf(state.current_ma[i]) > (float)k_motor_current_limit_ma) {
+      (void)shared_data_trigger_estop(k_estop_reason_overcurrent);
     }
   }
 

--- a/star-rx72n-firmware/src/tasks/motor_control_task.c
+++ b/star-rx72n-firmware/src/tasks/motor_control_task.c
@@ -2976,7 +2976,7 @@ static void internal_update_motor_state(void)
 
     /* Fail-safe: treat unsampled channel as unsafe until first valid read */
     if (!s_last_good_current_valid[i]) {
-      (void)shared_data_trigger_estop(k_estop_reason_overcurrent);
+      (void)shared_data_trigger_estop(k_estop_reason_sensor_failure);
       continue;
     }
 

--- a/star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -1779,16 +1779,17 @@ static telemetry_transport_t internal_select_transport(void)
  * | k_estop_reason_comm_timeout | ESTOP_REASON_COMM_TIMEOUT                  |
  * | k_estop_reason_obstacle     | ESTOP_REASON_OBSTACLE                      |
  * | k_estop_reason_driver_fault | ESTOP_REASON_FAULT                         |
- * | k_estop_reason_overcurrent  | ESTOP_REASON_OVERCURRENT                   |
- * | k_estop_reason_manual       | ESTOP_REASON_MANUAL                        |
- * | (unrecognized)              | ESTOP_REASON_UNKNOWN (safe default)        |
+ * | k_estop_reason_overcurrent    | ESTOP_REASON_OVERCURRENT                   |
+ * | k_estop_reason_manual         | ESTOP_REASON_MANUAL                        |
+ * | k_estop_reason_sensor_failure | ESTOP_REASON_FAULT (closest proto value)   |
+ * | (unrecognized)                | ESTOP_REASON_UNKNOWN (safe default)        |
  *
  * @param[in] reason Firmware estop reason code from shared_data
  *
  * @return star_v1_EstopReason Corresponding proto enum value
  * @retval star_v1_EstopReason_ESTOP_REASON_UNKNOWN Unknown or no estop active
  * @retval star_v1_EstopReason_ESTOP_REASON_MANUAL  Manual software command
- * @retval star_v1_EstopReason_ESTOP_REASON_FAULT   Motor driver hardware fault
+ * @retval star_v1_EstopReason_ESTOP_REASON_FAULT   Motor driver or sensor failure
  * @retval star_v1_EstopReason_ESTOP_REASON_COMM_TIMEOUT Communication timeout
  * @retval star_v1_EstopReason_ESTOP_REASON_OBSTACLE Obstacle too close
  * @retval star_v1_EstopReason_ESTOP_REASON_OVERCURRENT Motor overcurrent
@@ -1825,6 +1826,8 @@ static star_v1_EstopReason internal_map_estop_reason(estop_reason_t reason)
       return star_v1_EstopReason_ESTOP_REASON_OVERCURRENT;
     case k_estop_reason_manual:
       return star_v1_EstopReason_ESTOP_REASON_MANUAL;
+    case k_estop_reason_sensor_failure:
+      return star_v1_EstopReason_ESTOP_REASON_FAULT;
     case k_estop_reason_none:
     default:
       return star_v1_EstopReason_ESTOP_REASON_UNKNOWN;

--- a/star-rx72n-firmware/tests/mocks/mock_shared_data.h
+++ b/star-rx72n-firmware/tests/mocks/mock_shared_data.h
@@ -106,12 +106,13 @@ typedef enum : uint8_t {
  * @brief Emergency stop trigger reasons
  */
 typedef enum : uint8_t {
-  k_estop_reason_none         = 0, /**< No e-stop active */
-  k_estop_reason_comm_timeout = 1, /**< No commands for 500ms */
-  k_estop_reason_obstacle     = 2, /**< Obstacle detected by HC-SR04 */
-  k_estop_reason_driver_fault = 3, /**< Motor driver hardware fault detected */
-  k_estop_reason_overcurrent  = 4, /**< Motor overcurrent detected */
-  k_estop_reason_manual       = 5, /**< Manual e-stop request */
+  k_estop_reason_none           = 0, /**< No e-stop active */
+  k_estop_reason_comm_timeout   = 1, /**< No commands for 500ms */
+  k_estop_reason_obstacle       = 2, /**< Obstacle detected by HC-SR04 */
+  k_estop_reason_driver_fault   = 3, /**< Motor driver hardware fault detected */
+  k_estop_reason_overcurrent    = 4, /**< Motor overcurrent detected */
+  k_estop_reason_manual         = 5, /**< Manual e-stop request */
+  k_estop_reason_sensor_failure = 6, /**< ADC or sensor read failure */
 } estop_reason_t;
 
 /* =============================================================================


### PR DESCRIPTION
## Summary
- Replaces the placeholder `"adc0"` generic bus with 4 dedicated per-channel ADC buses (`motor0_current` through `motor3_current`) mapped to S12AD0 channels AN004–AN007 (pins P44–P47), one per DRV8263H-Q1 IPROPI output
- Adds `rx_bus_adc_init()` calls in `internal_register_system_buses()` so each channel is fully initialised before tasks start (the old registration never initialised the ADC hardware)
- Reads IPROPI voltage at 100 Hz inside `internal_update_motor_state()`, converts to mA via `rx_drv8263_adc_to_amps()`, and writes to `shared_data` `motor_state.current_ma[]` so telemetry can forward live current readings to the RPi5

## Test plan
- [x] Cross-compile with GNURX passes (`bash build.sh`) — zero warnings/errors
- [x] All 51 unit tests pass (`ctest --output-on-failure`)
- [x] `make format-rx72n` reports all files already properly formatted
- [x] Code review checklist:
  - [x] NASA Power of 10 rules followed (no dynamic alloc, all return values checked, bounds on loop)
  - [x] SOLID principles applied (bus abstraction used, motor task depends on interface not hardware)
  - [x] Doxygen documentation complete for all new variables and updated algorithm steps
  - [x] No magic numbers (all channel/unit/resolution values are named enum constants)
  - [x] Inclusive terminology used

Closes #421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-motor real-time current sensing and dedicated current-sense buses for four motors.
  * Automatic overcurrent detection that triggers an emergency stop when limits are exceeded.
  * Preserves last-good current readings per motor to tolerate transient ADC faults and improve stability.
  * Exposes motor-current bus names for use by other components.

* **Documentation**
  * Updated comments and docs describing the new current-sensing and overcurrent flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->