### PR TITLE
feat(ros2): bridge BBB telemetry and cmd_vel through gateway

### DIFF
--- a/star-ros2/src/star_bringup/launch/slam.launch.py
+++ b/star-ros2/src/star_bringup/launch/slam.launch.py
@@ -62,6 +62,12 @@ def generate_launch_description():
         description='Run EKF odometry fusion (disable in dev mode - use static odom TF instead)'
     )
 
+    use_bbb_arg = DeclareLaunchArgument(
+        'use_bbb', default_value='true',
+        description='Enable BeagleBone Blue telemetry bridging (publishes /odom/unfiltered, '
+                    '/imu/data, /joint_states from BBB via gateway and forwards /cmd_vel to BBB)'
+    )
+
     # RPLiDAR C1 requires sllidar_ros2 (Slamtec's newer driver with SDK 2.x).
     # rplidar_ros 2.1.0 uses SDK 1.12.0 which returns 0x80008000/0x80008002 for the C1's
     # DTOF scan protocol. sllidar_ros2 uses the updated SDK that supports C1 natively.
@@ -158,14 +164,37 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('use_nav2')),
     )
 
+    # Gateway bridge node -- bridges ROS2 to Go gateway via gRPC.
+    # When use_bbb is true, also bridges BBB telemetry to ROS2 topics and
+    # forwards /cmd_vel to BBB motors via gateway.
+    gateway_bridge = Node(
+        package='star_gateway_bridge',
+        executable='star_gateway_bridge_main',
+        name='star_gateway_bridge',
+        output='screen',
+        parameters=[{
+            'gateway_address': 'localhost:50051',
+            'telemetry_rate_hz': 10.0,
+            'teleop_rate_hz': 50.0,
+            'use_bbb_telemetry': LaunchConfiguration('use_bbb'),
+            'wheel_base': 0.150,
+            'wheel_radius': 0.0325,
+            'ticks_per_rev': 11599,
+        }],
+        respawn=True,
+        respawn_delay=RESPAWN_DELAY_SEC,
+    )
+
     return LaunchDescription([
         serial_port_arg,
         use_nav2_arg,
         use_ekf_arg,
+        use_bbb_arg,
         static_tf,
         ekf,
         static_odom_tf,
         rplidar,
+        gateway_bridge,
         slam,
         nav2,
     ])

--- a/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/message_converter.hpp
+++ b/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/message_converter.hpp
@@ -4,13 +4,13 @@
  * Protocol Buffers.
  *
  * @details
- * Provides stateless converter functions for translating between ROS2 message
- * types and the STAR protobuf schema used by the gateway service. All
- * converters validate inputs for NaN/infinity and apply safe clamping where
- * applicable.
+ * Provides converter functions for translating between ROS2 message types and
+ * the STAR protobuf schema used by the gateway service. Static methods are
+ * stateless and thread-safe. BBB telemetry methods (telemetry_to_odometry,
+ * telemetry_to_joint_state) hold dead-reckoning state and are NOT thread-safe.
  *
- * @note All conversion functions are stateless and thread-safe when called from
- * different threads on separate message instances.
+ * @note Static conversion functions are thread-safe. Instance BBB methods
+ * must be called from a single thread (the ROS2 timer executor).
  *
  * @since Version 1.0.0
 
