### PR TITLE
feat(bbb): battery voltage duty cycle clamp for motor protection

### DIFF
--- a/star-beaglebone-blue/README.md
+++ b/star-beaglebone-blue/README.md
@@ -1,0 +1,127 @@
+# BeagleBone Blue Motor Controller Firmware
+
+Userspace C firmware for the BeagleBone Blue (OSD3358/AM335x), serving as the
+STAR robot's primary motor controller. Communicates with the Pi5 gateway over
+USB CDC using the same nanopb+CRC-32 frame protocol as the RX72N fallback.
+
+## Hardware
+
+| Component | Spec |
+|-----------|------|
+| **Motors** | 4x DFRobot FIT0520 (6V brushed DC, 210 RPM, 3.2A stall, 34.02:1 gear ratio) |
+| **Motor drivers** | 4x TI DRV8838 H-bridge (onboard, 0-11V VM, 1.7A continuous) |
+| **Encoders** | Hall effect quadrature, 341 PPR (11,599 ticks/wheel rev with gear ratio) |
+| **IMU** | InvenSense MPU-9250 (accel + gyro + mag, polled at 100 Hz) |
+| **Communication** | USB CDC ACM (BBB /dev/ttyGS0 <-> Pi5 /dev/ttyACM0) |
+
+## Power
+
+Motors are powered directly from the battery rail (VBAT) through the DRV8838.
+There is **no voltage regulator** between battery and motors.
+
+| Source | Voltage | Powers Motors? |
+|--------|---------|---------------|
+| USB (micro-USB) | 5V | **No** -- SoC only |
+| 2S LiPo (JST connector) | 6.0-8.4V | **Yes** |
+| Barrel jack | 9-18V | **Yes** |
+
+### Battery Voltage Duty Clamp
+
+The firmware reads battery voltage via `rc_adc_batt()` (ADC channel 6, 11:1
+resistor divider on the BBB Blue PCB) at 10 Hz and clamps motor duty cycles
+to protect 6V motors from overvoltage:
+
+```
+max_duty = 0.95 * (6.0V / V_battery)
+```
+
+| Battery State | V_batt | Max Duty | Effective Motor V |
+|---------------|--------|----------|-------------------|
+| Full charge | 8.4V | 67.9% | 5.7V |
+| Nominal | 7.4V | 77.0% | 5.7V |
+| Discharged (BMS cutoff) | 6.0V | 95.0% | 5.7V |
+| USB / no battery | 0.0V | 65.0% (fallback) | N/A |
+
+Constants in `src/inc/hardware_config.h`:
+- `k_bb_motor_rated_v = 6.0` -- motor rated voltage
+- `k_bb_duty_derating = 0.95` -- 5% safety margin for ADC tolerance
+- `k_bb_duty_fallback_max = 0.65` -- used when battery voltage unknown (USB power).
+  Assumes worst-case 8.8V freshly charged 2S: `0.95 * 6.0 / 8.8 = 0.648`
+
+The ADC reads the **total pack voltage** (both cells combined), not individual
+cells. Per-cell monitoring and balancing is handled by the external BMS.
+
+### Recommended Battery: 2S3P (6x 18650)
+
+- **Cells**: EVE INR 18650/35V 3.5Ah (10A continuous, ~42 mohm)
+- **Configuration**: 2S3P = 7.2V nominal, 10.5Ah, 30A continuous
+- **BMS**: 2S 20A (handles balance, over-discharge, over-charge)
+- **Charger**: TP5100 WH-370 module (CC/CV to 8.4V, 2A) -- charges through BMS
+- **Runtime**: ~2.3 hours at normal driving (4.5A draw)
+- **Charge time**: ~5.5 hours from empty at 2A
+
+The BBB Blue's onboard charger (BQ24250) is **1S only** -- it cannot charge a 2S
+pack. Use the TP5100 or any external 2S balance charger.
+
+## Build
+
+### Native build on BBB (Trixie has GCC 14)
+
+```bash
+ssh debian@192.168.7.2   # pw: StarBBB2026!
+cd ~/star-beaglebone-blue
+cmake --preset native-debug
+cmake --build build-native-debug -j$(nproc)
+```
+
+### Cross-compile on Pi5
+
+```bash
+cd star-beaglebone-blue
+cmake --preset cross-debug-pi5
+cmake --build build-cross-debug -j$(nproc)
+scp build-cross-debug/star-beaglebone-blue debian@192.168.7.2:~/
+```
+
+### Standalone motor test (no Pi5 needed)
+
+```bash
+# Build on Pi5:
+arm-linux-gnueabihf-gcc -O2 -isystem /opt/bbb-sysroot/usr/include \
+  -L/opt/bbb-sysroot/usr/lib/arm-linux-gnueabihf \
+  -o motor-test scripts/motor-test.c -lrobotcontrol -lm -lpthread
+
+# Deploy and run:
+scp motor-test debian@192.168.7.2:~/
+ssh debian@192.168.7.2 "sudo ./motor-test"              # full test
+ssh debian@192.168.7.2 "sudo ./motor-test --no-motors"  # encoders + IMU only
+ssh debian@192.168.7.2 "sudo ./motor-test --motor 1"    # single motor
+```
+
+## Run
+
+```bash
+ssh debian@192.168.7.2
+sudo ./star-beaglebone-blue
+# BBB opens /dev/ttyGS0, Pi5 sees /dev/ttyACM0
+```
+
+Or use `./start.sh` from the STAR repo root -- it auto-detects the BBB and
+starts everything (firmware, gateway, ROS2, Foxglove).
+
+## Architecture
+
+See [docs/architecture.md](docs/architecture.md) for task thread design.
+
+5 pthreads at 10-100 Hz:
+- **comm_task** (100 Hz) -- USB CDC frame parse + protobuf decode
+- **motor_control_task** (100 Hz) -- duty clamp + rc_motor_set + encoder read
+- **imu_task** (100 Hz) -- MPU-9250 polling (accel + gyro)
+- **telemetry_task** (10 Hz) -- protobuf encode + USB CDC send
+- **watchdog_task** (10 Hz) -- 500ms comm timeout -> e-stop
+
+## librobotcontrol Patches (5.10-ti kernel)
+
+Stock librobotcontrol does not work on the 5.10-ti kernel. See
+[docs/SETUP_AND_TROUBLESHOOTING.md](docs/SETUP_AND_TROUBLESHOOTING.md) for
+the three required patches (PWM paths, encoder counter subsystem, I2C).

