### PR TITLE
feat(gpio): implement HOST_IRQ (P67) data-ready signal to RPi5 (issue #417)

### DIFF
--- a/star-rx72n-firmware/src/hardware_init.c
+++ b/star-rx72n-firmware/src/hardware_init.c
@@ -292,6 +292,10 @@ typedef enum : uint16_t {
   k_pin_host_sclk = k_rx_pd_3, /**< PD.3 - SCLK (RSPI2 clock from RPi5) */
   k_pin_host_cs0  = k_rx_pd_4, /**< PD.4 - CS0 (chip select from RPi5) */
 
+  /* Host control signals */
+  k_pin_host_irq =
+    k_rx_p6_7, /**< P6.7 - HOST_IRQ (active-low output to RPi5, data ready, pin 98) */
+
   /* MTU Encoder clock inputs (front wheels) */
   k_pin_enc0_pha = k_rx_p2_4, /**< P2.4 - MTCLKA (encoder 0 phase A) */
   k_pin_enc0_phb = k_rx_p2_5, /**< P2.5 - MTCLKB (encoder 0 phase B) */
@@ -890,6 +894,49 @@ static rx_err_t internal_gpio_init_imu(void)
 }
 
 /**
+ * @brief Configure HOST_IRQ output pin (P67, active-low data-ready signal to RPi5)
+ *
+ * @details
+ * Configures P6.7 (pin 98) as a GPIO output, initialised HIGH (deasserted).
+ * The telemetry task drives this pin LOW immediately before each telemetry
+ * send and HIGH again after the send completes, giving the RPi5 a hardware
+ * data-ready interrupt instead of requiring fixed-rate polling.
+ *
+ * | Signal   | Pin | Direction | Active Level | Default |
+ * |----------|-----|-----------|--------------|---------|
+ * | HOST_IRQ | P67 | Output    | LOW          | HIGH    |
+ *
+ * @return rx_err_t Error code
+ * @retval k_rx_ok Pin configured successfully
+ * @retval k_rx_err_hw_init_failed MPC GPIO configuration failed
+ *
+ * @pre MPC write protection disabled (PWPR.B0WI=0, PWPR.PFSWE=1)
+ * @pre P6.7 not in use by another peripheral
+ * @post P6.7 configured as GPIO output, driven HIGH (deasserted, no data pending)
+ * @post RPi5 sees HOST_IRQ HIGH (idle/no-data state)
+ *
+ * @note Thread-safe. No shared state modified.
+ * @note Called only during single-threaded initialization before RTOS start.
+ *
+ * @see telemetry_task.c internal_build_and_send_telemetry() Asserts/deasserts at runtime
+ * @see rx_port_constants.h k_rx_p6_7 for the combined port/pin constant
+ *
+ * @since Version 1.0.0
+ */
+static rx_err_t internal_gpio_init_host_irq(void)
+{
+  static const char* s_tag = "GPIO_IRQ";
+
+  rx_err_t err = rx_mpc_set_gpio((rx_port_pin_t)k_pin_host_irq);
+  RX_RETURN_ON_ERROR(err, s_tag, "HOST_IRQ MPC config failed");
+
+  /* Initial HIGH = deasserted (no data pending) */
+  internal_gpio_set_output((rx_port_pin_t)k_pin_host_irq, true);
+
+  return k_rx_ok;
+}
+
+/**
  * @brief Configure DRV8263H motor driver control pins (DRVOFF + nSLEEP)
  *
  * @details
@@ -1269,6 +1316,9 @@ static rx_err_t gpio_init(void)
 
   err = internal_gpio_init_host_spi();
   RX_RETURN_ON_ERROR(err, s_tag, "Host SPI pin init failed");
+
+  err = internal_gpio_init_host_irq();
+  RX_RETURN_ON_ERROR(err, s_tag, "HOST_IRQ pin init failed");
 
   err = internal_gpio_init_mtu_encoders();
   RX_RETURN_ON_ERROR(err, s_tag, "MTU encoder pin init failed");

--- a/star-rx72n-firmware/src/hardware_init.c
+++ b/star-rx72n-firmware/src/hardware_init.c
@@ -1561,6 +1561,21 @@ static void validate_peripherals(void)
 }
 
 /**
+ * @var g_pin_host_irq
+ * @brief Canonical pin identifier for the HOST_IRQ output signal (P6.7, active-low)
+ *
+ * @details
+ * Single authoritative definition of the HOST_IRQ GPIO pin.  Consumers
+ * (e.g. telemetry_task) use this constant with gpio_write_low() /
+ * gpio_write_high() instead of embedding the raw port/bit literal.
+ *
+ * @note Read-only after hardware_init() completes.
+ * @since Version 1.0.0
+ * @see internal_gpio_init_host_irq() Configures pin direction and initial level
+ */
+const rx_port_pin_t g_pin_host_irq = (rx_port_pin_t)k_pin_host_irq;
+
+/**
  * @brief Initialize all application-specific hardware peripherals for STAR motor controller
  *
  * @details

--- a/star-rx72n-firmware/src/inc/hardware_init.h
+++ b/star-rx72n-firmware/src/inc/hardware_init.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "rx_err.h"
+#include "rx_port_constants.h"
 
 /**
  * @brief Initialize all application hardware peripherals
@@ -34,3 +35,26 @@
  * @see main() Calls this function during boot
  */
 rx_err_t hardware_init(void);
+
+/**
+ * @var g_pin_host_irq
+ * @brief Canonical pin identifier for the HOST_IRQ output signal
+ *
+ * @details
+ * Identifies GPIO pin P6.7 (RX72N package pin 98), which drives the active-low
+ * HOST_IRQ line to the RPi5.  Assert LOW before sending telemetry; deassert HIGH
+ * after the transfer completes (or on error).
+ *
+ * Using a single named constant ensures that every module (hardware_init,
+ * telemetry_task, future modules) refers to the same pin without embedding the
+ * raw port/bit value at multiple call sites.
+ *
+ * @note Read-only.  Do not modify from application code.
+ * @warning Only hardware_init.c may initialise this pin direction; all other
+ *          modules must use gpio_write_low() / gpio_write_high() exclusively.
+ * @since Version 1.0.0
+ * @see hardware_init() Configures this pin as a GPIO output, initially HIGH
+ * @see gpio_write_low()  Assert HOST_IRQ (data ready)
+ * @see gpio_write_high() Deassert HOST_IRQ (transfer complete)
+ */
+extern const rx_port_pin_t g_pin_host_irq;

--- a/star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -680,12 +680,14 @@
 
 #include "telemetry_task.h"
 
+#include "hardware.h"
 #include "rx_check.h"
 #include "rx_comm_manager.h"
 #include "rx_frame.h"
 #include "rx_iwdt.h"
 #include "rx_log.h"
 #include "rx_nanopb.h"
+#include "rx_port_constants.h"
 #include "shared_data.h"
 #include "tx_api.h"
 
@@ -2289,7 +2291,9 @@ static rx_err_t internal_send_via_channel(rx_comm_channel_t channel, uint32_t en
  * 2. **internal_collect_state()** - populate motor and temperature fields
  * 3. **internal_encode_telemetry()** - nanopb encode to s_telem_buffer
  * 4. **internal_select_transport()** - USB preferred, SPI fallback
- * 5. **internal_send_via_channel()** - transmit via comm manager
+ * 5. **Assert HOST_IRQ LOW** (P67, active-low) to notify RPi5 data is ready
+ * 6. **internal_send_via_channel()** - transmit via comm manager
+ * 7. **Deassert HOST_IRQ HIGH** (P67) regardless of send outcome
  *
  * Encoding failure is fatal for this cycle (message not sent, retry next cycle).
  * Send failure is non-critical (message lost, host detects via sequence gap).
@@ -2309,6 +2313,7 @@ static rx_err_t internal_send_via_channel(rx_comm_channel_t channel, uint32_t en
  * @pre Task created and running (telemetry_task_create() called)
  *
  * @post Telemetry message sent via USB CDC (primary) or SPI (fallback)
+ * @post HOST_IRQ (P67) is HIGH (deasserted) on return, regardless of send result
  * @post s_sequence incremented exactly once per call
  * @post s_telem_buffer overwritten with latest encoded protobuf
  *
@@ -2366,9 +2371,16 @@ static rx_err_t internal_build_and_send_telemetry(void)
     return k_rx_err_invalid_state;
   }
 
+  /* Assert HOST_IRQ LOW (P67, active-low) to notify RPi5 that data is ready */
+  (void)gpio_write_low((rx_port_pin_t)k_rx_p6_7);
+
   /* Map transport to channel and send */
   channel = (transport == k_telemetry_transport_usb) ? k_comm_channel_usb : k_comm_channel_spi;
   err     = internal_send_via_channel(channel, encoded_len);
+
+  /* Deassert HOST_IRQ HIGH regardless of send outcome */
+  (void)gpio_write_high((rx_port_pin_t)k_rx_p6_7);
+
   if (err != k_rx_ok) {
     return err;
   }

--- a/star-rx72n-firmware/src/tasks/telemetry_task.c
+++ b/star-rx72n-firmware/src/tasks/telemetry_task.c
@@ -681,13 +681,13 @@
 #include "telemetry_task.h"
 
 #include "hardware.h"
+#include "hardware_init.h"
 #include "rx_check.h"
 #include "rx_comm_manager.h"
 #include "rx_frame.h"
 #include "rx_iwdt.h"
 #include "rx_log.h"
 #include "rx_nanopb.h"
-#include "rx_port_constants.h"
 #include "shared_data.h"
 #include "tx_api.h"
 
@@ -2371,15 +2371,15 @@ static rx_err_t internal_build_and_send_telemetry(void)
     return k_rx_err_invalid_state;
   }
 
-  /* Assert HOST_IRQ LOW (P67, active-low) to notify RPi5 that data is ready */
-  (void)gpio_write_low((rx_port_pin_t)k_rx_p6_7);
+  /* Assert HOST_IRQ LOW (active-low) to notify RPi5 that data is ready */
+  (void)gpio_write_low(g_pin_host_irq);
 
   /* Map transport to channel and send */
   channel = (transport == k_telemetry_transport_usb) ? k_comm_channel_usb : k_comm_channel_spi;
   err     = internal_send_via_channel(channel, encoded_len);
 
   /* Deassert HOST_IRQ HIGH regardless of send outcome */
-  (void)gpio_write_high((rx_port_pin_t)k_rx_p6_7);
+  (void)gpio_write_high(g_pin_host_irq);
 
   if (err != k_rx_ok) {
     return err;


### PR DESCRIPTION
## Summary
- Configure P6.7 (pin 98, HOST_IRQ) as a GPIO output in `hardware_init.c` via new `internal_gpio_init_host_irq()`, defaulting HIGH (deasserted, no data pending)
- Assert HOST_IRQ LOW before each telemetry send in `internal_build_and_send_telemetry()` and deassert HIGH after the send completes — regardless of success or failure
- Allows the RPi5 to interrupt-drive its SPI reads on the falling edge of HOST_IRQ instead of polling at a fixed 20 Hz rate, reducing latency and RPi5 CPU usage

## Test plan
- [x] Cross-compile with GNURX passes (`bash build.sh`) — zero warnings/errors
- [x] All 51 unit tests pass (`ctest --output-on-failure`)
- [x] `make format-rx72n` reports all files properly formatted
- [x] Code review checklist:
  - [x] NASA Power of 10 rules followed (all return values cast void intentionally — deassert must always run)
  - [x] Doxygen complete for `internal_gpio_init_host_irq()` and updated `@post` / algorithm steps in `internal_build_and_send_telemetry()`
  - [x] No magic numbers (`k_pin_host_irq = k_rx_p6_7` in pin enum, `k_rx_p6_7` used at call site)
  - [x] Inclusive terminology used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HOST_IRQ control signal pin to hardware configuration.
  * Configured HOST_IRQ pin initialization with default HIGH state.
  * Implemented HOST_IRQ signaling sequence: assert LOW before data transmission, deassert HIGH after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->