@@ -44,9 +44,19 @@ namespace star::star_gateway_bridge
 /**
  * @brief Message converter for ROS2 <-> Protobuf translation.
  *
- * Provides stateless conversion functions with input validation and unit
- * conversions. All conversions validate for NaN/infinity and clamp values to
- * safe ranges.
+ * @details
+ * Provides conversion functions with input validation and unit conversions.
+ * Static methods (twist_to_velocity_command, odometry_to_proto, etc.) are
+ * stateless and thread-safe. BBB telemetry methods (telemetry_to_odometry,
+ * telemetry_to_joint_state) are stateful -- they hold dead-reckoning pose
+ * and previous encoder tick baselines -- and are NOT thread-safe. Call
+ * init_bbb_params() before using any BBB conversion method.
+ *
+ * @note BBB conversion methods mutate internal state and must be called from
+ * a single thread (the ROS2 timer executor).
+ *
+ * @see StarGatewayBridgeNode  Owner of the converter instance.
+ * @since Version 1.0.0
  */
 class MessageConverter {
 public:
@@ -312,19 +322,34 @@ public:
   // ===========================================================================
 
   /**
-   * @brief Configuration for BBB telemetry conversions.
+   * @struct BbbParams
+   * @brief Platform geometry and encoder configuration for BBB telemetry
+   *        conversions.
    *
    * @details
-   * Parameters matching the STAR differential drive platform.
-   * Used by telemetry_to_odometry() and telemetry_to_joint_state().
+   * Defines the physical parameters of the STAR differential-drive robot
+   * needed to convert raw encoder ticks into metric odometry and joint states.
+   * All values must be strictly positive.
+   *
+   * @code
+   * MessageConverter::BbbParams params{0.150, 0.0325, 11599};
+   * converter.init_bbb_params(params);
+   * @endcode
+   *
+   * @see init_bbb_params()          Applies these parameters to the converter.
+   * @see telemetry_to_odometry()    Consumes wheel_base and ticks_per_rev.
+   * @see telemetry_to_joint_state() Consumes wheel_radius and ticks_per_rev.
    *
    * @since Version 1.1.0
    */
   struct BbbParams
   {
-    double wheel_base;    /**< Track width in metres (default 0.150). */
-    double wheel_radius;  /**< Wheel radius in metres (default 0.0325). */
-    int32_t ticks_per_rev; /**< Encoder ticks per wheel revolution (default 11599). */
+    double wheel_base;     /**< Track width in metres (centre-to-centre between
+                                left and right wheels). Must be > 0. */
+    double wheel_radius;   /**< Wheel radius in metres. Must be > 0. */
+    int32_t ticks_per_rev; /**< Encoder ticks per full wheel revolution.
+                                Must be > 0. STAR default: 11599 (341 PPR *
+                                34.02:1 gear ratio). */
   };
 
   /**
@@ -332,13 +357,26 @@ public:
    *
    * @details
    * Must be called before telemetry_to_odometry() or telemetry_to_joint_state().
-   * Sets up dead-reckoning state for odometry integration from encoder deltas.
+   * Resets all dead-reckoning state (pose, encoder tick baselines) so the
+   * converter starts fresh.
    *
    * @param[in] params Platform geometry and encoder configuration.
    *
-   * @pre params.wheel_base > 0 and params.wheel_radius > 0.
-   * @pre params.ticks_per_rev > 0.
+   * @pre params.wheel_base > 0, params.wheel_radius > 0, params.ticks_per_rev > 0.
+   * @post Dead-reckoning state reset to origin (0, 0, 0).
    * @post BBB conversion methods are ready for use.
+   *
+   * @throw std::invalid_argument If any parameter is non-positive.
+   *
+   * @note Not thread-safe; call from a single thread before starting timers.
+   *
+   * @code
+   * MessageConverter::BbbParams p{0.150, 0.0325, 11599};
+   * converter.init_bbb_params(p);
+   * @endcode
+   *
+   * @see telemetry_to_odometry()    Uses these params for dead-reckoning.
+   * @see telemetry_to_joint_state() Uses these params for tick-to-rad conversion.
    *
    * @since Version 1.1.0
    */
@@ -351,22 +389,39 @@ public:
    * @details
    * Computes pose (x, y, theta) from cumulative encoder tick deltas using
    * differential drive kinematics. Velocity is taken from encoder velocity_mps
-   * fields when non-zero. Covariance matrices are set to realistic values for
-   * robot_localization EKF fusion.
+   * fields. Covariance matrices are set to realistic values for
+   * robot_localization EKF fusion. Returns false if any encoder sub-message
+   * is missing, leaving odom and internal state unmodified.
    *
    * @param[in]  telemetry  TelemetryData from BBB via gateway gRPC.
    * @param[out] odom       Populated Odometry message (odom frame, base_link child).
    *
+   * @return true if conversion succeeded, false if encoder data incomplete.
+   * @retval true  All four encoder sub-messages present; odom populated.
+   * @retval false Incomplete telemetry; odom and DR state unchanged.
+   *
    * @pre init_bbb_params() must have been called.
    * @pre telemetry contains encoder_front_left/right/back_left/right sub-messages.
    * @post odom.header.frame_id == "odom", odom.child_frame_id == "base_link".
-   * @post Internal dead-reckoning state (x_, y_, theta_) is updated.
+   * @post Internal dead-reckoning state (dr_x_, dr_y_, dr_theta_) is updated.
    *
-   * @note NOT thread-safe; holds dead-reckoning state.
+   * @throw None.
+   * @note NOT thread-safe; mutates dead-reckoning state.
+   *
+   * @code
+   * nav_msgs::msg::Odometry odom;
+   * if (converter.telemetry_to_odometry(telemetry, odom)) {
+   *   odom.header.stamp = node->now();
+   *   odom_pub->publish(odom);
+   * }
+   * @endcode
+   *
+   * @see init_bbb_params()          Must be called first.
+   * @see telemetry_to_joint_state() Companion encoder conversion.
    *
    * @since Version 1.1.0
    */
-  void telemetry_to_odometry(
+  bool telemetry_to_odometry(
     const ::star::v1::TelemetryData & telemetry,
     nav_msgs::msg::Odometry & odom);
 
@@ -374,20 +429,36 @@ public:
    * @brief Convert TelemetryData IMU readings to sensor_msgs/Imu.
    *
    * @details
-   * Maps BNO055 IMU data (quaternion, gyro, accel) from protobuf to ROS2 Imu
-   * message. Orientation covariance is set for yaw-only fusion (2D mode).
+   * Maps BNO055/MPU-9250 IMU data (quaternion, gyro, accel) from protobuf to
+   * ROS2 Imu message. Orientation covariance is set for yaw-only fusion (2D
+   * mode). Returns false if the IMU sub-message is absent.
    *
    * @param[in]  telemetry  TelemetryData from BBB via gateway gRPC.
    * @param[out] imu_msg    Populated Imu message (imu_link frame).
    *
+   * @return true if IMU data present, false if telemetry.has_imu() is false.
+   * @retval true  IMU sub-message present; imu_msg populated.
+   * @retval false No IMU data; imu_msg unchanged.
+   *
    * @pre telemetry.imu() sub-message is populated.
    * @post imu_msg.header.frame_id == "imu_link".
    *
+   * @throw None.
    * @note Thread-safe; stateless conversion.
+   *
+   * @code
+   * sensor_msgs::msg::Imu imu;
+   * if (MessageConverter::telemetry_to_imu(telemetry, imu)) {
+   *   imu.header.stamp = node->now();
+   *   imu_pub->publish(imu);
+   * }
+   * @endcode
+   *
+   * @see telemetry_to_odometry() Companion encoder conversion.
    *
    * @since Version 1.1.0
    */
-  static void telemetry_to_imu(
+  static bool telemetry_to_imu(
     const ::star::v1::TelemetryData & telemetry,
     sensor_msgs::msg::Imu & imu_msg);
 
@@ -396,18 +467,36 @@ public:
    *
    * @details
    * Reports position (radians) and velocity (rad/s) for all four wheel joints.
+   * Returns false if any encoder sub-message is missing.
    *
    * @param[in]  telemetry    TelemetryData from BBB via gateway gRPC.
    * @param[out] joint_state  Populated JointState message.
    *
+   * @return true if all encoder data present, false if incomplete.
+   * @retval true  All four encoder sub-messages present; joint_state populated.
+   * @retval false Incomplete data; joint_state unchanged.
+   *
    * @pre init_bbb_params() must have been called.
    * @post joint_state.name has 4 entries matching wheel joint names.
    *
-   * @note Thread-safe; stateless conversion (uses params only).
+   * @throw None.
+   * @note Uses bbb_params_ but does not mutate state; safe to call concurrently
+   *       if bbb_params_ is not being written.
+   *
+   * @code
+   * sensor_msgs::msg::JointState js;
+   * if (converter.telemetry_to_joint_state(telemetry, js)) {
+   *   js.header.stamp = node->now();
+   *   joint_state_pub->publish(js);
+   * }
+   * @endcode
+   *
+   * @see init_bbb_params()       Must be called first.
+   * @see telemetry_to_odometry() Companion encoder conversion.
    *
    * @since Version 1.1.0
    */
-  void telemetry_to_joint_state(
+  bool telemetry_to_joint_state(
     const ::star::v1::TelemetryData & telemetry,
     sensor_msgs::msg::JointState & joint_state);
 

--- a/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/message_converter.hpp
+++ b/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/message_converter.hpp
@@ -27,6 +27,8 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/range.hpp>
 #include <std_msgs/msg/bool.hpp>
@@ -306,6 +308,110 @@ public:
     const rclcpp::Time & stamp, sensor_msgs::msg::Range & out);
 
   // ===========================================================================
+  // BBB Telemetry -> ROS2 Conversions (Protobuf -> ROS2)
+  // ===========================================================================
+
+  /**
+   * @brief Configuration for BBB telemetry conversions.
+   *
+   * @details
+   * Parameters matching the STAR differential drive platform.
+   * Used by telemetry_to_odometry() and telemetry_to_joint_state().
+   *
+   * @since Version 1.1.0
+   */
+  struct BbbParams
+  {
+    double wheel_base;    /**< Track width in metres (default 0.150). */
+    double wheel_radius;  /**< Wheel radius in metres (default 0.0325). */
+    int32_t ticks_per_rev; /**< Encoder ticks per wheel revolution (default 11599). */
+  };
+
+  /**
+   * @brief Initialize BBB telemetry converter with platform parameters.
+   *
+   * @details
+   * Must be called before telemetry_to_odometry() or telemetry_to_joint_state().
+   * Sets up dead-reckoning state for odometry integration from encoder deltas.
+   *
+   * @param[in] params Platform geometry and encoder configuration.
+   *
+   * @pre params.wheel_base > 0 and params.wheel_radius > 0.
+   * @pre params.ticks_per_rev > 0.
+   * @post BBB conversion methods are ready for use.
+   *
+   * @since Version 1.1.0
+   */
+  void init_bbb_params(const BbbParams & params);
+
+  /**
+   * @brief Convert TelemetryData encoder readings to nav_msgs/Odometry via
+   *        dead-reckoning integration.
+   *
+   * @details
+   * Computes pose (x, y, theta) from cumulative encoder tick deltas using
+   * differential drive kinematics. Velocity is taken from encoder velocity_mps
+   * fields when non-zero. Covariance matrices are set to realistic values for
+   * robot_localization EKF fusion.
+   *
+   * @param[in]  telemetry  TelemetryData from BBB via gateway gRPC.
+   * @param[out] odom       Populated Odometry message (odom frame, base_link child).
+   *
+   * @pre init_bbb_params() must have been called.
+   * @pre telemetry contains encoder_front_left/right/back_left/right sub-messages.
+   * @post odom.header.frame_id == "odom", odom.child_frame_id == "base_link".
+   * @post Internal dead-reckoning state (x_, y_, theta_) is updated.
+   *
+   * @note NOT thread-safe; holds dead-reckoning state.
+   *
+   * @since Version 1.1.0
+   */
+  void telemetry_to_odometry(
+    const ::star::v1::TelemetryData & telemetry,
+    nav_msgs::msg::Odometry & odom);
+
+  /**
+   * @brief Convert TelemetryData IMU readings to sensor_msgs/Imu.
+   *
+   * @details
+   * Maps BNO055 IMU data (quaternion, gyro, accel) from protobuf to ROS2 Imu
+   * message. Orientation covariance is set for yaw-only fusion (2D mode).
+   *
+   * @param[in]  telemetry  TelemetryData from BBB via gateway gRPC.
+   * @param[out] imu_msg    Populated Imu message (imu_link frame).
+   *
+   * @pre telemetry.imu() sub-message is populated.
+   * @post imu_msg.header.frame_id == "imu_link".
+   *
+   * @note Thread-safe; stateless conversion.
+   *
+   * @since Version 1.1.0
+   */
+  static void telemetry_to_imu(
+    const ::star::v1::TelemetryData & telemetry,
+    sensor_msgs::msg::Imu & imu_msg);
+
+  /**
+   * @brief Convert TelemetryData encoder readings to sensor_msgs/JointState.
+   *
+   * @details
+   * Reports position (radians) and velocity (rad/s) for all four wheel joints.
+   *
+   * @param[in]  telemetry    TelemetryData from BBB via gateway gRPC.
+   * @param[out] joint_state  Populated JointState message.
+   *
+   * @pre init_bbb_params() must have been called.
+   * @post joint_state.name has 4 entries matching wheel joint names.
+   *
+   * @note Thread-safe; stateless conversion (uses params only).
+   *
+   * @since Version 1.1.0
+   */
+  void telemetry_to_joint_state(
+    const ::star::v1::TelemetryData & telemetry,
+    sensor_msgs::msg::JointState & joint_state);
+
+  // ===========================================================================
   // Validation Helpers
   // ===========================================================================
 
@@ -342,6 +448,20 @@ public:
   static int64_t ros_time_to_us(const rclcpp::Time & time);
 
 private:
+  // BBB dead-reckoning state (for telemetry_to_odometry)
+  BbbParams bbb_params_{0.150, 0.0325, 11599};
+  bool bbb_params_initialized_{false};
+  double dr_x_{0.0};      /**< Dead-reckoning X position (m). */
+  double dr_y_{0.0};      /**< Dead-reckoning Y position (m). */
+  double dr_theta_{0.0};  /**< Dead-reckoning heading (rad). */
+  int64_t prev_ticks_fl_{0};
+  int64_t prev_ticks_fr_{0};
+  int64_t prev_ticks_bl_{0};
+  int64_t prev_ticks_br_{0};
+  bool first_odom_msg_{true};
+
+  static double normalize_angle(double angle);
+
   // Differential drive kinematics constants
   static constexpr double MAX_VELOCITY_MPS =
     2.0;   /**< VelocityCommand valid range (m/s); wheel and output velocities

--- a/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/star_gateway_bridge_node.hpp
+++ b/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/star_gateway_bridge_node.hpp
@@ -39,9 +39,13 @@
 #include <std_msgs/msg/string.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+
 #include <grpcpp/grpcpp.h>  // NOLINT(build/include_order)
 
 #include "star/v1/gateway_service.grpc.pb.h"
+#include "star/v1/motor_control.grpc.pb.h"
 #include "star/v1/telemetry.grpc.pb.h"
 #include "star_gateway_bridge/message_converter.hpp"
 
@@ -90,6 +94,9 @@ public:
    * - teleop_timeout_ms: Teleop command staleness timeout (default: 500ms)
    * - grpc_deadline_ms: gRPC call deadline (default: 100ms)
    * - wheel_base: Distance between wheels in meters (default: 0.150m)
+   * - use_bbb_telemetry: Enable BBB telemetry bridging (default: false)
+   * - wheel_radius: Wheel radius in meters (default: 0.0325m)
+   * - ticks_per_rev: Encoder ticks per revolution (default: 11599)
    *
    * @param options ROS2 node options for component configuration
    */
@@ -216,6 +223,48 @@ private:
   void obstacle_poll_timer_callback();
 
   // ===========================================================================
+  // BBB Telemetry Bridging
+  // ===========================================================================
+
+  /**
+   * @brief Callback for /cmd_vel topic -- forwards velocity commands to BBB via
+   *        MotorControlService::SetVelocity gRPC.
+   *
+   * @details
+   * Only active when use_bbb_telemetry_ is true. Converts the incoming Twist
+   * to a VelocityCommand protobuf and sends it to the Go gateway, which
+   * forwards it over USB CDC to the BeagleBone Blue.
+   *
+   * @param[in] msg Velocity command from Nav2 or teleop.
+   *
+   * @pre use_bbb_telemetry_ must be true and motor_control_stub_ non-null.
+   * @post VelocityCommand sent to gateway via gRPC or error logged.
+   *
+   * @note Not thread-safe; called from ROS2 executor only.
+   * @since Version 1.1.0
+   */
+  void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
+
+  /**
+   * @brief Timer callback that polls gateway telemetry and publishes BBB sensor
+   *        data to ROS2 topics at telemetry_rate_hz_.
+   *
+   * @details
+   * Only active when use_bbb_telemetry_ is true. Calls
+   * TelemetryService::GetTelemetry and publishes:
+   *   - /odom/unfiltered (nav_msgs/Odometry) from encoder dead-reckoning
+   *   - /imu/data (sensor_msgs/Imu) from BNO055/MPU-9250
+   *   - /joint_states (sensor_msgs/JointState) from encoder ticks
+   *
+   * @pre grpc_connected_ and telemetry_svc_stub_ must be valid.
+   * @post ROS2 messages published for EKF and robot_state_publisher consumption.
+   *
+   * @note Not thread-safe; called from ROS2 timer executor only.
+   * @since Version 1.1.0
+   */
+  void bbb_telemetry_poll_timer_callback();
+
+  // ===========================================================================
   // gRPC Helpers
   // ===========================================================================
 
@@ -242,6 +291,11 @@ private:
   // ROS2 Publishers
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr teleop_cmd_vel_pub_;
 
+  // BBB telemetry publishers (active when use_bbb_telemetry_ == true)
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr bbb_odom_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr bbb_imu_pub_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr bbb_joint_state_pub_;
+
   /** @brief Publisher for front-left HC-SR04 sensor distance (sensor_msgs/Range). */
   rclcpp::Publisher<sensor_msgs::msg::Range>::SharedPtr obstacle_fl_pub_;
   /** @brief Publisher for front-right HC-SR04 sensor distance (sensor_msgs/Range). */
@@ -255,6 +309,7 @@ private:
 
   // ROS2 Subscribers
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr robot_status_sub_;
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_sub_; /**< BBB cmd_vel forwarding */
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr
     odom_sub_;   /**< Receives filtered odometry and updates
                     cached_ekf_odometry_ under odometry_mutex_. */
@@ -275,6 +330,7 @@ private:
   /** @brief Timer that polls TelemetryService::GetTelemetry and publishes
    *         obstacle data at telemetry_rate_hz_ (default 10 Hz). */
   rclcpp::TimerBase::SharedPtr obstacle_timer_;
+  rclcpp::TimerBase::SharedPtr bbb_telemetry_timer_; /**< BBB odom/IMU polling */
 
   // gRPC Client
   std::shared_ptr<grpc::Channel> grpc_channel_;
@@ -291,6 +347,7 @@ private:
    * @since Version 1.0.0
    */
   std::unique_ptr<star::v1::TelemetryService::Stub> telemetry_svc_stub_;
+  std::unique_ptr<star::v1::MotorControlService::Stub> motor_control_stub_; /**< BBB motor commands */
 
   // Cached telemetry data (protected by mutexes)
   std::mutex robot_status_mutex_;
@@ -319,6 +376,10 @@ private:
   int teleop_timeout_ms_;
   int grpc_deadline_ms_;
   double wheel_base_;
+  bool use_bbb_telemetry_; /**< Enable BBB telemetry bridging mode. */
+  double wheel_radius_;    /**< Wheel radius in metres. */
+  int ticks_per_rev_;      /**< Encoder ticks per revolution. */
+  uint32_t cmd_vel_sequence_{0}; /**< Incrementing sequence for SetVelocity. */
 
   // Connection state
   bool grpc_connected_;

--- a/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/star_gateway_bridge_node.hpp
+++ b/star-ros2/src/star_gateway_bridge/include/star_gateway_bridge/star_gateway_bridge_node.hpp
@@ -233,14 +233,21 @@ private:
    * @details
    * Only active when use_bbb_telemetry_ is true. Converts the incoming Twist
    * to a VelocityCommand protobuf and sends it to the Go gateway, which
-   * forwards it over USB CDC to the BeagleBone Blue.
+   * forwards it over USB CDC to the BeagleBone Blue. On gRPC failure, sends
+   * a zero-velocity command to stop the motors before marking the connection
+   * as lost.
    *
    * @param[in] msg Velocity command from Nav2 or teleop.
    *
    * @pre use_bbb_telemetry_ must be true and motor_control_stub_ non-null.
    * @post VelocityCommand sent to gateway via gRPC or error logged.
    *
+   * @throw None. All exceptions are caught internally.
    * @note Not thread-safe; called from ROS2 executor only.
+   *
+   * @see MotorControlService::SetVelocity  gRPC method called.
+   * @see send_zero_velocity_to_bbb()       Called on transport failure.
+   *
    * @since Version 1.1.0
    */
   void cmd_vel_callback(const geometry_msgs::msg::Twist::SharedPtr msg);
@@ -256,13 +263,46 @@ private:
    *   - /imu/data (sensor_msgs/Imu) from BNO055/MPU-9250
    *   - /joint_states (sensor_msgs/JointState) from encoder ticks
    *
+   * Incomplete telemetry (missing encoder or IMU sub-messages) is silently
+   * skipped; only fully-populated fields are published.
+   *
    * @pre grpc_connected_ and telemetry_svc_stub_ must be valid.
    * @post ROS2 messages published for EKF and robot_state_publisher consumption.
    *
+   * @throw None. All exceptions are caught internally.
    * @note Not thread-safe; called from ROS2 timer executor only.
+   *
+   * @see TelemetryService::GetTelemetry  gRPC method called.
+   * @see MessageConverter::telemetry_to_odometry()  Encoder conversion.
+   * @see MessageConverter::telemetry_to_imu()       IMU conversion.
+   *
    * @since Version 1.1.0
    */
   void bbb_telemetry_poll_timer_callback();
+
+  /**
+   * @brief Send a zero-velocity command to BBB motors via gRPC.
+   *
+   * @details
+   * Idempotent safety helper. Constructs a VelocityCommand with all zero
+   * wheel velocities and sends it via MotorControlService::SetVelocity.
+   * Called from the destructor and from cmd_vel_callback on transport failure
+   * to ensure BBB motors are stopped when the ROS2 node shuts down or loses
+   * connectivity.
+   *
+   * No-op if motor_control_stub_ is null or grpc_channel_ is not available.
+   *
+   * @pre motor_control_stub_ may or may not be valid (checked internally).
+   * @post Zero-velocity command sent if gRPC channel is available.
+   *
+   * @throw None. All gRPC errors are swallowed (best-effort stop).
+   * @note Not thread-safe; called from destructor or ROS2 executor only.
+   *
+   * @see cmd_vel_callback()  Calls this on transport failure.
+   *
+   * @since Version 1.1.0
+   */
+  void send_zero_velocity_to_bbb();
 
   // ===========================================================================
   // gRPC Helpers
@@ -291,9 +331,14 @@ private:
   // ROS2 Publishers
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr teleop_cmd_vel_pub_;
 
-  // BBB telemetry publishers (active when use_bbb_telemetry_ == true)
+  /** @brief Publisher for BBB wheel odometry on /odom/unfiltered (nav_msgs/Odometry).
+   *         Created only when use_bbb_telemetry_ is true. Fed to EKF. */
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr bbb_odom_pub_;
+  /** @brief Publisher for BBB IMU data on /imu/data (sensor_msgs/Imu).
+   *         Created only when use_bbb_telemetry_ is true. Fed to EKF. */
   rclcpp::Publisher<sensor_msgs::msg::Imu>::SharedPtr bbb_imu_pub_;
+  /** @brief Publisher for BBB wheel joint states on /joint_states (sensor_msgs/JointState).
+   *         Created only when use_bbb_telemetry_ is true. */
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr bbb_joint_state_pub_;
 
   /** @brief Publisher for front-left HC-SR04 sensor distance (sensor_msgs/Range). */
@@ -330,7 +375,10 @@ private:
   /** @brief Timer that polls TelemetryService::GetTelemetry and publishes
    *         obstacle data at telemetry_rate_hz_ (default 10 Hz). */
   rclcpp::TimerBase::SharedPtr obstacle_timer_;
-  rclcpp::TimerBase::SharedPtr bbb_telemetry_timer_; /**< BBB odom/IMU polling */
+  /** @brief Timer that polls TelemetryService::GetTelemetry and publishes BBB
+   *         odom/IMU/joint_state data at telemetry_rate_hz_ (default 10 Hz).
+   *         Created only when use_bbb_telemetry_ is true. */
+  rclcpp::TimerBase::SharedPtr bbb_telemetry_timer_;
 
   // gRPC Client
   std::shared_ptr<grpc::Channel> grpc_channel_;
@@ -347,7 +395,13 @@ private:
    * @since Version 1.0.0
    */
   std::unique_ptr<star::v1::TelemetryService::Stub> telemetry_svc_stub_;
-  std::unique_ptr<star::v1::MotorControlService::Stub> motor_control_stub_; /**< BBB motor commands */
+  /** @brief gRPC stub for MotorControlService (SetVelocity) on the same channel.
+   *         Used by cmd_vel_callback() and send_zero_velocity_to_bbb() to forward
+   *         velocity commands to the BBB via the Go gateway. Created in
+   *         initialize_grpc_client(); null when gRPC is not connected.
+   *         @note Shares grpc_channel_ with other stubs.
+   *         @since Version 1.1.0 */
+  std::unique_ptr<star::v1::MotorControlService::Stub> motor_control_stub_;
 
   // Cached telemetry data (protected by mutexes)
   std::mutex robot_status_mutex_;

--- a/star-ros2/src/star_gateway_bridge/src/message_converter.cpp
+++ b/star-ros2/src/star_gateway_bridge/src/message_converter.cpp
@@ -540,4 +540,204 @@ void MessageConverter::obstacle_distance_to_range(
                        std::min(HC_SR04_MAX_RANGE_M, distance_m));
 }
 
+// ===========================================================================
+// BBB Telemetry -> ROS2 Conversions
+// ===========================================================================
+
+void MessageConverter::init_bbb_params(const BbbParams & params)
+{
+  assert(params.wheel_base > 0.0);
+  assert(params.wheel_radius > 0.0);
+  assert(params.ticks_per_rev > 0);
+  bbb_params_ = params;
+  bbb_params_initialized_ = true;
+  // Reset dead-reckoning state
+  dr_x_ = 0.0;
+  dr_y_ = 0.0;
+  dr_theta_ = 0.0;
+  prev_ticks_fl_ = 0;
+  prev_ticks_fr_ = 0;
+  prev_ticks_bl_ = 0;
+  prev_ticks_br_ = 0;
+  first_odom_msg_ = true;
+}
+
+void MessageConverter::telemetry_to_odometry(
+  const ::star::v1::TelemetryData & telemetry,
+  nav_msgs::msg::Odometry & odom)
+{
+  assert(bbb_params_initialized_);
+
+  const auto & enc_fl = telemetry.encoder_front_left();
+  const auto & enc_fr = telemetry.encoder_front_right();
+  const auto & enc_bl = telemetry.encoder_back_left();
+  const auto & enc_br = telemetry.encoder_back_right();
+
+  int64_t ticks_fl = enc_fl.ticks();
+  int64_t ticks_fr = enc_fr.ticks();
+  int64_t ticks_bl = enc_bl.ticks();
+  int64_t ticks_br = enc_br.ticks();
+
+  if (first_odom_msg_) {
+    prev_ticks_fl_ = ticks_fl;
+    prev_ticks_fr_ = ticks_fr;
+    prev_ticks_bl_ = ticks_bl;
+    prev_ticks_br_ = ticks_br;
+    first_odom_msg_ = false;
+    // Publish zero-pose on first message
+  }
+
+  int64_t delta_fl = ticks_fl - prev_ticks_fl_;
+  int64_t delta_fr = ticks_fr - prev_ticks_fr_;
+  int64_t delta_bl = ticks_bl - prev_ticks_bl_;
+  int64_t delta_br = ticks_br - prev_ticks_br_;
+
+  prev_ticks_fl_ = ticks_fl;
+  prev_ticks_fr_ = ticks_fr;
+  prev_ticks_bl_ = ticks_bl;
+  prev_ticks_br_ = ticks_br;
+
+  double m_per_tick =
+    (2.0 * PI * bbb_params_.wheel_radius) / bbb_params_.ticks_per_rev;
+
+  double dist_fl = delta_fl * m_per_tick;
+  double dist_fr = delta_fr * m_per_tick;
+  double dist_bl = delta_bl * m_per_tick;
+  double dist_br = delta_br * m_per_tick;
+
+  double dist_left = (dist_fl + dist_bl) / 2.0;
+  double dist_right = (dist_fr + dist_br) / 2.0;
+
+  double dist_center = (dist_right + dist_left) / 2.0;
+  double delta_theta = (dist_right - dist_left) / bbb_params_.wheel_base;
+
+  double avg_theta = dr_theta_ + delta_theta / 2.0;
+  dr_x_ += dist_center * std::cos(avg_theta);
+  dr_y_ += dist_center * std::sin(avg_theta);
+  dr_theta_ = normalize_angle(dr_theta_ + delta_theta);
+
+  odom.header.frame_id = "odom";
+  odom.child_frame_id = "base_link";
+
+  odom.pose.pose.position.x = dr_x_;
+  odom.pose.pose.position.y = dr_y_;
+  odom.pose.pose.position.z = 0.0;
+
+  // Yaw -> quaternion
+  double half_yaw = dr_theta_ / 2.0;
+  odom.pose.pose.orientation.x = 0.0;
+  odom.pose.pose.orientation.y = 0.0;
+  odom.pose.pose.orientation.z = std::sin(half_yaw);
+  odom.pose.pose.orientation.w = std::cos(half_yaw);
+
+  // Velocity from encoder-reported velocities
+  double v_fl = enc_fl.velocity_mps();
+  double v_fr = enc_fr.velocity_mps();
+  double v_bl = enc_bl.velocity_mps();
+  double v_br = enc_br.velocity_mps();
+
+  double v_left = (v_fl + v_bl) / 2.0;
+  double v_right = (v_fr + v_br) / 2.0;
+  odom.twist.twist.linear.x = (v_right + v_left) / 2.0;
+  odom.twist.twist.angular.z = (v_right - v_left) / bbb_params_.wheel_base;
+
+  // Pose covariance (6x6 row-major: x, y, z, roll, pitch, yaw)
+  odom.pose.covariance[0] = 0.1;     // x
+  odom.pose.covariance[7] = 0.1;     // y
+  odom.pose.covariance[14] = 1e6;    // z (not observed)
+  odom.pose.covariance[21] = 1e6;    // roll (not observed)
+  odom.pose.covariance[28] = 1e6;    // pitch (not observed)
+  odom.pose.covariance[35] = 0.1;    // yaw
+
+  // Twist covariance
+  odom.twist.covariance[0] = 0.05;   // vx
+  odom.twist.covariance[7] = 1e6;    // vy (diff drive constraint)
+  odom.twist.covariance[14] = 1e6;   // vz
+  odom.twist.covariance[21] = 1e6;   // roll rate
+  odom.twist.covariance[28] = 1e6;   // pitch rate
+  odom.twist.covariance[35] = 0.05;  // yaw rate
+}
+
+void MessageConverter::telemetry_to_imu(
+  const ::star::v1::TelemetryData & telemetry,
+  sensor_msgs::msg::Imu & imu_msg)
+{
+  imu_msg.header.frame_id = "imu_link";
+
+  const auto & imu = telemetry.imu();
+
+  // Orientation from BNO055 quaternion
+  imu_msg.orientation.x = imu.quat_x();
+  imu_msg.orientation.y = imu.quat_y();
+  imu_msg.orientation.z = imu.quat_z();
+  imu_msg.orientation.w = imu.quat_w();
+
+  // Angular velocity (gyro)
+  imu_msg.angular_velocity.x = imu.gyro_x_rad_per_s();
+  imu_msg.angular_velocity.y = imu.gyro_y_rad_per_s();
+  imu_msg.angular_velocity.z = imu.gyro_z_rad_per_s();
+
+  // Linear acceleration
+  imu_msg.linear_acceleration.x = imu.accel_x_mps2();
+  imu_msg.linear_acceleration.y = imu.accel_y_mps2();
+  imu_msg.linear_acceleration.z = imu.accel_z_mps2();
+
+  // Orientation covariance (yaw-only for 2D EKF fusion)
+  // row-major 3x3: roll, pitch, yaw
+  imu_msg.orientation_covariance[0] = 1e6;   // roll (not used in 2D)
+  imu_msg.orientation_covariance[4] = 1e6;   // pitch (not used in 2D)
+  imu_msg.orientation_covariance[8] = 0.01;  // yaw
+
+  // Angular velocity covariance
+  imu_msg.angular_velocity_covariance[0] = 0.01;
+  imu_msg.angular_velocity_covariance[4] = 0.01;
+  imu_msg.angular_velocity_covariance[8] = 0.01;
+
+  // Linear acceleration covariance
+  imu_msg.linear_acceleration_covariance[0] = 0.1;
+  imu_msg.linear_acceleration_covariance[4] = 0.1;
+  imu_msg.linear_acceleration_covariance[8] = 0.1;
+}
+
+void MessageConverter::telemetry_to_joint_state(
+  const ::star::v1::TelemetryData & telemetry,
+  sensor_msgs::msg::JointState & joint_state)
+{
+  assert(bbb_params_initialized_);
+
+  const auto & enc_fl = telemetry.encoder_front_left();
+  const auto & enc_fr = telemetry.encoder_front_right();
+  const auto & enc_bl = telemetry.encoder_back_left();
+  const auto & enc_br = telemetry.encoder_back_right();
+
+  joint_state.name = {
+    "front_left_wheel", "front_right_wheel",
+    "back_left_wheel", "back_right_wheel"};
+
+  double rad_per_tick = (2.0 * PI) / bbb_params_.ticks_per_rev;
+  joint_state.position = {
+    static_cast<double>(enc_fl.ticks()) * rad_per_tick,
+    static_cast<double>(enc_fr.ticks()) * rad_per_tick,
+    static_cast<double>(enc_bl.ticks()) * rad_per_tick,
+    static_cast<double>(enc_br.ticks()) * rad_per_tick};
+
+  double inv_radius = 1.0 / bbb_params_.wheel_radius;
+  joint_state.velocity = {
+    enc_fl.velocity_mps() * inv_radius,
+    enc_fr.velocity_mps() * inv_radius,
+    enc_bl.velocity_mps() * inv_radius,
+    enc_br.velocity_mps() * inv_radius};
+}
+
+double MessageConverter::normalize_angle(double angle)
+{
+  while (angle > PI) {
+    angle -= 2.0 * PI;
+  }
+  while (angle < -PI) {
+    angle += 2.0 * PI;
+  }
+  return angle;
+}
+
 }  // namespace star::star_gateway_bridge

--- a/star-ros2/src/star_gateway_bridge/src/message_converter.cpp
+++ b/star-ros2/src/star_gateway_bridge/src/message_converter.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <chrono>
 #include <cmath>
+#include <stdexcept>
 
 namespace star::star_gateway_bridge
 {
@@ -546,9 +547,15 @@ void MessageConverter::obstacle_distance_to_range(
 
 void MessageConverter::init_bbb_params(const BbbParams & params)
 {
-  assert(params.wheel_base > 0.0);
-  assert(params.wheel_radius > 0.0);
-  assert(params.ticks_per_rev > 0);
+  if (params.wheel_base <= 0.0 || params.wheel_radius <= 0.0 ||
+    params.ticks_per_rev <= 0)
+  {
+    throw std::invalid_argument(
+      "BBB params must be positive (wheel_base=" +
+      std::to_string(params.wheel_base) + ", wheel_radius=" +
+      std::to_string(params.wheel_radius) + ", ticks_per_rev=" +
+      std::to_string(params.ticks_per_rev) + ")");
+  }
   bbb_params_ = params;
   bbb_params_initialized_ = true;
   // Reset dead-reckoning state
@@ -562,11 +569,22 @@ void MessageConverter::init_bbb_params(const BbbParams & params)
   first_odom_msg_ = true;
 }
 
-void MessageConverter::telemetry_to_odometry(
+bool MessageConverter::telemetry_to_odometry(
   const ::star::v1::TelemetryData & telemetry,
   nav_msgs::msg::Odometry & odom)
 {
-  assert(bbb_params_initialized_);
+  if (!bbb_params_initialized_) {
+    return false;
+  }
+
+  // Validate all four encoder sub-messages are present
+  if (!telemetry.has_encoder_front_left() ||
+    !telemetry.has_encoder_front_right() ||
+    !telemetry.has_encoder_back_left() ||
+    !telemetry.has_encoder_back_right())
+  {
+    return false;
+  }
 
   const auto & enc_fl = telemetry.encoder_front_left();
   const auto & enc_fr = telemetry.encoder_front_right();
@@ -584,7 +602,7 @@ void MessageConverter::telemetry_to_odometry(
     prev_ticks_bl_ = ticks_bl;
     prev_ticks_br_ = ticks_br;
     first_odom_msg_ = false;
-    // Publish zero-pose on first message
+    // First message seeds baselines; publish zero-pose
   }
 
   int64_t delta_fl = ticks_fl - prev_ticks_fl_;
@@ -656,12 +674,18 @@ void MessageConverter::telemetry_to_odometry(
   odom.twist.covariance[21] = 1e6;   // roll rate
   odom.twist.covariance[28] = 1e6;   // pitch rate
   odom.twist.covariance[35] = 0.05;  // yaw rate
+
+  return true;
 }
 
-void MessageConverter::telemetry_to_imu(
+bool MessageConverter::telemetry_to_imu(
   const ::star::v1::TelemetryData & telemetry,
   sensor_msgs::msg::Imu & imu_msg)
 {
+  if (!telemetry.has_imu()) {
+    return false;
+  }
+
   imu_msg.header.frame_id = "imu_link";
 
   const auto & imu = telemetry.imu();
@@ -697,13 +721,25 @@ void MessageConverter::telemetry_to_imu(
   imu_msg.linear_acceleration_covariance[0] = 0.1;
   imu_msg.linear_acceleration_covariance[4] = 0.1;
   imu_msg.linear_acceleration_covariance[8] = 0.1;
+
+  return true;
 }
 
-void MessageConverter::telemetry_to_joint_state(
+bool MessageConverter::telemetry_to_joint_state(
   const ::star::v1::TelemetryData & telemetry,
   sensor_msgs::msg::JointState & joint_state)
 {
-  assert(bbb_params_initialized_);
+  if (!bbb_params_initialized_) {
+    return false;
+  }
+
+  if (!telemetry.has_encoder_front_left() ||
+    !telemetry.has_encoder_front_right() ||
+    !telemetry.has_encoder_back_left() ||
+    !telemetry.has_encoder_back_right())
+  {
+    return false;
+  }
 
   const auto & enc_fl = telemetry.encoder_front_left();
   const auto & enc_fr = telemetry.encoder_front_right();
@@ -727,6 +763,8 @@ void MessageConverter::telemetry_to_joint_state(
     enc_fr.velocity_mps() * inv_radius,
     enc_bl.velocity_mps() * inv_radius,
     enc_br.velocity_mps() * inv_radius};
+
+  return true;
 }
 
 double MessageConverter::normalize_angle(double angle)

--- a/star-ros2/src/star_gateway_bridge/src/star_gateway_bridge_node.cpp
+++ b/star-ros2/src/star_gateway_bridge/src/star_gateway_bridge_node.cpp
@@ -894,7 +894,7 @@ void StarGatewayBridgeNode::send_zero_velocity_to_bbb()
     command->set_timestamp_us(
         std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch())
-            .count());
+      .count());
 
     star::v1::SetVelocityResponse response;
     grpc::Status status =

--- a/star-ros2/src/star_gateway_bridge/src/star_gateway_bridge_node.cpp
+++ b/star-ros2/src/star_gateway_bridge/src/star_gateway_bridge_node.cpp
@@ -77,6 +77,9 @@ StarGatewayBridgeNode::StarGatewayBridgeNode(const rclcpp::NodeOptions & options
   this->declare_parameter("teleop_timeout_ms", 500);
   this->declare_parameter("grpc_deadline_ms", 100);
   this->declare_parameter("wheel_base", 0.150); // 150mm track width
+  this->declare_parameter("use_bbb_telemetry", false);
+  this->declare_parameter("wheel_radius", 0.0325); // 32.5mm wheel radius
+  this->declare_parameter("ticks_per_rev", 11599);  // 341 PPR * 34.02:1 gear
 
   // Cache parameters
   gateway_address_ = this->get_parameter("gateway_address").as_string();
@@ -87,6 +90,9 @@ StarGatewayBridgeNode::StarGatewayBridgeNode(const rclcpp::NodeOptions & options
   teleop_timeout_ms_ = this->get_parameter("teleop_timeout_ms").as_int();
   grpc_deadline_ms_ = this->get_parameter("grpc_deadline_ms").as_int();
   wheel_base_ = this->get_parameter("wheel_base").as_double();
+  use_bbb_telemetry_ = this->get_parameter("use_bbb_telemetry").as_bool();
+  wheel_radius_ = this->get_parameter("wheel_radius").as_double();
+  ticks_per_rev_ = this->get_parameter("ticks_per_rev").as_int();
 
   RCLCPP_INFO(
     this->get_logger(),
@@ -180,9 +186,10 @@ bool StarGatewayBridgeNode::initialize_grpc_client()
     return false;
   }
 
-  // Create gRPC stubs (both services share the same channel)
+  // Create gRPC stubs (all services share the same channel)
   grpc_stub_ = star::v1::GatewayService::NewStub(grpc_channel_);
   telemetry_svc_stub_ = star::v1::TelemetryService::NewStub(grpc_channel_);
+  motor_control_stub_ = star::v1::MotorControlService::NewStub(grpc_channel_);
 
   RCLCPP_INFO(this->get_logger(),
               "Successfully connected to Gateway gRPC server");
@@ -352,6 +359,40 @@ void StarGatewayBridgeNode::initialize_ros_interfaces()
   diagnostics_timer_ = this->create_wall_timer(
       std::chrono::seconds(1),
       std::bind(&StarGatewayBridgeNode::publish_diagnostics, this));
+
+  // BBB telemetry bridging (when use_bbb_telemetry is true)
+  if (use_bbb_telemetry_) {
+    RCLCPP_INFO(this->get_logger(),
+      "BBB telemetry mode ENABLED - publishing /odom/unfiltered, /imu/data, "
+      "/joint_states and forwarding /cmd_vel to gateway");
+
+    // Initialize converter with platform parameters
+    MessageConverter::BbbParams bbb_params;
+    bbb_params.wheel_base = wheel_base_;
+    bbb_params.wheel_radius = wheel_radius_;
+    bbb_params.ticks_per_rev = ticks_per_rev_;
+    converter_.init_bbb_params(bbb_params);
+
+    // Publishers for BBB sensor data -> ROS2
+    bbb_odom_pub_ = this->create_publisher<nav_msgs::msg::Odometry>(
+        "/odom/unfiltered", 10);
+    bbb_imu_pub_ = this->create_publisher<sensor_msgs::msg::Imu>(
+        "/imu/data", 10);
+    bbb_joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
+        "/joint_states", 10);
+
+    // Subscriber for ROS2 /cmd_vel -> gateway -> BBB
+    cmd_vel_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+        "/cmd_vel", 10,
+        std::bind(&StarGatewayBridgeNode::cmd_vel_callback, this,
+                  std::placeholders::_1));
+
+    // BBB telemetry polling timer (same rate as obstacle timer)
+    bbb_telemetry_timer_ = this->create_wall_timer(
+        std::chrono::milliseconds(telemetry_period_ms),
+        std::bind(&StarGatewayBridgeNode::bbb_telemetry_poll_timer_callback,
+                  this));
+  }
 
   RCLCPP_INFO(
       this->get_logger(),
@@ -690,6 +731,130 @@ void StarGatewayBridgeNode::obstacle_poll_timer_callback()
   } catch (...) {
     RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
                           "Unknown exception in obstacle_poll_timer_callback");
+  }
+}
+
+// ===========================================================================
+// BBB Telemetry Bridging
+// ===========================================================================
+
+void StarGatewayBridgeNode::cmd_vel_callback(
+  const geometry_msgs::msg::Twist::SharedPtr msg)
+{
+  if (!grpc_connected_ || !motor_control_stub_) {
+    return;
+  }
+
+  try {
+    grpc::ClientContext context;
+    context.set_deadline(std::chrono::system_clock::now() +
+                         std::chrono::milliseconds(grpc_deadline_ms_));
+
+    star::v1::SetVelocityRequest request;
+    auto * header = request.mutable_header();
+    header->set_request_id(
+        "cmdvel_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count()));
+
+    auto * command = request.mutable_command();
+    if (!converter_.twist_to_velocity_command(*msg, *command, wheel_base_,
+                                              cmd_vel_sequence_++))
+    {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                           "Failed to convert cmd_vel Twist to VelocityCommand");
+      return;
+    }
+
+    star::v1::SetVelocityResponse response;
+    grpc::Status status =
+      motor_control_stub_->SetVelocity(&context, request, &response);
+
+    if (!status.ok()) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+                           "SetVelocity gRPC failed: %s",
+                           status.error_message().c_str());
+      const grpc::StatusCode code = status.error_code();
+      if (code == grpc::StatusCode::UNAVAILABLE ||
+        code == grpc::StatusCode::DEADLINE_EXCEEDED ||
+        code == grpc::StatusCode::INTERNAL)
+      {
+        grpc_connected_ = false;
+      }
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                          "Exception in cmd_vel_callback: %s", e.what());
+  }
+}
+
+void StarGatewayBridgeNode::bbb_telemetry_poll_timer_callback()
+{
+  try {
+    if (!grpc_connected_ || !telemetry_svc_stub_) {
+      return;
+    }
+
+    grpc::ClientContext context;
+    context.set_deadline(std::chrono::system_clock::now() +
+                         std::chrono::milliseconds(grpc_deadline_ms_));
+
+    star::v1::GetTelemetryRequest request;
+    request.mutable_header()->set_request_id(
+        "bbb_telem_" +
+        std::to_string(
+            std::chrono::system_clock::now().time_since_epoch().count()));
+
+    star::v1::GetTelemetryResponse response;
+    grpc::Status status =
+      telemetry_svc_stub_->GetTelemetry(&context, request, &response);
+
+    if (!status.ok()) {
+      RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                           "GetTelemetry (BBB) gRPC failed: %s",
+                           status.error_message().c_str());
+      const grpc::StatusCode code = status.error_code();
+      if (code == grpc::StatusCode::UNAVAILABLE ||
+        code == grpc::StatusCode::DEADLINE_EXCEEDED ||
+        code == grpc::StatusCode::INTERNAL)
+      {
+        grpc_connected_ = false;
+      }
+      return;
+    }
+
+    if (!response.has_telemetry()) {
+      return;
+    }
+
+    const auto & telemetry = response.telemetry();
+    const rclcpp::Time stamp = this->now();
+
+    // Publish odometry from encoder dead-reckoning
+    nav_msgs::msg::Odometry odom;
+    converter_.telemetry_to_odometry(telemetry, odom);
+    odom.header.stamp = stamp;
+    bbb_odom_pub_->publish(odom);
+
+    // Publish IMU data
+    sensor_msgs::msg::Imu imu_msg;
+    converter_.telemetry_to_imu(telemetry, imu_msg);
+    imu_msg.header.stamp = stamp;
+    bbb_imu_pub_->publish(imu_msg);
+
+    // Publish joint states
+    sensor_msgs::msg::JointState joint_state;
+    converter_.telemetry_to_joint_state(telemetry, joint_state);
+    joint_state.header.stamp = stamp;
+    bbb_joint_state_pub_->publish(joint_state);
+
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                          "Exception in bbb_telemetry_poll_timer_callback: %s",
+                          e.what());
+  } catch (...) {
+    RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
+                          "Unknown exception in bbb_telemetry_poll_timer_callback");
   }
 }
 