--- a/star-beaglebone-blue/scripts/motor-test.c
+++ b/star-beaglebone-blue/scripts/motor-test.c
@@ -17,7 +17,7 @@
  * Requires: librobotcontrol (patched for 5.10-ti kernel)
  * Power: Motors need barrel jack (9-18V) or 2S LiPo. USB alone = no motors.
  *
- * Copyright (c) 2026 Locked Inc.
+ * @copyright Copyright (c) 2026 Locked Inc.
  * SPDX-License-Identifier: MIT
  */
 

--- a/star-beaglebone-blue/scripts/motor-test.c
+++ b/star-beaglebone-blue/scripts/motor-test.c
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
 
     printf("  Battery: ");
     double vbatt = rc_adc_batt();
-    if (vbatt > 0) {
+    if (vbatt > 1.0) {  /* rc_adc_batt() deadzone: returns 0.0 below 1.0V */
         printf("%.2f V", vbatt);
         if (vbatt < 6.0) printf(" (LOW -- motors may not work on USB power)");
         printf("\n");
@@ -284,6 +284,7 @@ int main(int argc, char *argv[])
     print_header("Cleanup");
     rc_motor_set(0, 0.0);  /* all motors off */
     rc_mpu_power_off();
+    rc_adc_cleanup();
     rc_encoder_eqep_cleanup();
     rc_motor_cleanup();
     rc_remove_pid_file();

--- a/star-beaglebone-blue/scripts/motor-test.c
+++ b/star-beaglebone-blue/scripts/motor-test.c
@@ -198,6 +198,13 @@ int main(int argc, char *argv[])
     /* Init hardware */
     print_header("Hardware Init");
 
+    printf("  ADC: ");
+    if (rc_adc_init() == 0) {
+        printf("OK\n");
+    } else {
+        printf("FAIL (battery monitoring unavailable)\n");
+    }
+
     printf("  Motors: ");
     if (rc_motor_init() == 0) {
         printf("OK\n");

--- a/star-beaglebone-blue/src/hardware_init.c
+++ b/star-beaglebone-blue/src/hardware_init.c
@@ -77,6 +77,12 @@ bb_err_t bb_hardware_init(void)
         return k_bb_err_hardware;
     }
 
+    /* ADC for battery voltage monitoring. Non-fatal -- USB power has no battery
+     * ADC and motor_control_task falls back to k_bb_duty_fallback_max. */
+    if (rc_adc_init() != 0) {
+        fprintf(stderr, "WARN: rc_adc_init failed (battery monitoring unavailable)\n");
+    }
+
     return k_bb_err_ok;
 }
 
@@ -99,6 +105,7 @@ bb_err_t bb_hardware_deinit(void)
 {
     (void)rc_motor_set(k_bb_motor_all, 0.0);
     rc_mpu_power_off();
+    rc_adc_cleanup();
     rc_motor_cleanup();
     rc_encoder_eqep_cleanup();
     return k_bb_err_ok;

--- a/star-beaglebone-blue/src/hardware_init.c
+++ b/star-beaglebone-blue/src/hardware_init.c
@@ -105,8 +105,8 @@ bb_err_t bb_hardware_deinit(void)
 {
     (void)rc_motor_set(k_bb_motor_all, 0.0);
     rc_mpu_power_off();
-    rc_adc_cleanup();
-    rc_motor_cleanup();
-    rc_encoder_eqep_cleanup();
+    (void)rc_adc_cleanup();
+    (void)rc_motor_cleanup();
+    (void)rc_encoder_eqep_cleanup();
     return k_bb_err_ok;
 }

--- a/star-beaglebone-blue/src/inc/hardware_config.h
+++ b/star-beaglebone-blue/src/inc/hardware_config.h
@@ -194,6 +194,37 @@ typedef enum : uint8_t {
  */
 static const float s_bb_duty_percent_scale = 100.0F;
 
+/* ---------------------------------------------------------------------------
+ * Motor voltage protection
+ * ---------------------------------------------------------------------------*/
+
+/**
+ * @brief Motor rated voltage (DFRobot FIT0520: 6V brushed DC gearmotor).
+ *
+ * The DRV8838 H-bridge passes V_battery directly to motors. With a 2S LiPo
+ * (up to 8.4V), 100% duty would deliver 40% overvoltage to 6V motors.
+ * The motor_control_task clamps duty to: 0.95 * (6.0 / V_batt).
+ *
+ * @since Version 1.1.0
+ */
+static const float k_bb_motor_rated_v = 6.0F;
+
+/**
+ * @brief Duty cycle derating factor (5% margin for ADC tolerance).
+ * @since Version 1.1.0
+ */
+static const float k_bb_duty_derating = 0.95F;
+
+/**
+ * @brief Fallback max duty when battery voltage is unknown (USB power).
+ *
+ * Assumes worst-case 8.8V (freshly charged 2S with surface charge).
+ * 0.95 * 6.0 / 8.8 = 0.648, rounded down to 0.65.
+ *
+ * @since Version 1.1.0
+ */
+static const float k_bb_duty_fallback_max = 0.65F;
+
 #ifdef __cplusplus
 }
 #endif

--- a/star-beaglebone-blue/src/inc/hardware_config.h
+++ b/star-beaglebone-blue/src/inc/hardware_config.h
@@ -207,13 +207,13 @@ static const float s_bb_duty_percent_scale = 100.0F;
  *
  * @since Version 1.1.0
  */
-static const float k_bb_motor_rated_v = 6.0F;
+static const float s_bb_motor_rated_v = 6.0F;
 
 /**
  * @brief Duty cycle derating factor (5% margin for ADC tolerance).
  * @since Version 1.1.0
  */
-static const float k_bb_duty_derating = 0.95F;
+static const float s_bb_duty_derating = 0.95F;
 
 /**
  * @brief Fallback max duty when battery voltage is unknown (USB power).
@@ -223,7 +223,18 @@ static const float k_bb_duty_derating = 0.95F;
  *
  * @since Version 1.1.0
  */
-static const float k_bb_duty_fallback_max = 0.65F;
+static const float s_bb_duty_fallback_max = 0.65F;
+
+/**
+ * @brief ADC battery voltage deadzone threshold (volts).
+ *
+ * librobotcontrol's rc_adc_batt() returns 0.0 when the raw reading is
+ * below 1.0V (disconnected battery or USB-only power). We use the same
+ * threshold to decide whether battery monitoring is available.
+ *
+ * @since Version 1.1.0
+ */
+static const float s_bb_batt_deadzone_v = 1.0F;
 
 #ifdef __cplusplus
 }

--- a/star-beaglebone-blue/tasks/motor_control_task.c
+++ b/star-beaglebone-blue/tasks/motor_control_task.c
@@ -50,7 +50,7 @@ enum : uint64_t { k_adc_interval_ns = 100000000ULL };
  */
 static float internal_get_max_duty(void)
 {
-    static float s_max_duty = 0.65F; /* k_bb_duty_fallback_max */
+    static float s_max_duty = 0.65F; /* s_bb_duty_fallback_max */
     static struct timespec s_last_read = {0};
 
     struct timespec now = {0};
@@ -67,14 +67,14 @@ static float internal_get_max_duty(void)
         s_last_read = now;
 
         double vbatt = rc_adc_batt();
-        if (vbatt > 1.0) {
-            s_max_duty = k_bb_duty_derating
-                       * (k_bb_motor_rated_v / (float)vbatt);
+        if (vbatt > (double)s_bb_batt_deadzone_v) {
+            s_max_duty = s_bb_duty_derating
+                       * (s_bb_motor_rated_v / (float)vbatt);
             if (s_max_duty > 1.0F) {
                 s_max_duty = 1.0F;
             }
         } else {
-            s_max_duty = k_bb_duty_fallback_max;
+            s_max_duty = s_bb_duty_fallback_max;
         }
     }
 

--- a/star-beaglebone-blue/tasks/motor_control_task.c
+++ b/star-beaglebone-blue/tasks/motor_control_task.c
@@ -21,8 +21,12 @@
 #include "motor_control_task.h"
 #include "hardware_config.h"
 
+#include <math.h>
 #include <robotcontrol.h>
 #include <time.h>
+
+/** ADC read divider: read battery voltage every 10th iteration (10 Hz). */
+enum : uint32_t { k_adc_read_divider = 10U };
 
 /* Motor indices from hardware_config.h: k_bb_motor_idx_fl/fr/rl/rr */
 
@@ -55,7 +59,28 @@ void* bb_motor_control_task(void* arg)
     struct timespec next = {0};
     (void)clock_gettime(CLOCK_MONOTONIC, &next);
 
+    float max_duty = k_bb_duty_fallback_max; /* safe default until ADC reads */
+    uint32_t loop_count = 0U;
+
     while (rc_get_state() != EXITING) {
+        /* Read battery voltage at 10 Hz (every k_adc_read_divider iterations).
+         * Compute voltage-proportional duty clamp to protect 6V motors from
+         * overvoltage on 2S LiPo (up to 8.4V). DRV8838 passes V_batt directly
+         * to motors: V_motor = duty * V_batt. */
+        if ((loop_count % k_adc_read_divider) == 0U) {
+            double vbatt = rc_adc_batt();
+            if (vbatt > 1.0) {
+                max_duty = k_bb_duty_derating
+                         * (k_bb_motor_rated_v / (float)vbatt);
+                if (max_duty > 1.0F) {
+                    max_duty = 1.0F;
+                }
+            } else {
+                max_duty = k_bb_duty_fallback_max;
+            }
+        }
+        loop_count++;
+
         bool estop = false;
         (void)bb_shared_data_get_estop(sd, &estop);
 
@@ -66,9 +91,16 @@ void* bb_motor_control_task(void* arg)
             (void)rc_motor_set(k_bb_motor_rear_left, 0.0);
             (void)rc_motor_set(k_bb_motor_rear_right, 0.0);
         } else {
-            /* Apply motor commands from shared_data */
+            /* Apply motor commands with voltage-based duty clamp */
             bb_motor_cmd_t cmd = {0};
             (void)bb_shared_data_get_motor_cmd(sd, &cmd);
+
+            for (uint8_t i = 0U; i < (uint8_t)k_bb_motor_count; i++) {
+                float d = cmd.duty_percent[i];
+                if (d > max_duty)  { d = max_duty; }
+                if (d < -max_duty) { d = -max_duty; }
+                cmd.duty_percent[i] = d;
+            }
 
             (void)rc_motor_set(k_bb_motor_front_left,
                                (double)cmd.duty_percent[k_bb_motor_idx_fl]);

--- a/star-beaglebone-blue/tasks/motor_control_task.c
+++ b/star-beaglebone-blue/tasks/motor_control_task.c
@@ -21,12 +21,55 @@
 #include "motor_control_task.h"
 #include "hardware_config.h"
 
-#include <math.h>
 #include <robotcontrol.h>
 #include <time.h>
 
-/** ADC read divider: read battery voltage every 10th iteration (10 Hz). */
-enum : uint32_t { k_adc_read_divider = 10U };
+/* ---------------------------------------------------------------------------
+ * Battery voltage sampling (timer-based, 10 Hz)
+ * ---------------------------------------------------------------------------*/
+
+/** Minimum interval between ADC reads in nanoseconds (100 ms = 10 Hz). */
+enum : uint64_t { k_adc_interval_ns = 100000000ULL };
+
+/**
+ * @brief Compute the voltage-proportional max duty cycle.
+ *
+ * Reads rc_adc_batt() at most once per k_adc_interval_ns. Returns a cached
+ * value between calls. Protects 6V motors from overvoltage on 2S LiPo by
+ * clamping: max_duty = 0.95 * (6.0 / V_batt).
+ *
+ * @return float Max allowable abs(duty), in [0, 1].
+ * @since Version 1.1.0
+ */
+static float internal_get_max_duty(void)
+{
+    static float s_max_duty = 0.65F; /* k_bb_duty_fallback_max */
+    static struct timespec s_last_read = {0};
+
+    struct timespec now = {0};
+    (void)clock_gettime(CLOCK_MONOTONIC, &now);
+
+    uint64_t elapsed_ns = (uint64_t)(now.tv_sec - s_last_read.tv_sec)
+                        * k_bb_ns_per_sec
+                        + (uint64_t)(now.tv_nsec - s_last_read.tv_nsec);
+
+    if (elapsed_ns >= k_adc_interval_ns) {
+        s_last_read = now;
+
+        double vbatt = rc_adc_batt();
+        if (vbatt > 1.0) {
+            s_max_duty = k_bb_duty_derating
+                       * (k_bb_motor_rated_v / (float)vbatt);
+            if (s_max_duty > 1.0F) {
+                s_max_duty = 1.0F;
+            }
+        } else {
+            s_max_duty = k_bb_duty_fallback_max;
+        }
+    }
+
+    return s_max_duty;
+}
 
 /* Motor indices from hardware_config.h: k_bb_motor_idx_fl/fr/rl/rr */
 
@@ -59,27 +102,8 @@ void* bb_motor_control_task(void* arg)
     struct timespec next = {0};
     (void)clock_gettime(CLOCK_MONOTONIC, &next);
 
-    float max_duty = k_bb_duty_fallback_max; /* safe default until ADC reads */
-    uint32_t loop_count = 0U;
-
     while (rc_get_state() != EXITING) {
-        /* Read battery voltage at 10 Hz (every k_adc_read_divider iterations).
-         * Compute voltage-proportional duty clamp to protect 6V motors from
-         * overvoltage on 2S LiPo (up to 8.4V). DRV8838 passes V_batt directly
-         * to motors: V_motor = duty * V_batt. */
-        if ((loop_count % k_adc_read_divider) == 0U) {
-            double vbatt = rc_adc_batt();
-            if (vbatt > 1.0) {
-                max_duty = k_bb_duty_derating
-                         * (k_bb_motor_rated_v / (float)vbatt);
-                if (max_duty > 1.0F) {
-                    max_duty = 1.0F;
-                }
-            } else {
-                max_duty = k_bb_duty_fallback_max;
-            }
-        }
-        loop_count++;
+        const float max_duty = internal_get_max_duty();
 
         bool estop = false;
         (void)bb_shared_data_get_estop(sd, &estop);

--- a/star-beaglebone-blue/tasks/motor_control_task.c
+++ b/star-beaglebone-blue/tasks/motor_control_task.c
@@ -50,10 +50,10 @@ enum : uint64_t { k_adc_interval_ns = 100000000ULL };
  */
 static float internal_get_max_duty(void)
 {
-    static float s_max_duty = 0.65F; /* s_bb_duty_fallback_max */
-    static struct timespec s_last_read = {0};
+    static float s_max_duty = s_bb_duty_fallback_max;
+    static struct timespec s_last_read = {};
 
-    struct timespec now = {0};
+    struct timespec now = {};
     (void)clock_gettime(CLOCK_MONOTONIC, &now);
 
     /* Signed arithmetic for correct elapsed time when tv_nsec wraps.

--- a/star-beaglebone-blue/tasks/motor_control_task.c
+++ b/star-beaglebone-blue/tasks/motor_control_task.c
@@ -34,11 +34,18 @@ enum : uint64_t { k_adc_interval_ns = 100000000ULL };
 /**
  * @brief Compute the voltage-proportional max duty cycle.
  *
- * Reads rc_adc_batt() at most once per k_adc_interval_ns. Returns a cached
- * value between calls. Protects 6V motors from overvoltage on 2S LiPo by
- * clamping: max_duty = 0.95 * (6.0 / V_batt).
+ * Reads rc_adc_batt() at most once per k_adc_interval_ns using
+ * CLOCK_MONOTONIC for timing (immune to wall-clock adjustments).
+ * Returns a cached value between calls. First call always reads ADC
+ * (s_last_read initializes to zero, so elapsed is always large).
+ *
+ * Protects 6V motors from overvoltage on 2S LiPo by clamping:
+ * max_duty = 0.95 * (6.0 / V_batt).
  *
  * @return float Max allowable abs(duty), in [0, 1].
+ *
+ * @warning NOT thread-safe. Must be called from the motor control
+ *          thread only (single-caller assumption).
  * @since Version 1.1.0
  */
 static float internal_get_max_duty(void)
@@ -49,11 +56,14 @@ static float internal_get_max_duty(void)
     struct timespec now = {0};
     (void)clock_gettime(CLOCK_MONOTONIC, &now);
 
-    uint64_t elapsed_ns = (uint64_t)(now.tv_sec - s_last_read.tv_sec)
-                        * k_bb_ns_per_sec
-                        + (uint64_t)(now.tv_nsec - s_last_read.tv_nsec);
+    /* Signed arithmetic for correct elapsed time when tv_nsec wraps.
+     * Example: now={10, 0.1s} last={9, 0.9s} -> elapsed = 0.2s.
+     * Using unsigned would underflow (0.1 - 0.9 wraps to ~18e18). */
+    int64_t elapsed_ns = (int64_t)(now.tv_sec - s_last_read.tv_sec)
+                       * (int64_t)k_bb_ns_per_sec
+                       + (int64_t)(now.tv_nsec - s_last_read.tv_nsec);
 
-    if (elapsed_ns >= k_adc_interval_ns) {
+    if (elapsed_ns >= (int64_t)k_adc_interval_ns) {
         s_last_read = now;
 
         double vbatt = rc_adc_batt();


### PR DESCRIPTION
## Summary

- Add voltage-proportional duty cycle clamp to protect 6V motors from overvoltage on 2S LiPo (up to 8.4V)
- Formula: `max_duty = 0.95 * (6.0V / V_batt)` with 5% derating for ADC tolerance
- Falls back to 65% max duty on USB power (no battery detected)
- Add `rc_adc_init()` to hardware init for battery voltage monitoring
- Fix motor-test.c ADC init bug

## Why

The DRV8838 H-bridge passes battery voltage directly to motors. At 100% duty on a fully charged 2S LiPo (8.4V), the 6V-rated FIT0520 motors receive 40% overvoltage. This clamp limits the effective motor voltage to ~5.7V across the full battery charge range.

## Power specs (verified from datasheets)

| Battery State | V_batt | Max Duty | V_motor |
|---|---|---|---|
| Full charge | 8.4V | 67.9% | 5.7V |
| Nominal | 7.4V | 77.0% | 5.7V |
| Discharged | 6.0V | 95.0% | 5.7V |
| USB (no batt) | 0.0V | 65.0% (fallback) | N/A |

## Test plan

- [x] Cross-compiles cleanly
- [x] motor-test ADC init shows "OK" (was broken before)
- [x] Battery reads "N/A" on USB power (correct -- no battery)
- [ ] With 2S LiPo: battery voltage reads correctly, duty clamped
- [ ] Motors do not exceed 6V at any battery charge level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented real-time battery voltage monitoring in motor control system to enable voltage-dependent duty cycle limiting
  * Motors now automatically adjust duty cycles based on measured battery voltage, protecting them from over-voltage conditions while maintaining responsive control
  
* **Improvements**
  * Motor diagnostic test now displays battery monitoring system initialization status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->