### PR TITLE
Add rfp-cli to dev container and blinky flash target

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,5 @@
 # Track large binary files with Git LFS
 *.run filter=lfs diff=lfs merge=lfs -text
 gcc-14.2.0.202511-GNURX-ELF.run filter=lfs diff=lfs merge=lfs -text
+*.tgz filter=lfs diff=lfs merge=lfs -text
+RFP_CLI_Linux_V32200_x64.tgz filter=lfs diff=lfs merge=lfs -text

--- a/Dockerfile
+++ b/Dockerfile
@@ -161,6 +161,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     ros-jazzy-nav2-bringup \
     ros-jazzy-bondcpp
 
+# Install Renesas Flash Programmer CLI for RX72N flashing via E2 Lite
+ARG RFP_CLI_URL="https://github.com/Locked-Inc/STAR/raw/main/RFP_CLI_Linux_V32200_x64.tgz"
+RUN curl -sSL "${RFP_CLI_URL}" -o /tmp/rfp-cli.tgz && \
+    tar -xzf /tmp/rfp-cli.tgz -C /opt && \
+    mv /opt/linux-x64 /opt/rfp && \
+    rm /tmp/rfp-cli.tgz && \
+    ln -s /opt/rfp/rfp-cli /usr/local/bin/rfp-cli && \
+    chmod +x /opt/rfp/rfp-cli
+
 # Install CodeRabbit CLI for code review
 RUN curl -fsSL https://cli.coderabbit.ai/install.sh | sh
 

--- a/RFP_CLI_Linux_V32200_x64.tgz
+++ b/RFP_CLI_Linux_V32200_x64.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9f0399d7dbf79c6450bf97f2173945a83e3b58bf6d3576ba88253b0ad5675e2
+size 53362360

--- a/star-rx72n-firmware/blinky/Makefile
+++ b/star-rx72n-firmware/blinky/Makefile
@@ -22,7 +22,9 @@ LDFLAGS := $(CPU) -nostartfiles -Wl,-e_PowerON_Reset_PC -T linker.ld
 SRCS    := startup.S main.c
 TARGET  := blinky
 
-.PHONY: all clean
+RFP_CLI := rfp-cli
+
+.PHONY: all flash clean
 
 all: $(TARGET).elf $(TARGET).mot $(TARGET).hex
 	@echo ""
@@ -36,6 +38,10 @@ $(TARGET).mot: $(TARGET).elf
 
 $(TARGET).hex: $(TARGET).elf
 	$(OBJCOPY) -O ihex $< $@
+
+flash: $(TARGET).mot
+	sudo $(RFP_CLI) -d RX72N -t e2l -if fine -run \
+	    -auth id FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -a $<
 
 clean:
 	rm -f $(TARGET).elf $(TARGET).mot $(TARGET).hex


### PR DESCRIPTION
## Summary
- Bundle Renesas Flash Programmer CLI (V3.22.00) via Git LFS
- Install rfp-cli in Dockerfile so any dev can flash RX72N via E2 Lite without manual setup
- Add `make flash` target to blinky Makefile

## Test plan
- [x] Flashed RX72N successfully with external power
- [x] Flashed RX72N successfully with E2 Lite 3.3V power supply