--- a/star-ros2/src/star_gateway_bridge/src/star_gateway_bridge_node.cpp
+++ b/star-ros2/src/star_gateway_bridge/src/star_gateway_bridge_node.cpp
@@ -138,7 +138,16 @@ StarGatewayBridgeNode::~StarGatewayBridgeNode()
   obstacle_br_pub_.reset();
   obstacle_detected_pub_.reset();
 
-  // Send stop command before shutdown
+  // Cancel BBB telemetry timer and send zero velocity to BBB
+  if (bbb_telemetry_timer_) {
+    bbb_telemetry_timer_->cancel();
+    bbb_telemetry_timer_.reset();
+  }
+  if (use_bbb_telemetry_) {
+    send_zero_velocity_to_bbb();
+  }
+
+  // Send stop command on teleop topic before shutdown
   auto zero_twist = geometry_msgs::msg::Twist();
   if (teleop_cmd_vel_pub_) {
     teleop_cmd_vel_pub_->publish(zero_twist);
@@ -779,6 +788,7 @@ void StarGatewayBridgeNode::cmd_vel_callback(
         code == grpc::StatusCode::DEADLINE_EXCEEDED ||
         code == grpc::StatusCode::INTERNAL)
       {
+        send_zero_velocity_to_bbb();
         grpc_connected_ = false;
       }
     }
@@ -830,23 +840,26 @@ void StarGatewayBridgeNode::bbb_telemetry_poll_timer_callback()
     const auto & telemetry = response.telemetry();
     const rclcpp::Time stamp = this->now();
 
-    // Publish odometry from encoder dead-reckoning
+    // Publish odometry from encoder dead-reckoning (skip if data incomplete)
     nav_msgs::msg::Odometry odom;
-    converter_.telemetry_to_odometry(telemetry, odom);
-    odom.header.stamp = stamp;
-    bbb_odom_pub_->publish(odom);
+    if (converter_.telemetry_to_odometry(telemetry, odom)) {
+      odom.header.stamp = stamp;
+      bbb_odom_pub_->publish(odom);
+    }
 
-    // Publish IMU data
+    // Publish IMU data (skip if IMU sub-message absent)
     sensor_msgs::msg::Imu imu_msg;
-    converter_.telemetry_to_imu(telemetry, imu_msg);
-    imu_msg.header.stamp = stamp;
-    bbb_imu_pub_->publish(imu_msg);
+    if (MessageConverter::telemetry_to_imu(telemetry, imu_msg)) {
+      imu_msg.header.stamp = stamp;
+      bbb_imu_pub_->publish(imu_msg);
+    }
 
-    // Publish joint states
+    // Publish joint states (skip if encoder data incomplete)
     sensor_msgs::msg::JointState joint_state;
-    converter_.telemetry_to_joint_state(telemetry, joint_state);
-    joint_state.header.stamp = stamp;
-    bbb_joint_state_pub_->publish(joint_state);
+    if (converter_.telemetry_to_joint_state(telemetry, joint_state)) {
+      joint_state.header.stamp = stamp;
+      bbb_joint_state_pub_->publish(joint_state);
+    }
 
   } catch (const std::exception & e) {
     RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
@@ -855,6 +868,48 @@ void StarGatewayBridgeNode::bbb_telemetry_poll_timer_callback()
   } catch (...) {
     RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 5000,
                           "Unknown exception in bbb_telemetry_poll_timer_callback");
+  }
+}
+
+void StarGatewayBridgeNode::send_zero_velocity_to_bbb()
+{
+  if (!motor_control_stub_ || !grpc_channel_) {
+    return;
+  }
+
+  try {
+    grpc::ClientContext context;
+    context.set_deadline(std::chrono::system_clock::now() +
+                         std::chrono::milliseconds(grpc_deadline_ms_));
+
+    star::v1::SetVelocityRequest request;
+    auto * header = request.mutable_header();
+    header->set_request_id("estop_zero");
+
+    auto * command = request.mutable_command();
+    command->set_front_left_velocity_mps(0.0F);
+    command->set_front_right_velocity_mps(0.0F);
+    command->set_back_left_velocity_mps(0.0F);
+    command->set_back_right_velocity_mps(0.0F);
+    command->set_timestamp_us(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+
+    star::v1::SetVelocityResponse response;
+    grpc::Status status =
+      motor_control_stub_->SetVelocity(&context, request, &response);
+
+    if (status.ok()) {
+      RCLCPP_INFO(this->get_logger(), "Sent zero velocity to BBB (safety stop)");
+    } else {
+      RCLCPP_WARN(this->get_logger(),
+                  "Failed to send zero velocity to BBB: %s",
+                  status.error_message().c_str());
+    }
+  } catch (...) {
+    RCLCPP_WARN(this->get_logger(),
+                "Exception sending zero velocity to BBB (best-effort)");
   }
 }
 


### PR DESCRIPTION
## Summary

- Extends `star_gateway_bridge` to bridge BBB sensor data into ROS2 and forward `/cmd_vel` to BBB motors via gateway gRPC
- Adds `use_bbb` launch argument to `slam.launch.py` (default: `true`) that enables the BBB telemetry path
- Auto-launches the gateway bridge node in the SLAM launch file

## Problem

The ROS2 stack was designed around `star_spi_bridge` talking to the RX72N over SPI. With BeagleBone Blue as the primary motor controller over USB CDC, there was a critical integration gap:
- `/cmd_vel` from Nav2 could not reach BBB motors
- BBB encoder/IMU telemetry could not reach ROS2 topics (`/odom/unfiltered`, `/imu/data`)
- EKF had no sensor input, making SLAM and Nav2 blind

## Solution

When `use_bbb_telemetry` is enabled, the gateway bridge now:
1. **Subscribes to `/cmd_vel`** and forwards to BBB via `MotorControlService::SetVelocity` gRPC
2. **Polls `TelemetryService::GetTelemetry`** at 10Hz and publishes:
   - `/odom/unfiltered` (dead-reckoning from encoder deltas)
   - `/imu/data` (BNO055/MPU-9250 quaternion + gyro + accel)
   - `/joint_states` (wheel positions and velocities)
3. Uses the same polling pattern as the existing obstacle timer

## Files Changed

| File | Change |
|------|--------|
| `message_converter.hpp/cpp` | Add `telemetry_to_odometry()`, `telemetry_to_imu()`, `telemetry_to_joint_state()` with dead-reckoning state |
| `star_gateway_bridge_node.hpp/cpp` | Add `/cmd_vel` subscriber, BBB telemetry publishers, `MotorControlService` gRPC stub, `use_bbb_telemetry` parameter |
| `slam.launch.py` | Add `use_bbb` launch arg, launch gateway bridge node with BBB params |

## Test plan

- [x] `colcon build --packages-select star_gateway_bridge` compiles cleanly
- [x] All 45 existing unit tests pass
- [ ] Verify `/odom/unfiltered` publishes at ~10Hz with BBB connected
- [ ] Verify `/imu/data` publishes at ~10Hz with BBB connected
- [ ] Verify `ros2 topic pub /cmd_vel geometry_msgs/Twist "{linear: {x: 0.1}}" --once` drives BBB motors
- [ ] Verify EKF produces `/odometry/filtered` from BBB data
- [ ] Full stack: `ros2 launch star_bringup slam.launch.py use_bbb:=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable BeagleBone Blue (BBB) telemetry bridging via a launch-time option.
  * Publishes BBB-derived odometry, IMU, and joint state topics when enabled.
  * Forwards /cmd_vel to BBB motor control and issues safe zero-velocity on transport failures or shutdown.
  * Periodic telemetry polling to populate sensor and telemetry topics while BBB mode is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->