### PR TITLE
Add Hailo-8L YOLO 3D perception for ADA compliance

### DIFF
--- a/final_capstone/compliance-engine/README.md
+++ b/final_capstone/compliance-engine/README.md
@@ -11,7 +11,7 @@ Part of the Locked Inc. senior capstone (Texas A&M ESET, Spring 2026).
 ## At a glance
 
 | Check | ADA section | Status | Node |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Ramp slope | 405.2 | IMPLEMENTED | `ramp_slope_node` |
 | Door clear width | 404.2.3 | IMPLEMENTED | `door_clear_width_node` |
 | Door threshold presence | 404.2.5 | IMPLEMENTED (presence-only) | `door_threshold_node` |
@@ -22,6 +22,7 @@ Part of the Locked Inc. senior capstone (Texas A&M ESET, Spring 2026).
 | Ramp landing | 405.7 | ARCHITECTED | - |
 
 Plus:
+
 - Dynamic obstacle clustering (`dynamic_obstacle_node`, DBSCAN)
 - Compliance CPU safety-net monitor (`compliance_monitor_node`)
 - Nav2 costmap fusion of 4 x HC-SR04 ultrasonic (via the

--- a/final_capstone/compliance-engine/docs/ARCHITECTURE.md
+++ b/final_capstone/compliance-engine/docs/ARCHITECTURE.md
@@ -68,7 +68,7 @@ graph.
 ## Topic / message table
 
 | Topic | Type | Direction | Rate | Consumer |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `/scan` | `sensor_msgs/LaserScan` | in | 10 Hz | ramp slope, door clear width, path blockage, dynamic obstacle |
 | `/imu/data` | `sensor_msgs/Imu` | in | 200 Hz | ramp slope, door clear width, door threshold, protruding objects |
 | `/odom` | `nav_msgs/Odometry` | in | 100 Hz | every compliance node |
@@ -92,7 +92,7 @@ graph.
 ## TF frame requirements
 
 | Frame | Parent | Source |
-|---|---|---|
+| --- | --- | --- |
 | `map` | - | slam_toolbox async |
 | `odom` | `map` | slam_toolbox |
 | `base_link` | `odom` | robot_localization EKF |
@@ -132,7 +132,7 @@ transformed into `base_link` or any other frame.
 ## CPU budget on Pi 5 (measured targets)
 
 | Node | Expected load | Disable flag |
-|---|---|---|
+| --- | --- | --- |
 | ramp_slope_node | 5-8% | - |
 | door_clear_width_node (idle) | 3% | `use_stereo:=false` |
 | door_clear_width_node (burst, doorway measurement) | 35% for 200 ms | |

--- a/final_capstone/compliance-engine/docs/DEPLOYMENT.md
+++ b/final_capstone/compliance-engine/docs/DEPLOYMENT.md
@@ -193,7 +193,7 @@ Every flagged measurement appends a row to a CSV file under
 `final_capstone/extras/`:
 
 | File | Rows written by |
-|---|---|
+| --- | --- |
 | `validation_log.csv` | `ramp_slope_node` + `door_clear_width_node` |
 | `threshold_log.csv` | `door_threshold_node` |
 | `protrusion_log.csv` | `protruding_objects_node` |

--- a/final_capstone/compliance-engine/docs/TROUBLESHOOTING.md
+++ b/final_capstone/compliance-engine/docs/TROUBLESHOOTING.md
@@ -13,6 +13,7 @@ to least-common in each section.
   `colcon build` failed silently.
 - **Diagnose:** `ros2 pkg list | grep star_compliance`
 - **Fix:**
+
   ```bash
   ./bootstrap_pi.sh
   source star-ros2/install/setup.bash
@@ -38,6 +39,7 @@ to least-common in each section.
 - **Diagnose:** `ls star-ros2/install/star_compliance_msgs/` - should
   contain `share/` and `lib/`.
 - **Fix:**
+
   ```bash
   cd star-ros2
   colcon build --packages-select star_compliance_msgs
@@ -53,11 +55,13 @@ to least-common in each section.
 - **Cause (likely):** LiDAR corridor-width minima aren't firing. Robot
   hasn't encountered a doorway narrow enough.
 - **Diagnose:**
+
   ```bash
   ros2 topic echo /scan --qos-reliability best_effort --once
   ros2 node info /star_door_clear_width_node
   ros2 param get /star_door_clear_width_node enabled
   ```
+
 - **Fix:** drive the robot into a hallway narrower than 1.1 m, or
   lower the `DOORWAY_CANDIDATE_MAX_M` constant in
   `detectors/doorway_lidar_detector.py`.
@@ -88,9 +92,11 @@ to least-common in each section.
 
 - **Cause:** jolt threshold too high for the actual event magnitude.
 - **Diagnose:**
+
   ```bash
   ros2 topic echo /imu/data | grep linear_acceleration -A 3
   ```
+
   Watch the `z` value while crossing a threshold. It should briefly
   exceed `threshold_ms2 + 9.8`.
 - **Fix:** lower `threshold_ms2` incrementally from 2.0 -> 1.5 -> 1.0,
@@ -102,15 +108,19 @@ to least-common in each section.
 - **Cause:** the input cloud topic is empty or the BNO055 hasn't
   published yet.
 - **Diagnose:**
+
   ```bash
   ros2 topic hz /cloud_map
   ros2 topic hz /imu/data
   ```
+
 - **Fix:** switch input topic to `/stereo/points2` if `/cloud_map`
   is stale:
+
   ```bash
   ros2 param set /star_protruding_objects_node input_cloud_topic /stereo/points2
   ```
+
   Note: 3-4x CPU cost. Monitor via `/compliance/monitor/status`.
 
 - **Cause:** CPU safety monitor has auto-disabled the node.
@@ -151,9 +161,11 @@ to least-common in each section.
 - **Diagnose:** follow the "How to tune door_offset_m" recipe in
   TUNING.md.
 - **Fix:**
+
   ```bash
   ros2 param set /star_door_clear_width_node door_offset_m 0.075
   ```
+
   or update the default in `compliance.launch.py` and rebuild.
 
 ---
@@ -210,7 +222,7 @@ If you can't resolve a symptom via this guide:
 
 1. Capture the logs: `tar czf star-logs.tgz /tmp/star-logs/`
 2. Run `ros2 doctor --report > ros2_report.txt`
-3. Open an issue at https://github.com/Locked-Inc/STAR with:
+3. Open an issue at <https://github.com/Locked-Inc/STAR> with:
    - Pi 5 model and RAM size
    - ROS 2 distro + date of `bootstrap_pi.sh` run
    - Which compliance node is misbehaving

--- a/final_capstone/compliance-engine/docs/TUNING.md
+++ b/final_capstone/compliance-engine/docs/TUNING.md
@@ -26,7 +26,7 @@ ros2 param set /star_protruding_objects_node enabled false
 Defined in `star_compliance/bringup/compliance.launch.py`.
 
 | Argument | Default | Effect |
-|---|---|---|
+| --- | --- | --- |
 | `use_stereo` | `true` | Door clear-width uses stereo. Set `false` for LiDAR-only operation when the IMX219-83 is disconnected. |
 | `use_ada_307` | `true` | ADA 307 node starts. Set `false` to save ~25% CPU. |
 | `use_path_blockage` | `true` | ADA 403.5 node starts. |
@@ -41,7 +41,7 @@ Defined in `star_compliance/bringup/compliance.launch.py`.
 ### ramp_slope_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | (none user-configurable today) | - | - | - |
 
 Known-good constants defined in `detectors/plane_segmentation.py`:
@@ -51,7 +51,7 @@ RANSAC `distance_threshold=0.03`, `num_iterations=500`,
 ### door_clear_width_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `door_offset_m` | `0.0635` | 0.04 - 0.08 | Total door+stop+hinge offset subtracted from frame width. Defaults to 2.5 in (1.75 in door + 0.5 in stop + 0.25 in hinge). Calibrate per deployment by measuring a few known doors and fitting the mean. |
 | `sensor_height_m` | `0.25` | 0.15 - 0.35 | LiDAR scan-plane height above the floor. Used to derive the handle-height band. Measure once with a ruler; static per robot build. |
 | `enabled` | `true` | bool | Toggle the whole node without killing its subscriptions. Useful for mid-run throttling. |
@@ -69,7 +69,7 @@ RANSAC `distance_threshold=0.03`, `num_iterations=500`,
 ### door_threshold_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `threshold_ms2` | `2.0` | 1.0 - 5.0 | z-accel deviation (above baseline) that fires the jolt detector. Lower = more sensitive (more false positives on carpet transitions); higher = fewer reads but misses compliant thresholds. |
 | `watch_duration_sec` | `2.0` | 1.0 - 4.0 | How long after a DoorwayMeasurement the jolt detector stays armed. Match to robot traversal speed: time to cross a 1.2 m doorway at 0.5 m/s is 2.4 s. |
 | `enabled` | `true` | bool | Toggle at runtime. |
@@ -87,7 +87,7 @@ RANSAC `distance_threshold=0.03`, `num_iterations=500`,
 ### protruding_objects_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `enabled` | `true` | bool | Auto-toggled by `compliance_monitor_node` under CPU stress. |
 | `input_cloud_topic` | `/cloud_map` | topic | `/cloud_map` is 1 Hz (cheap). `/stereo/points2` is 5-10 Hz (3-4x CPU). |
 | `sensor_height_m` | `0.25` | 0.15 - 0.35 | Same as above; used to anchor the floor plane. |
@@ -105,7 +105,7 @@ RANSAC `distance_threshold=0.03`, `num_iterations=500`,
 ### path_blockage_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `enabled` | `true` | bool | Toggle at runtime. |
 
 Constants in `detectors/corridor_medial_axis.py`:
@@ -117,7 +117,7 @@ editing the module if persistent false positives appear.
 ### dynamic_obstacle_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `enabled` | `true` | bool | Toggle at runtime. |
 | `eps_m` | `0.15` | 0.08 - 0.30 | DBSCAN neighborhood radius. Smaller = more, smaller clusters; larger = fewer, larger clusters. |
 | `min_samples` | `5` | 3 - 15 | DBSCAN core-point threshold. Lower = more FP from LiDAR noise; higher = misses small dynamic objects. |
@@ -134,7 +134,7 @@ editing the module if persistent false positives appear.
 ### compliance_monitor_node
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `cpu_count` | auto-detect | 1-16 | Divisor for normalizing the 1-minute load average. Override only if `os.cpu_count()` misreports. |
 
 Thresholds `HIGH_LOAD_THRESHOLD=0.80` and `LOW_LOAD_THRESHOLD=0.50`
@@ -148,7 +148,7 @@ budget.
 `star-ros2/src/star_bringup/config/nav2_params.yaml`:
 
 | Parameter | Default | Range | Meaning |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `local_costmap.sonar_layer.phi` | 1.2 | 0.5 - 2.5 | Full cone angle (radians) for HC-SR04 inflation. 1.2 rad ~ 70 deg. The HC-SR04's datasheet is 15 deg effective, but inflating wider accounts for near-range spread. |
 | `sonar_layer.clear_threshold` | 0.2 | 0.1 - 0.5 | Cells with cost probability below this are cleared. |
 | `sonar_layer.mark_threshold` | 0.8 | 0.5 - 0.95 | Cells with cost above this are marked as obstacle. |

--- a/final_capstone/compliance-engine/docs/VALIDATION.md
+++ b/final_capstone/compliance-engine/docs/VALIDATION.md
@@ -15,7 +15,7 @@ STAR is accurate enough to be worth a CASp's time.
 ### Instruments (own / borrow before running a validation pass)
 
 | Instrument | Purpose | Accuracy |
-|---|---|---|
+| --- | --- | --- |
 | Stanley FatMax 25 ft tape | Frame widths, path widths | +/- 1/32 in |
 | Bosch GLM50 laser distance meter | Door clearances, threshold heights | +/- 1/16 in over 50 ft |
 | Wixey WR300 digital angle gauge | Ramp slopes | +/- 0.1 deg |
@@ -68,6 +68,7 @@ and the door stop, door open 90 degrees. **Also** measure frame-to-
 frame for comparison with STAR's mid-layer number.
 
 **Trials:** n >= 20 doors across 3 buildings. Mix:
+
 - 5 compliant doors (ADA clear width >= 32 in)
 - 5 borderline doors (ADA clear width 30-33 in)
 - 5 clearly non-compliant doors (ADA clear width < 30 in)
@@ -75,6 +76,7 @@ frame for comparison with STAR's mid-layer number.
 
 **STAR reading:** drive up to each door and pause. Observe
 `/compliance/door_clear_width`:
+
 - `frame_width_m` - raw measurement at handle height
 - `ada_clear_width_m` - after offset subtraction
 - `confidence` - HIGH / MEDIUM / LOW
@@ -98,6 +100,7 @@ equivalent) on the threshold. Any threshold >= 0.25 in is a
 
 **Trials:** n >= 10 thresholds across mixed flooring (vinyl, carpet
 transition, tile, wooden):
+
 - 5 compliant (< 0.25 in)
 - 5 non-compliant (>= 0.5 in)
 
@@ -120,6 +123,7 @@ protruding object's extremity, measured parallel to the floor. Also
 note the object's center height above the floor.
 
 **Trials:** n >= 10 protrusions:
+
 - 3 clearly non-compliant (> 5 in stand-off, in the 27-80 in band)
 - 3 borderline (~4 in stand-off, in the band)
 - 2 compliant (< 3 in stand-off)
@@ -143,6 +147,7 @@ width (cart present, sign in place, etc.) and the pre-blockage baseline.
 
 **Trials:** n >= 5 controlled setups with planted obstacles in a
 corridor that's >= 40 in wide empty:
+
 - 3 obvious blockages (30 in remaining)
 - 2 borderline (35 in remaining)
 
@@ -187,7 +192,7 @@ deliverable that isn't in the CSV.** Traceable claims only.
 ## Validation scheduling
 
 | Session | Checks | When |
-|---|---|---|
+| --- | --- | --- |
 | V1 - bench | ramp slope, door threshold presence | dress rehearsal #1 (T-6) |
 | V2 - campus (ETID hall) | ramp slope, door clear width, path blockage | T-5 |
 | V3 - campus (multi-building) | door clear width, protruding objects | T-4 |

--- a/final_capstone/compliance-engine/star_compliance/detectors/cane_zone_filter.py
+++ b/final_capstone/compliance-engine/star_compliance/detectors/cane_zone_filter.py
@@ -22,6 +22,38 @@ CANE_ZONE_MIN_M = 27.0 * INCH_TO_M    # 0.6858
 CANE_ZONE_MAX_M = 80.0 * INCH_TO_M    # 2.032
 ADA_307_PROTRUSION_LIMIT_M = 4.0 * INCH_TO_M   # 0.1016
 
+# COCO classes the YOLO node may report that we treat as transient
+# (movable) for ADA 307 purposes. The standard targets *fixed*
+# protrusions; a person, a chair, or a backpack appearing in the
+# cane zone during a scan is a transient occupancy hit, not a building
+# accessibility violation. The compliance node reports them with
+# flagged_violation=false so the audit reviewer still sees them but
+# the building is not penalised.
+TRANSIENT_CLASSES = frozenset({
+    "person",
+    "chair",
+    "backpack",
+    "handbag",
+    "suitcase",
+    "umbrella",
+    "dog",
+    "cat",
+    "sports ball",
+    "frisbee",
+    "skateboard",
+})
+
+# Maximum distance between a LiDAR cluster centroid and the centroid
+# of a YOLO 3D detection to consider them the same object. Tuned to
+# the IMX219-83 stereo depth standard error (~10 cm at 2 m range)
+# plus map-frame TF jitter.
+DEFAULT_CLASS_MATCH_RADIUS_M = 0.30
+
+
+def is_transient_class(class_label: str) -> bool:
+    """Return True when the YOLO label identifies a transient object."""
+    return bool(class_label) and class_label in TRANSIENT_CLASSES
+
 
 def filter_to_cane_zone(points: np.ndarray,
                         floor_height_m: float,

--- a/final_capstone/compliance-engine/star_compliance/detectors/cane_zone_filter.py
+++ b/final_capstone/compliance-engine/star_compliance/detectors/cane_zone_filter.py
@@ -22,14 +22,19 @@ CANE_ZONE_MIN_M = 27.0 * INCH_TO_M    # 0.6858
 CANE_ZONE_MAX_M = 80.0 * INCH_TO_M    # 2.032
 ADA_307_PROTRUSION_LIMIT_M = 4.0 * INCH_TO_M   # 0.1016
 
-# COCO classes the YOLO node may report that we treat as transient
+# Classes the YOLO node may report that we treat as transient
 # (movable) for ADA 307 purposes. The standard targets *fixed*
 # protrusions; a person, a chair, or a backpack appearing in the
 # cane zone during a scan is a transient occupancy hit, not a building
 # accessibility violation. The compliance node reports them with
 # flagged_violation=false so the audit reviewer still sees them but
 # the building is not penalised.
+#
+# Covers both COCO 80 labels (lowercase) and Open Images V7 labels
+# (Title Case, sometimes more granular — "Man" / "Woman" / "Boy" /
+# "Girl" are separate in OIV7 but all collapse to Person here).
 TRANSIENT_CLASSES = frozenset({
+    # COCO
     "person",
     "chair",
     "backpack",
@@ -41,6 +46,41 @@ TRANSIENT_CLASSES = frozenset({
     "sports ball",
     "frisbee",
     "skateboard",
+    # Open Images V7 equivalents and extras
+    "Person",
+    "Man",
+    "Woman",
+    "Boy",
+    "Girl",
+    "Human body",
+    "Human head",
+    "Chair",
+    "Stool",
+    "Backpack",
+    "Handbag",
+    "Briefcase",
+    "Luggage and bags",
+    "Suitcase",
+    "Umbrella",
+    "Dog",
+    "Cat",
+    "Rabbit",
+    "Skateboard",
+    "Scooter",
+    "Roller skates",
+    "Bicycle",
+    "Cart",
+    "Ball",
+    "Football",
+    "Basketball",
+    "Tennis ball",
+    "Frisbee",
+    "Flying disc",
+    # Mobility aids on the move
+    "Wheelchair",
+    "Walking stick",
+    "Crutch",
+    "Cane",
 })
 
 # Maximum distance between a LiDAR cluster centroid and the centroid

--- a/final_capstone/compliance-engine/star_compliance/detectors/cane_zone_filter.py
+++ b/final_capstone/compliance-engine/star_compliance/detectors/cane_zone_filter.py
@@ -31,7 +31,7 @@ ADA_307_PROTRUSION_LIMIT_M = 4.0 * INCH_TO_M   # 0.1016
 # the building is not penalised.
 #
 # Covers both COCO 80 labels (lowercase) and Open Images V7 labels
-# (Title Case, sometimes more granular — "Man" / "Woman" / "Boy" /
+# (Title Case, sometimes more granular -- "Man" / "Woman" / "Boy" /
 # "Girl" are separate in OIV7 but all collapse to Person here).
 TRANSIENT_CLASSES = frozenset({
     # COCO

--- a/final_capstone/compliance-engine/star_compliance/nodes/dynamic_obstacle_node.py
+++ b/final_capstone/compliance-engine/star_compliance/nodes/dynamic_obstacle_node.py
@@ -2,15 +2,26 @@
 DBSCAN dynamic-obstacle clusterer node.
 
 Subscribes to:
-  /scan    sensor_msgs/LaserScan
-  /map     nav_msgs/OccupancyGrid (for background subtraction)
-  /odom    nav_msgs/Odometry (to transform scan into map frame)
+  /scan                     sensor_msgs/LaserScan
+  /map                      nav_msgs/OccupancyGrid (background subtraction)
+  /odom                     nav_msgs/Odometry (transform scan into map frame)
+  /perception/detections_3d  vision_msgs/Detection3DArray (Hailo YOLO 3D
+                            detections in cam0_optical_frame, optional)
 
 Publishes:
   /perception/dynamic_obstacles   star_compliance_msgs/DynamicObstacleArray
 
 Not ADA-specific; feeds the path-blockage node and future Nav2
 behavior-tree "pause for pedestrian" actions.
+
+Fusion behaviour
+----------------
+When YOLO 3D detections are available, the node fuses them with the
+LiDAR DBSCAN clusters:
+  * Cluster + matching YOLO  -> source = "yolo+lidar", confidence = 1.0
+  * Cluster only             -> source = "lidar"
+  * YOLO `person` only       -> source = "yolo", confidence = 0.6
+                                (e.g. behind glass, beyond LiDAR)
 """
 
 from __future__ import annotations
@@ -36,11 +47,37 @@ except ImportError:  # pragma: no cover
     DynamicObstacleArray = None
     HAS_MSGS = False
 
+try:
+    from vision_msgs.msg import Detection3DArray
+    HAS_VISION_MSGS = True
+except ImportError:  # pragma: no cover
+    Detection3DArray = None
+    HAS_VISION_MSGS = False
+
+try:
+    from tf2_ros import Buffer, TransformListener
+    HAS_TF2 = True
+except ImportError:  # pragma: no cover
+    Buffer = None
+    TransformListener = None
+    HAS_TF2 = False
+
+from star_compliance.detectors.cane_zone_filter import (
+    DEFAULT_CLASS_MATCH_RADIUS_M,
+)
 from star_compliance.detectors.obstacle_clusterer import (
     cluster_points,
     subtract_known_map,
 )
 from star_compliance.detectors.doorway_lidar_detector import polar_to_xy
+
+
+MAP_FRAME = "map"
+PERSON_CLASS = "person"
+LIDAR_ONLY_CONFIDENCE = None  # Use whatever DBSCAN reports.
+YOLO_ONLY_PERSON_CONFIDENCE = 0.6
+YOLO_PLUS_LIDAR_CONFIDENCE = 1.0
+DEFAULT_YOLO_CACHE_SECONDS = 1.0
 
 
 class DynamicObstacleNode(Node):
@@ -51,9 +88,14 @@ class DynamicObstacleNode(Node):
         self.declare_parameter("enabled", True)
         self.declare_parameter("eps_m", 0.15)
         self.declare_parameter("min_samples", 5)
+        self.declare_parameter(
+            "class_match_radius_m", DEFAULT_CLASS_MATCH_RADIUS_M)
+        self.declare_parameter("yolo_cache_seconds", DEFAULT_YOLO_CACHE_SECONDS)
 
         self._latest_map: OccupancyGrid | None = None
         self._latest_odom: Odometry | None = None
+        # Each entry: (received_sec, x_map, y_map, class_label, score).
+        self._yolo_cache: list[tuple[float, float, float, str, float]] = []
 
         qos_sensor = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -76,6 +118,20 @@ class DynamicObstacleNode(Node):
             )
         else:
             self._pub = None
+
+        if HAS_VISION_MSGS and HAS_TF2:
+            self._tf_buffer: Buffer | None = Buffer()
+            self._tf_listener = TransformListener(self._tf_buffer, self)
+            self._sub_yolo = self.create_subscription(
+                Detection3DArray,
+                "/perception/detections_3d",
+                self._on_yolo,
+                qos_sensor,
+            )
+        else:  # pragma: no cover
+            self._tf_buffer = None
+            self._tf_listener = None
+            self._sub_yolo = None
 
         self.get_logger().info("star_dynamic_obstacle_node ready.")
 
@@ -122,19 +178,125 @@ class DynamicObstacleNode(Node):
             return
         arr = DynamicObstacleArray()
         arr.header.stamp = self.get_clock().now().to_msg()
-        arr.header.frame_id = "map"
+        arr.header.frame_id = MAP_FRAME
+
+        radius_m = float(self.get_parameter("class_match_radius_m").value)
+        matched_yolo_idx: set[int] = set()
+
         for c in clusters:
+            cx, cy = float(c.centroid_xy[0]), float(c.centroid_xy[1])
+            yolo_idx, label, score = self._match_yolo(cx, cy, radius_m)
             obs = DynamicObstacle()
             obs.header = arr.header
             obs.cluster_pose_map_frame.header = arr.header
-            obs.cluster_pose_map_frame.pose.position.x = c.centroid_xy[0]
-            obs.cluster_pose_map_frame.pose.position.y = c.centroid_xy[1]
+            obs.cluster_pose_map_frame.pose.position.x = cx
+            obs.cluster_pose_map_frame.pose.position.y = cy
             obs.cluster_pose_map_frame.pose.orientation.w = 1.0
             obs.cluster_radius_m = float(c.radius_m)
             obs.point_count = int(c.point_count)
-            obs.confidence = float(c.confidence)
+            if yolo_idx is not None:
+                obs.confidence = YOLO_PLUS_LIDAR_CONFIDENCE
+                obs.source = "yolo+lidar"
+                obs.class_label = label
+                matched_yolo_idx.add(yolo_idx)
+            else:
+                obs.confidence = float(c.confidence)
+                obs.source = "lidar"
+                obs.class_label = ""
             arr.obstacles.append(obs)
+
+        # YOLO-only persons (e.g. behind a glass door, beyond LiDAR
+        # range) get their own entries.
+        for idx, entry in enumerate(self._yolo_cache):
+            if idx in matched_yolo_idx:
+                continue
+            _, x_map, y_map, label, score = entry
+            if label != PERSON_CLASS:
+                continue
+            obs = DynamicObstacle()
+            obs.header = arr.header
+            obs.cluster_pose_map_frame.header = arr.header
+            obs.cluster_pose_map_frame.pose.position.x = x_map
+            obs.cluster_pose_map_frame.pose.position.y = y_map
+            obs.cluster_pose_map_frame.pose.orientation.w = 1.0
+            obs.cluster_radius_m = 0.30  # Nominal person radius.
+            obs.point_count = 0
+            obs.confidence = YOLO_ONLY_PERSON_CONFIDENCE
+            obs.source = "yolo"
+            obs.class_label = label
+            arr.obstacles.append(obs)
+
         self._pub.publish(arr)
+
+    # ------------------------------------------------------------------
+
+    def _on_yolo(self, msg) -> None:
+        """Cache YOLO 3D detections in map-frame coordinates."""
+        if self._tf_buffer is None:
+            return
+        try:
+            tf = self._tf_buffer.lookup_transform(
+                MAP_FRAME, msg.header.frame_id,
+                rclpy.time.Time(),
+                timeout=rclpy.duration.Duration(seconds=0.05),
+            )
+        except Exception as exc:  # pragma: no cover - TF state dependent
+            self.get_logger().warn(
+                f"YOLO TF lookup failed: {exc}",
+                throttle_duration_sec=10.0,
+            )
+            return
+
+        now = self.get_clock().now().nanoseconds * 1e-9
+        for d in msg.detections:
+            if not d.results:
+                continue
+            label = d.results[0].hypothesis.class_id
+            score = float(d.results[0].hypothesis.score)
+            x_map, y_map, _ = self._transform_point(
+                d.bbox.center.position.x,
+                d.bbox.center.position.y,
+                d.bbox.center.position.z,
+                tf,
+            )
+            self._yolo_cache.append((now, x_map, y_map, label, score))
+        cache_window = float(
+            self.get_parameter("yolo_cache_seconds").value)
+        cutoff = now - cache_window
+        self._yolo_cache = [e for e in self._yolo_cache if e[0] >= cutoff]
+
+    def _match_yolo(self, x: float, y: float, radius_m: float
+                    ) -> tuple[int | None, str, float]:
+        """Find the nearest YOLO entry within radius_m. 2D match (XY)."""
+        if not self._yolo_cache:
+            return None, "", 0.0
+        radius_sq = radius_m * radius_m
+        best_d2 = float("inf")
+        best_idx: int | None = None
+        best_label = ""
+        best_score = 0.0
+        for idx, (_, xm, ym, label, score) in enumerate(self._yolo_cache):
+            d2 = (xm - x) ** 2 + (ym - y) ** 2
+            if d2 < best_d2 and d2 <= radius_sq:
+                best_d2 = d2
+                best_idx = idx
+                best_label = label
+                best_score = score
+        return best_idx, best_label, best_score
+
+    @staticmethod
+    def _transform_point(x: float, y: float, z: float, tf
+                         ) -> tuple[float, float, float]:
+        """Apply a TransformStamped to a point. Pure linear algebra."""
+        t = tf.transform.translation
+        q = tf.transform.rotation
+        xx, yy, zz = q.x * q.x, q.y * q.y, q.z * q.z
+        xy, xz, yz = q.x * q.y, q.x * q.z, q.y * q.z
+        wx, wy, wz = q.w * q.x, q.w * q.y, q.w * q.z
+        rx = (1 - 2 * (yy + zz)) * x + 2 * (xy - wz) * y + 2 * (xz + wy) * z
+        ry = 2 * (xy + wz) * x + (1 - 2 * (xx + zz)) * y + 2 * (yz - wx) * z
+        rz = 2 * (xz - wy) * x + 2 * (yz + wx) * y + (1 - 2 * (xx + yy)) * z
+        return rx + t.x, ry + t.y, rz + t.z
 
     # ------------------------------------------------------------------
 

--- a/final_capstone/compliance-engine/star_compliance/nodes/protruding_objects_node.py
+++ b/final_capstone/compliance-engine/star_compliance/nodes/protruding_objects_node.py
@@ -2,11 +2,21 @@
 ADA 307 Protruding Objects compliance node.
 
 Subscribes to:
-  /cloud_map    sensor_msgs/PointCloud2 (RTAB-Map consolidated, 1 Hz)
-                 - configurable via the `input_cloud_topic` parameter;
-                   /stereo/points2 also works at higher rate with more
-                   CPU cost.
-  /imu/data     sensor_msgs/Imu (BNO055, for floor-plane anchor)
+  /cloud_map               sensor_msgs/PointCloud2 (RTAB-Map consolidated,
+                           1 Hz). Configurable via `input_cloud_topic`;
+                           /stereo/points2 also works at higher rate with
+                           more CPU cost.
+  /imu/data                sensor_msgs/Imu (BNO055, for floor-plane anchor)
+  /perception/detections_3d  vision_msgs/Detection3DArray (Hailo YOLO 3D
+                           detections in cam0_optical_frame, fused via
+                           star_perception.detection_3d_fusion_node).
+                           When present, each emitted ProtrudingObject is
+                           tagged with the nearest YOLO class label, and
+                           transient classes (person, chair, backpack,
+                           ...) are reported with flagged_violation=false.
+                           The node still works without YOLO -- all
+                           protrusions are then treated as unclassified
+                           and presumed-fixed.
 
 Publishes:
   /compliance/protruding_objects   star_compliance_msgs/ProtrudingObjectArray
@@ -43,12 +53,31 @@ except ImportError:  # pragma: no cover
     ProtrudingObjectArray = None
     HAS_MSGS = False
 
+try:
+    from vision_msgs.msg import Detection3DArray
+    HAS_VISION_MSGS = True
+except ImportError:  # pragma: no cover
+    Detection3DArray = None
+    HAS_VISION_MSGS = False
+
+try:
+    import tf2_ros
+    from tf2_ros import Buffer, TransformListener
+    HAS_TF2 = True
+except ImportError:  # pragma: no cover
+    tf2_ros = None
+    Buffer = None
+    TransformListener = None
+    HAS_TF2 = False
+
 from star_compliance.detectors.cane_zone_filter import (
     ADA_307_PROTRUSION_LIMIT_M,
     CANE_ZONE_MAX_M,
     CANE_ZONE_MIN_M,
+    DEFAULT_CLASS_MATCH_RADIUS_M,
     filter_to_cane_zone,
     is_protrusion,
+    is_transient_class,
 )
 from star_compliance.detectors.wall_plane_fitter import (
     fit_walls,
@@ -60,6 +89,8 @@ from star_compliance.engines.floor_frame import floor_from_bno055_quaternion
 ADA_SECTION = "307"
 DEFAULT_SENSOR_HEIGHT_M = 0.25
 DEFAULT_MIN_CLUSTER_POINTS = 5
+DEFAULT_YOLO_CACHE_SECONDS = 1.0
+MAP_FRAME = "map"
 
 
 VALIDATION_CSV = Path(
@@ -79,10 +110,15 @@ class ProtrudingObjectsNode(Node):
         self.declare_parameter("input_cloud_topic", "/cloud_map")
         self.declare_parameter("sensor_height_m", DEFAULT_SENSOR_HEIGHT_M)
         self.declare_parameter("min_cluster_points", DEFAULT_MIN_CLUSTER_POINTS)
+        self.declare_parameter(
+            "class_match_radius_m", DEFAULT_CLASS_MATCH_RADIUS_M)
+        self.declare_parameter("yolo_cache_seconds", DEFAULT_YOLO_CACHE_SECONDS)
 
         self._latest_imu: Imu | None = None
         self._latest_cloud: PointCloud2 | None = None
         self._last_process_sec: float = 0.0
+        # Each entry: (received_sec, x_map, y_map, z_map, class_label, score).
+        self._yolo_cache: list[tuple[float, float, float, float, str, float]] = []
 
         qos_sensor = QoSProfile(
             reliability=ReliabilityPolicy.BEST_EFFORT,
@@ -99,6 +135,23 @@ class ProtrudingObjectsNode(Node):
         self._sub_imu = self.create_subscription(
             Imu, "/imu/data", self._on_imu, qos_sensor,
         )
+
+        # Optional YOLO 3D detection feed. Subscribed when both
+        # vision_msgs and tf2 are available; otherwise the node falls
+        # back to unclassified protrusions.
+        if HAS_VISION_MSGS and HAS_TF2:
+            self._tf_buffer: Buffer | None = Buffer()
+            self._tf_listener = TransformListener(self._tf_buffer, self)
+            self._sub_yolo = self.create_subscription(
+                Detection3DArray,
+                "/perception/detections_3d",
+                self._on_yolo,
+                qos_sensor,
+            )
+        else:  # pragma: no cover - integration test path
+            self._tf_buffer = None
+            self._tf_listener = None
+            self._sub_yolo = None
 
         if HAS_MSGS:
             self._pub = self.create_publisher(
@@ -127,6 +180,81 @@ class ProtrudingObjectsNode(Node):
 
     def _on_imu(self, msg: Imu) -> None:
         self._latest_imu = msg
+
+    def _on_yolo(self, msg) -> None:
+        """Cache YOLO 3D detections in map-frame for later matching."""
+        if self._tf_buffer is None:
+            return
+        try:
+            tf = self._tf_buffer.lookup_transform(
+                MAP_FRAME, msg.header.frame_id,
+                rclpy.time.Time(),
+                timeout=rclpy.duration.Duration(seconds=0.05),
+            )
+        except Exception as exc:  # pragma: no cover - depends on TF tree
+            self.get_logger().warn(
+                f"YOLO TF lookup failed ({msg.header.frame_id} -> "
+                f"{MAP_FRAME}): {exc}",
+                throttle_duration_sec=10.0,
+            )
+            return
+
+        now = self.get_clock().now().nanoseconds * 1e-9
+        for d in msg.detections:
+            if not d.results:
+                continue
+            class_label = d.results[0].hypothesis.class_id
+            score = float(d.results[0].hypothesis.score)
+            x_map, y_map, z_map = self._transform_point(
+                d.bbox.center.position.x,
+                d.bbox.center.position.y,
+                d.bbox.center.position.z,
+                tf,
+            )
+            self._yolo_cache.append(
+                (now, x_map, y_map, z_map, class_label, score)
+            )
+        self._evict_stale_yolo(now)
+
+    def _evict_stale_yolo(self, now_sec: float) -> None:
+        cache_window = float(self.get_parameter("yolo_cache_seconds").value)
+        cutoff = now_sec - cache_window
+        self._yolo_cache = [
+            entry for entry in self._yolo_cache if entry[0] >= cutoff
+        ]
+
+    @staticmethod
+    def _transform_point(x: float, y: float, z: float, tf
+                         ) -> tuple[float, float, float]:
+        """Apply a TransformStamped to a point. Pure linear algebra."""
+        t = tf.transform.translation
+        q = tf.transform.rotation
+        # Rotation matrix from quaternion (q.x, q.y, q.z, q.w).
+        xx, yy, zz = q.x * q.x, q.y * q.y, q.z * q.z
+        xy, xz, yz = q.x * q.y, q.x * q.z, q.y * q.z
+        wx, wy, wz = q.w * q.x, q.w * q.y, q.w * q.z
+        rx = (1 - 2 * (yy + zz)) * x + 2 * (xy - wz) * y + 2 * (xz + wy) * z
+        ry = 2 * (xy + wz) * x + (1 - 2 * (xx + zz)) * y + 2 * (yz - wx) * z
+        rz = 2 * (xz - wy) * x + 2 * (yz + wx) * y + (1 - 2 * (xx + yy)) * z
+        return rx + t.x, ry + t.y, rz + t.z
+
+    def _match_yolo(self, x: float, y: float, z: float
+                    ) -> tuple[str, float]:
+        """Return (class_label, score) of the nearest YOLO detection."""
+        if not self._yolo_cache:
+            return "", 0.0
+        radius = float(self.get_parameter("class_match_radius_m").value)
+        radius_sq = radius * radius
+        best_d2 = float("inf")
+        best_label = ""
+        best_score = 0.0
+        for _, xm, ym, zm, label, score in self._yolo_cache:
+            d2 = (xm - x) ** 2 + (ym - y) ** 2 + (zm - z) ** 2
+            if d2 < best_d2 and d2 <= radius_sq:
+                best_d2 = d2
+                best_label = label
+                best_score = score
+        return best_label, best_score
 
     def _process_if_ready(self) -> None:
         if not self.get_parameter("enabled").value:
@@ -174,13 +302,17 @@ class ProtrudingObjectsNode(Node):
                                  point_count=1,
                                  min_points=1):
                 continue
+            x, y, z = float(row[0]), float(row[1]), float(row[2])
+            class_label, class_score = self._match_yolo(x, y, z)
             objects.append({
-                "x": float(row[0]),
-                "y": float(row[1]),
-                "z": float(row[2]),
+                "x": x,
+                "y": y,
+                "z": z,
                 "distance": float(distance),
-                "height_above_floor": float(row[2] - floor_height_m),
+                "height_above_floor": float(z - floor_height_m),
                 "wall_d": float(wall.d),
+                "class_label": class_label,
+                "class_confidence": class_score,
             })
 
         if not objects:
@@ -207,7 +339,14 @@ class ProtrudingObjectsNode(Node):
                 p.cluster_extent_m = 0.0
                 p.cluster_point_count = 1
                 p.wall_plane_distance_m = o["wall_d"]
-                p.flagged_violation = True
+                p.class_label = o["class_label"]
+                p.class_confidence = float(o["class_confidence"])
+                # Transient YOLO classes (person, chair, ...) are not
+                # ADA 307 violations -- the standard targets *fixed*
+                # protrusions. Empty class_label keeps the legacy
+                # presumed-fixed behaviour.
+                p.flagged_violation = not is_transient_class(
+                    o["class_label"])
                 p.ada_section = ADA_SECTION
                 p.cloud_snippet_path = ""
                 arr.objects.append(p)

--- a/final_capstone/compliance-engine/tests/ros_mocks.py
+++ b/final_capstone/compliance-engine/tests/ros_mocks.py
@@ -98,19 +98,19 @@ class FakeLogger:
     def __init__(self):
         self.records: list[tuple[str, str]] = []
 
-    def info(self, msg: str) -> None:
+    def info(self, msg: str, **_kwargs) -> None:
         self.records.append(("info", msg))
 
-    def warn(self, msg: str) -> None:
+    def warn(self, msg: str, **_kwargs) -> None:
         self.records.append(("warn", msg))
 
-    def warning(self, msg: str) -> None:
+    def warning(self, msg: str, **_kwargs) -> None:
         self.warn(msg)
 
-    def error(self, msg: str) -> None:
+    def error(self, msg: str, **_kwargs) -> None:
         self.records.append(("error", msg))
 
-    def debug(self, msg: str) -> None:
+    def debug(self, msg: str, **_kwargs) -> None:
         self.records.append(("debug", msg))
 
 
@@ -253,6 +253,9 @@ def install_ros_mocks() -> None:
         "cv_bridge",
         "sensor_msgs_py", "sensor_msgs_py.point_cloud2",
         "star_compliance_msgs", "star_compliance_msgs.msg",
+        "vision_msgs", "vision_msgs.msg",
+        "tf2_ros",
+        "rclpy.duration", "rclpy.time",
     ):
         if pkg not in sys.modules:
             _make_module(pkg)
@@ -284,3 +287,38 @@ def install_ros_mocks() -> None:
         "PathBlockage",
     ):
         setattr(sys.modules["star_compliance_msgs.msg"], msg_cls, MagicMock)
+
+    # vision_msgs Detection3DArray is consumed by the YOLO-aware
+    # branches in protruding_objects_node and dynamic_obstacle_node.
+    setattr(sys.modules["vision_msgs.msg"], "Detection3DArray", MagicMock)
+
+    # tf2_ros: a Buffer with a configurable lookup_transform return,
+    # plus a stub TransformListener. Tests poke node._tf_buffer
+    # directly to inject a TransformStamped.
+    class _FakeTfBuffer:
+        def __init__(self) -> None:
+            self.transform_to_return = None  # tests assign a stub.
+
+        def lookup_transform(self, target, source, time, timeout=None):
+            if self.transform_to_return is None:
+                raise RuntimeError("test did not set transform_to_return")
+            return self.transform_to_return
+
+    class _FakeTransformListener:
+        def __init__(self, buffer, node):
+            self.buffer = buffer
+            self.node = node
+
+    setattr(sys.modules["tf2_ros"], "Buffer", _FakeTfBuffer)
+    setattr(sys.modules["tf2_ros"],
+            "TransformListener", _FakeTransformListener)
+
+    # rclpy.time.Time and rclpy.duration.Duration are referenced by
+    # the YOLO callbacks. Stubs satisfy the constructor and the
+    # lookup_transform timeout argument. Both submodules must also be
+    # exposed as attributes of `rclpy` so `rclpy.time.Time()` works
+    # after a plain `import rclpy`.
+    sys.modules["rclpy.time"].Time = MagicMock
+    sys.modules["rclpy.duration"].Duration = MagicMock
+    rclpy.time = sys.modules["rclpy.time"]
+    rclpy.duration = sys.modules["rclpy.duration"]

--- a/final_capstone/compliance-engine/tests/test_cane_zone_filter.py
+++ b/final_capstone/compliance-engine/tests/test_cane_zone_filter.py
@@ -8,8 +8,11 @@ from star_compliance.detectors.cane_zone_filter import (
     ADA_307_PROTRUSION_LIMIT_M,
     CANE_ZONE_MAX_M,
     CANE_ZONE_MIN_M,
+    DEFAULT_CLASS_MATCH_RADIUS_M,
+    TRANSIENT_CLASSES,
     filter_to_cane_zone,
     is_protrusion,
+    is_transient_class,
 )
 
 
@@ -76,3 +79,42 @@ def test_is_protrusion_insufficient_points_returns_false():
     assert not is_protrusion(distance_from_wall_m=0.15,
                              height_above_floor_m=1.0,
                              point_count=2)
+
+
+# ---------------------------------------------------------------------------
+# YOLO transient-class helpers (added with Hailo-8L perception fusion).
+# ---------------------------------------------------------------------------
+
+
+def test_transient_classes_includes_known_movables():
+    # Sanity: things that should not flag an ADA 307 violation when
+    # they happen to be in the cane zone during a scan.
+    for label in ("person", "chair", "backpack", "dog"):
+        assert label in TRANSIENT_CLASSES
+
+
+def test_transient_classes_excludes_fixed_obstacles():
+    # Fire extinguishers, signage, and the like must NOT be in the
+    # transient set or we would miss real ADA 307 violations.
+    for label in ("fire hydrant", "tv", "clock", ""):
+        assert label not in TRANSIENT_CLASSES
+
+
+def test_is_transient_class_truthy_for_listed():
+    assert is_transient_class("person") is True
+    assert is_transient_class("chair") is True
+
+
+def test_is_transient_class_false_for_empty_string():
+    # Unclassified protrusions (no YOLO match) are presumed-fixed.
+    assert is_transient_class("") is False
+
+
+def test_is_transient_class_false_for_unknown_label():
+    assert is_transient_class("not_a_class") is False
+
+
+def test_default_class_match_radius_is_reasonable():
+    # 30 cm covers the IMX219-83 stereo depth standard error at 2 m
+    # (~10 cm) plus map-frame TF jitter.
+    assert 0.10 <= DEFAULT_CLASS_MATCH_RADIUS_M <= 1.0

--- a/final_capstone/compliance-engine/tests/test_nodes_smoke.py
+++ b/final_capstone/compliance-engine/tests/test_nodes_smoke.py
@@ -74,12 +74,15 @@ def test_protruding_objects_node_wires_topics():
     # input_cloud_topic default is /cloud_map
     assert "/cloud_map" in topics
     assert "/imu/data" in topics
+    # New: YOLO 3D detection feed (Hailo-8L pipeline).
+    assert "/perception/detections_3d" in topics
 
     pubs = {p.topic for p in node.publishers}
     assert "/compliance/protruding_objects" in pubs
 
     assert "enabled" in node.parameters
     assert "input_cloud_topic" in node.parameters
+    assert "class_match_radius_m" in node.parameters
     assert node.parameters["input_cloud_topic"] == "/cloud_map"
 
 
@@ -106,9 +109,13 @@ def test_dynamic_obstacle_node_wires_topics():
     assert "/scan" in topics
     assert "/map" in topics
     assert "/odom" in topics
+    # New: YOLO 3D detection feed (Hailo-8L pipeline).
+    assert "/perception/detections_3d" in topics
 
     pubs = {p.topic for p in node.publishers}
     assert "/perception/dynamic_obstacles" in pubs
+
+    assert "class_match_radius_m" in node.parameters
 
 
 def test_compliance_monitor_node_wires_topics():

--- a/final_capstone/compliance-engine/tests/test_obstacle_clusterer.py
+++ b/final_capstone/compliance-engine/tests/test_obstacle_clusterer.py
@@ -49,7 +49,7 @@ def test_subtract_empty_points_returns_empty():
 def test_cluster_points_finds_two_distinct_clusters():
     rng = np.random.default_rng(3)
     cluster_a = rng.normal([0.0, 0.0], 0.05, size=(40, 2))
-    cluster_b = rng.normal([2.0, 2.0], 0.05, size=40).reshape(-1, 2)
+    cluster_b = rng.normal([2.0, 2.0], 0.05, size=(40, 2))
     points = np.vstack([cluster_a, cluster_b])
     clusters = cluster_points(points, eps_m=0.2, min_samples=5)
     assert len(clusters) == 2

--- a/final_capstone/compliance-engine/tests/test_yolo_fusion.py
+++ b/final_capstone/compliance-engine/tests/test_yolo_fusion.py
@@ -1,0 +1,199 @@
+"""
+YOLO 3D detection fusion behaviour tests.
+
+Verifies that the protruding-objects and dynamic-obstacle nodes,
+when fed a synthetic Detection3DArray, correctly tag their outputs
+with COCO class labels and gate ADA 307 flagging on the
+TRANSIENT_CLASSES set.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.ros_mocks import install_ros_mocks
+
+install_ros_mocks()
+
+
+def _make_identity_transform():
+    """A TransformStamped with translation 0 and identity quaternion."""
+    tf = SimpleNamespace()
+    tf.transform = SimpleNamespace()
+    tf.transform.translation = SimpleNamespace(x=0.0, y=0.0, z=0.0)
+    tf.transform.rotation = SimpleNamespace(x=0.0, y=0.0, z=0.0, w=1.0)
+    return tf
+
+
+def _make_detection_3d_msg(detections):
+    """Build a duck-typed Detection3DArray from (label, score, x, y, z)."""
+    msg = SimpleNamespace()
+    msg.header = SimpleNamespace()
+    msg.header.stamp = SimpleNamespace(sec=0, nanosec=0)
+    msg.header.frame_id = "cam0_optical_frame"
+    msg.detections = []
+    for label, score, x, y, z in detections:
+        d = SimpleNamespace()
+        d.bbox = SimpleNamespace()
+        d.bbox.center = SimpleNamespace()
+        d.bbox.center.position = SimpleNamespace(x=x, y=y, z=z)
+        hyp = SimpleNamespace()
+        hyp.hypothesis = SimpleNamespace(class_id=label, score=score)
+        d.results = [hyp]
+        msg.detections.append(d)
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# protruding_objects_node YOLO matching
+# ---------------------------------------------------------------------------
+
+
+def _yolo_into_protruding_node(node, detections):
+    node._tf_buffer.transform_to_return = _make_identity_transform()
+    node.find_subscription("/perception/detections_3d").callback(
+        _make_detection_3d_msg(detections)
+    )
+
+
+def test_protruding_node_caches_yolo_in_map_frame():
+    from star_compliance.nodes.protruding_objects_node import ProtrudingObjectsNode
+
+    node = ProtrudingObjectsNode()
+    _yolo_into_protruding_node(node, [
+        ("chair", 0.85, 1.0, 2.0, 1.2),
+        ("person", 0.92, 0.0, 1.0, 1.1),
+    ])
+    assert len(node._yolo_cache) == 2
+    # Cache entries are (received_sec, x, y, z, label, score).
+    labels = sorted(entry[4] for entry in node._yolo_cache)
+    assert labels == ["chair", "person"]
+
+
+def test_protruding_node_match_yolo_finds_nearest_within_radius():
+    from star_compliance.nodes.protruding_objects_node import ProtrudingObjectsNode
+
+    node = ProtrudingObjectsNode()
+    _yolo_into_protruding_node(node, [
+        ("chair", 0.85, 1.00, 2.00, 1.20),
+        ("person", 0.92, 5.00, 5.00, 1.10),
+    ])
+    label, score = node._match_yolo(1.05, 2.05, 1.20)
+    assert label == "chair"
+    assert score == pytest.approx(0.85)
+
+
+def test_protruding_node_match_yolo_returns_empty_outside_radius():
+    from star_compliance.nodes.protruding_objects_node import ProtrudingObjectsNode
+
+    node = ProtrudingObjectsNode()
+    _yolo_into_protruding_node(node, [("chair", 0.85, 0.0, 0.0, 0.0)])
+    # 5 m away is far outside the default 0.30 m radius.
+    label, score = node._match_yolo(5.0, 5.0, 5.0)
+    assert label == ""
+    assert score == 0.0
+
+
+def test_protruding_node_match_yolo_empty_cache():
+    from star_compliance.nodes.protruding_objects_node import ProtrudingObjectsNode
+
+    node = ProtrudingObjectsNode()
+    label, score = node._match_yolo(0.0, 0.0, 0.0)
+    assert label == ""
+    assert score == 0.0
+
+
+def test_protruding_node_transform_point_identity():
+    """An identity transform must leave coordinates unchanged."""
+    from star_compliance.nodes.protruding_objects_node import ProtrudingObjectsNode
+
+    tf = _make_identity_transform()
+    x, y, z = ProtrudingObjectsNode._transform_point(1.5, -0.5, 2.0, tf)
+    assert (x, y, z) == pytest.approx((1.5, -0.5, 2.0))
+
+
+def test_protruding_node_transform_point_translation():
+    from star_compliance.nodes.protruding_objects_node import ProtrudingObjectsNode
+
+    tf = _make_identity_transform()
+    tf.transform.translation = SimpleNamespace(x=10.0, y=-2.0, z=0.5)
+    x, y, z = ProtrudingObjectsNode._transform_point(1.0, 1.0, 1.0, tf)
+    assert (x, y, z) == pytest.approx((11.0, -1.0, 1.5))
+
+
+# ---------------------------------------------------------------------------
+# dynamic_obstacle_node YOLO matching
+# ---------------------------------------------------------------------------
+
+
+def _yolo_into_dynamic_node(node, detections):
+    node._tf_buffer.transform_to_return = _make_identity_transform()
+    node.find_subscription("/perception/detections_3d").callback(
+        _make_detection_3d_msg(detections)
+    )
+
+
+def test_dynamic_obstacle_node_caches_yolo():
+    from star_compliance.nodes.dynamic_obstacle_node import DynamicObstacleNode
+
+    node = DynamicObstacleNode()
+    _yolo_into_dynamic_node(node, [
+        ("person", 0.95, 1.0, 1.0, 1.0),
+        ("chair", 0.40, 2.0, 0.0, 1.2),
+    ])
+    assert len(node._yolo_cache) == 2
+
+
+def test_dynamic_obstacle_node_match_yolo_2d_radius():
+    """Match operates in XY (the obstacle plane); Z is ignored."""
+    from star_compliance.nodes.dynamic_obstacle_node import DynamicObstacleNode
+
+    node = DynamicObstacleNode()
+    _yolo_into_dynamic_node(node, [("person", 0.95, 1.0, 1.0, 1.5)])
+    idx, label, score = node._match_yolo(1.05, 1.05, radius_m=0.30)
+    assert idx == 0
+    assert label == "person"
+    assert score == pytest.approx(0.95)
+
+
+def test_dynamic_obstacle_node_no_match_outside_radius():
+    from star_compliance.nodes.dynamic_obstacle_node import DynamicObstacleNode
+
+    node = DynamicObstacleNode()
+    _yolo_into_dynamic_node(node, [("person", 0.95, 0.0, 0.0, 0.0)])
+    idx, label, score = node._match_yolo(5.0, 5.0, radius_m=0.30)
+    assert idx is None
+    assert label == ""
+    assert score == 0.0
+
+
+def test_dynamic_obstacle_node_transform_point_identity():
+    from star_compliance.nodes.dynamic_obstacle_node import DynamicObstacleNode
+
+    tf = _make_identity_transform()
+    x, y, z = DynamicObstacleNode._transform_point(2.0, 3.0, 4.0, tf)
+    assert (x, y, z) == pytest.approx((2.0, 3.0, 4.0))
+
+
+# ---------------------------------------------------------------------------
+# Cross-node: TRANSIENT_CLASSES gating produces the right flagged value
+# ---------------------------------------------------------------------------
+
+
+def test_transient_class_clears_violation_flag():
+    """The protruding-objects node must un-flag transient classes."""
+    from star_compliance.detectors.cane_zone_filter import is_transient_class
+
+    # Simulate the gating expression used in protruding_objects_node._emit:
+    for label, expected in (
+        ("person", False),
+        ("chair", False),
+        ("backpack", False),
+        ("fire hydrant", True),
+        ("tv", True),
+        ("", True),  # unclassified -> presumed-fixed -> flag
+    ):
+        assert (not is_transient_class(label)) is expected

--- a/star-ros2/src/star_bringup/launch/slam.launch.py
+++ b/star-ros2/src/star_bringup/launch/slam.launch.py
@@ -89,6 +89,14 @@ def generate_launch_description():
                     'operation or on systems without the camera connected.'
     )
 
+    use_perception_arg = DeclareLaunchArgument(
+        'use_perception', default_value='true',
+        description='Launch the Hailo-8L YOLO + 3D fusion pipeline. '
+                    'Requires the AI HAT+ 13 TOPS and the apt-installed '
+                    'hailo-all stack. Implicitly requires use_stereo:=true '
+                    'because the 3D fusion node consumes /stereo/disparity.'
+    )
+
     # RPLiDAR C1 requires sllidar_ros2 (Slamtec's newer driver with SDK 2.x).
     # rplidar_ros 2.1.0 uses SDK 1.12.0 which returns 0x80008000/0x80008002 for the C1's
     # DTOF scan protocol. sllidar_ros2 uses the updated SDK that supports C1 natively.
@@ -195,6 +203,21 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('use_stereo')),
     )
 
+    # Hailo-8L YOLO + 3D detection fusion. Subscribes to
+    # /cam0/camera/image_rect_color and /stereo/disparity (both produced
+    # by the stereo pipeline above) and publishes
+    # /perception/detections_3d in cam0_optical_frame for the compliance
+    # engine and Nav2 to consume.
+    perception = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([
+                FindPackageShare('star_perception'),
+                'launch', 'perception.launch.py',
+            ])
+        ),
+        condition=IfCondition(LaunchConfiguration('use_perception')),
+    )
+
     # Foxglove Studio WebSocket bridge -- enables browser-based visualization
     # at app.foxglove.dev without X11. Bound to 0.0.0.0 for remote browser access.
     # Connect from laptop: ws://<PI5_IP>:8765
@@ -243,6 +266,7 @@ def generate_launch_description():
         use_bbb_arg,
         use_foxglove_arg,
         use_stereo_arg,
+        use_perception_arg,
         static_tf,
         ekf,
         static_odom_tf,
@@ -252,4 +276,5 @@ def generate_launch_description():
         slam,
         nav2,
         stereo,
+        perception,
     ])

--- a/star-ros2/src/star_compliance_msgs/msg/DynamicObstacle.msg
+++ b/star-ros2/src/star_compliance_msgs/msg/DynamicObstacle.msg
@@ -20,3 +20,13 @@ uint32 point_count
 # DBSCAN core-point density / cluster_radius_m. Higher is more
 # confident. 0-1 normalized.
 float32 confidence
+
+# Provenance of this obstacle - one of:
+#   "lidar"      - from the LiDAR DBSCAN cluster only
+#   "yolo"       - from a YOLO 3D detection only (e.g. behind glass)
+#   "yolo+lidar" - both modalities agree, raises confidence to 1.0
+string source
+
+# COCO class name from the matched YOLO 3D detection. Empty string for
+# pure-LiDAR sources.
+string class_label

--- a/star-ros2/src/star_compliance_msgs/msg/ProtrudingObject.msg
+++ b/star-ros2/src/star_compliance_msgs/msg/ProtrudingObject.msg
@@ -45,3 +45,15 @@ string ada_section
 
 # Absolute path to a colored-point-cloud PNG embedded in the audit PDF.
 string cloud_snippet_path
+
+# --- YOLO semantic label (filled by the perception fusion node) ------
+
+# COCO class name from the nearest YOLO 3D detection within
+# class_match_radius_m (default 0.30 m). Empty string when no YOLO
+# detection matches; the cluster is then treated as an unclassified
+# (and therefore presumed-fixed) protrusion.
+string class_label
+
+# Detection confidence (0-1) from the matched YOLO detection. Zero when
+# class_label is empty.
+float32 class_confidence

--- a/star-ros2/src/star_perception/.gitignore
+++ b/star-ros2/src/star_perception/.gitignore
@@ -1,0 +1,10 @@
+# Pre-compiled Hailo Executable Format models are downloaded at install
+# time from the Hailo Model Zoo. They are large binaries and per the
+# project policy we do not commit them.
+models/*.hef
+
+# Standard Python noise.
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/

--- a/star-ros2/src/star_perception/config/yolov8s_coco.yaml
+++ b/star-ros2/src/star_perception/config/yolov8s_coco.yaml
@@ -1,0 +1,29 @@
+# Default parameters for the Hailo YOLOv8s COCO pipeline on Pi 5.
+#
+# Override on the command line, e.g.:
+#   ros2 launch star_perception perception.launch.py \
+#       score_threshold:=0.50 target_fps:=10.0
+#
+# These are tuned for indoor accessibility-audit scenarios:
+#  - 0.35 confidence keeps useful low-score chair / backpack hits;
+#  - 15 FPS matches the cam0 capture rate at 640x480 (faster wastes
+#    NPU power and creates stale results vs the 5-10 Hz disparity);
+#  - 6.0 m max depth matches the IMX219-83 stereo limit.
+
+star_hailo_yolo_node:
+  ros__parameters:
+    enabled: true
+    score_threshold: 0.35
+    target_fps: 15.0
+    publish_overlay: false
+    class_filter: []  # Empty list = all 80 COCO classes.
+
+star_detection_3d_fusion_node:
+  ros__parameters:
+    enabled: true
+    min_valid_samples: 30
+    min_depth_m: 0.20
+    max_depth_m: 6.0
+    disparity_border_pct: 0.15
+    sync_slop_sec: 0.10
+    marker_lifetime_sec: 0.50

--- a/star-ros2/src/star_perception/launch/perception.launch.py
+++ b/star-ros2/src/star_perception/launch/perception.launch.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Locked Inc.
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""
+Launch the Hailo-8L YOLO + 3D fusion perception pipeline.
+
+Brings up two nodes:
+  - star_hailo_yolo_node       2D YOLOv8 inference on Hailo-8L
+  - star_detection_3d_fusion_node    fuses with /stereo/disparity to 3D
+
+This launch file is included by star_bringup/launch/slam.launch.py
+behind a `use_perception` flag (default true). The stereo pipeline
+must already be running (stereo_camera.launch.py) for the disparity
+topic to exist.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def _default_hef_path() -> str:
+    share = get_package_share_directory("star_perception")
+    return os.path.join(share, "models", "yolov8s_h8l.hef")
+
+
+def generate_launch_description() -> LaunchDescription:
+    score_arg = DeclareLaunchArgument(
+        "score_threshold",
+        default_value="0.35",
+        description="Drop YOLO detections below this confidence.",
+    )
+    target_fps_arg = DeclareLaunchArgument(
+        "target_fps",
+        default_value="15.0",
+        description=(
+            "Soft FPS cap on the YOLO node. Frames arriving faster are "
+            "dropped at the subscriber. 15 matches the cam0 capture rate."
+        ),
+    )
+    overlay_arg = DeclareLaunchArgument(
+        "publish_overlay",
+        default_value="false",
+        description="Publish /perception/image_overlay (debug).",
+    )
+    hef_arg = DeclareLaunchArgument(
+        "hef_path",
+        default_value=_default_hef_path(),
+        description="Path to the YOLOv8 .hef compiled for Hailo-8L.",
+    )
+    sync_slop_arg = DeclareLaunchArgument(
+        "sync_slop_sec",
+        default_value="0.10",
+        description=(
+            "ApproximateTimeSynchronizer slop between detections and "
+            "disparity image."
+        ),
+    )
+
+    yolo_node = Node(
+        package="star_perception",
+        executable="hailo_yolo_node",
+        name="star_hailo_yolo_node",
+        output="screen",
+        parameters=[{
+            "hef_path": LaunchConfiguration("hef_path"),
+            "score_threshold": LaunchConfiguration("score_threshold"),
+            "target_fps": LaunchConfiguration("target_fps"),
+            "publish_overlay": LaunchConfiguration("publish_overlay"),
+        }],
+    )
+
+    fusion_node = Node(
+        package="star_perception",
+        executable="detection_3d_fusion_node",
+        name="star_detection_3d_fusion_node",
+        output="screen",
+        parameters=[{
+            "sync_slop_sec": LaunchConfiguration("sync_slop_sec"),
+        }],
+    )
+
+    return LaunchDescription([
+        score_arg,
+        target_fps_arg,
+        overlay_arg,
+        hef_arg,
+        sync_slop_arg,
+        yolo_node,
+        fusion_node,
+    ])

--- a/star-ros2/src/star_perception/launch/perception.launch.py
+++ b/star-ros2/src/star_perception/launch/perception.launch.py
@@ -21,7 +21,7 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -87,12 +87,20 @@ def generate_launch_description() -> LaunchDescription:
         }],
     )
 
+    # Skip the per-user site-packages so cv_bridge (built against the
+    # system numpy 1.x) isn't shadowed by a user-installed numpy 2.x.
+    # A full numpy-2 migration across every ROS2 Python node on Ubuntu
+    # 24.04 is out of scope for this package; this keeps the perception
+    # nodes insulated regardless of what's in ~/.local/.
+    no_user_site = SetEnvironmentVariable(name="PYTHONNOUSERSITE", value="1")
+
     return LaunchDescription([
         score_arg,
         target_fps_arg,
         overlay_arg,
         hef_arg,
         sync_slop_arg,
+        no_user_site,
         yolo_node,
         fusion_node,
     ])

--- a/star-ros2/src/star_perception/models/README.md
+++ b/star-ros2/src/star_perception/models/README.md
@@ -1,0 +1,23 @@
+# Hailo .hef models
+
+This directory holds pre-compiled Hailo Executable Format (`.hef`) models
+for the Hailo-8L NPU on the Raspberry Pi AI HAT+ 13 TOPS.
+
+The `.hef` binaries are NOT committed to git. Run the install script on
+the Pi 5 to download them from the Hailo Model Zoo:
+
+```
+./scripts/download_yolov8s_hef.sh
+```
+
+## Files placed here at install time
+
+- `yolov8s_h8l.hef` -- YOLOv8s trained on COCO, compiled for Hailo-8L.
+  640x640 input, 80 classes, ~30 FPS on Hailo-8L.
+
+## Choosing a different model
+
+Edit `scripts/download_yolov8s_hef.sh` to point at a different Hailo
+Model Zoo URL. YOLOv6n is a smaller fallback if power or thermal
+budget is tight; YOLOv11s and YOLOv8m are reasonable upgrades when
+the Hailo-8L is otherwise idle.

--- a/star-ros2/src/star_perception/models/README.md
+++ b/star-ros2/src/star_perception/models/README.md
@@ -1,23 +1,109 @@
-# Hailo .hef models
+# Hailo .hef models + class lists
 
-This directory holds pre-compiled Hailo Executable Format (`.hef`) models
-for the Hailo-8L NPU on the Raspberry Pi AI HAT+ 13 TOPS.
+This directory holds pre-compiled Hailo Executable Format (`.hef`)
+models for the Hailo-8L NPU on the Raspberry Pi AI HAT+ 13 TOPS, and
+YAML class-name lists that map HEF class indices to human-readable
+labels.
 
-The `.hef` binaries are NOT committed to git. Run the install script on
-the Pi 5 to download them from the Hailo Model Zoo:
+The `.hef` binaries are NOT committed to git (see `.gitignore`). YAML
+class lists ARE committed.
 
+## Files in this directory
+
+| file | committed? | purpose |
+|---|---|---|
+| `yolov8s_h8l.hef` | no (downloaded) | YOLOv8s / COCO 80 classes, 640x640, ~30 FPS on Hailo-8L. Default shipped model. |
+| `yolov8n-oiv7.hef` | no (compiled off-Pi) | YOLOv8n / Open Images V7 601 classes. ADA-relevant labels (Door, Stairs, Handrail, Wheelchair, Cane...). Compile on x86 via `scripts/compile_yolov8n_oiv7_hef.sh`. |
+| `coco_classes.yaml` | yes | 80 COCO class names in HEF index order. |
+| `oiv7_classes.yaml` | yes | 601 Open Images V7 class names in HEF index order. |
+| `yolov8n-oiv7.yaml` | yes | Hailo Model Zoo network config for the OIV7 compile step. |
+
+## Choosing a model at runtime
+
+The `hailo_yolo_node` takes two parameters:
+
+```bash
+ros2 launch star_perception perception.launch.py \
+  hef_path:=/path/to/model.hef \
+  classes_yaml:=/path/to/classes.yaml
 ```
-./scripts/download_yolov8s_hef.sh
+
+When `classes_yaml` is empty the node falls back to the built-in
+COCO 80 list (matches the default `yolov8s_h8l.hef`). Point it at
+`oiv7_classes.yaml` when running `yolov8n-oiv7.hef`.
+
+## Getting `yolov8s_h8l.hef`
+
+Prebuilt in the Hailo Model Zoo. On the Pi 5:
+
+```bash
+bash scripts/download_yolov8s_hef.sh
 ```
 
-## Files placed here at install time
+## Getting `yolov8n-oiv7.hef`
 
-- `yolov8s_h8l.hef` -- YOLOv8s trained on COCO, compiled for Hailo-8L.
-  640x640 input, 80 classes, ~30 FPS on Hailo-8L.
+**There is no prebuilt OIV7 HEF in the Hailo Model Zoo** as of
+v2.18 — all public Hailo-8L YOLOs are COCO-trained. You compile it
+once on an x86 dev box and copy the resulting `.hef` to the Pi 5.
 
-## Choosing a different model
+### Prerequisites on the x86 host
 
-Edit `scripts/download_yolov8s_hef.sh` to point at a different Hailo
-Model Zoo URL. YOLOv6n is a smaller fallback if power or thermal
-budget is tight; YOLOv11s and YOLOv8m are reasonable upgrades when
-the Hailo-8L is otherwise idle.
+- Linux x86_64 (Ubuntu 22.04 / Debian 12 tested by Hailo)
+- Hailo Dataflow Compiler installed (Hailo Developer Zone
+  download; free sign-up)
+- `pip install ultralytics hailo_model_zoo`
+- ~64-256 representative JPEG/PNG calibration images in
+  `scripts/calib/` (or pass `--calib-dir`). The Open Images V7
+  validation split is ideal; any mixed-class indoor/outdoor set
+  works. Calibration drives 8-bit quantization accuracy.
+
+### Compile
+
+```bash
+# On the x86 host, inside the star_perception package:
+cd star-ros2/src/star_perception
+./scripts/compile_yolov8n_oiv7_hef.sh --calib-dir /path/to/calib/images
+```
+
+The script:
+
+1. `yolo export model=yolov8n-oiv7.pt format=onnx imgsz=640 opset=11 simplify=True`
+   — Ultralytics auto-downloads `yolov8n-oiv7.pt` (AGPL-3.0, 3.2M
+   parameters) on first use.
+2. `hailomz compile --ckpt yolov8n-oiv7.onnx --calib-path ... --yaml models/yolov8n-oiv7.yaml --classes 601 --hw-arch hailo8l`
+   — produces `yolov8n-oiv7.hef`. ~15-30 minutes on current hardware.
+3. Tells you where to copy the HEF on the Pi 5.
+
+### On the Pi 5
+
+```bash
+scp x86host:yolov8n-oiv7.hef /workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/
+ros2 launch star_perception perception.launch.py \
+  hef_path:=/workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/yolov8n-oiv7.hef \
+  classes_yaml:=/workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/oiv7_classes.yaml
+```
+
+No rebuild needed — the HEF and YAML are pure data files in the
+install share directory. Restart the perception launch to pick
+them up.
+
+### Expected OIV7 performance
+
+- mAP: ~18 across 600 classes (vs COCO YOLOv8s's 44.9 across 80).
+  Per-class accuracy on doors, stairs, handrails, wheelchairs is
+  "good enough to tag the detection" — **not** the measurement
+  source.
+- Latency / FPS: similar to YOLOv8n / COCO (same backbone); a rough
+  benchmark comparable to COCO's ~30 FPS on Hailo-8L is expected.
+
+### Division of labour
+
+YOLO tells us **what is in the frame** (class label + confidence).
+The geometric pipeline (LiDAR doorway width, RANSAC wall/jamb plane
+fitter, StereoSGBM disparity, IMU floor frame) measures **how large
+/ how steep / how tall** the object is. ADA numbers (32-inch door
+clearance, 4.76-deg ramp slope, 0.5-inch threshold height, etc.)
+come from geometry — not from the bounding box extent of a YOLO
+detection. Adding new class labels (via OIV7 or a custom HEF) only
+improves the gating + semantic tagging, not the measurement
+accuracy.

--- a/star-ros2/src/star_perception/models/README.md
+++ b/star-ros2/src/star_perception/models/README.md
@@ -43,7 +43,7 @@ bash scripts/download_yolov8s_hef.sh
 ## Getting `yolov8n-oiv7.hef`
 
 **There is no prebuilt OIV7 HEF in the Hailo Model Zoo** as of
-v2.18 — all public Hailo-8L YOLOs are COCO-trained. You compile it
+v2.18 -- all public Hailo-8L YOLOs are COCO-trained. You compile it
 once on an x86 dev box and copy the resulting `.hef` to the Pi 5.
 
 ### Prerequisites on the x86 host
@@ -68,10 +68,10 @@ cd star-ros2/src/star_perception
 The script:
 
 1. `yolo export model=yolov8n-oiv7.pt format=onnx imgsz=640 opset=11 simplify=True`
-   — Ultralytics auto-downloads `yolov8n-oiv7.pt` (AGPL-3.0, 3.2M
+   -- Ultralytics auto-downloads `yolov8n-oiv7.pt` (AGPL-3.0, 3.2M
    parameters) on first use.
 2. `hailomz compile --ckpt yolov8n-oiv7.onnx --calib-path ... --yaml models/yolov8n-oiv7.yaml --classes 601 --hw-arch hailo8l`
-   — produces `yolov8n-oiv7.hef`. ~15-30 minutes on current hardware.
+   -- produces `yolov8n-oiv7.hef`. ~15-30 minutes on current hardware.
 3. Tells you where to copy the HEF on the Pi 5.
 
 ### On the Pi 5
@@ -83,7 +83,7 @@ ros2 launch star_perception perception.launch.py \
   classes_yaml:=/workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/oiv7_classes.yaml
 ```
 
-No rebuild needed — the HEF and YAML are pure data files in the
+No rebuild needed -- the HEF and YAML are pure data files in the
 install share directory. Restart the perception launch to pick
 them up.
 
@@ -91,7 +91,7 @@ them up.
 
 - mAP: ~18 across 600 classes (vs COCO YOLOv8s's 44.9 across 80).
   Per-class accuracy on doors, stairs, handrails, wheelchairs is
-  "good enough to tag the detection" — **not** the measurement
+  "good enough to tag the detection" -- **not** the measurement
   source.
 - Latency / FPS: similar to YOLOv8n / COCO (same backbone); a rough
   benchmark comparable to COCO's ~30 FPS on Hailo-8L is expected.
@@ -103,7 +103,7 @@ The geometric pipeline (LiDAR doorway width, RANSAC wall/jamb plane
 fitter, StereoSGBM disparity, IMU floor frame) measures **how large
 / how steep / how tall** the object is. ADA numbers (32-inch door
 clearance, 4.76-deg ramp slope, 0.5-inch threshold height, etc.)
-come from geometry — not from the bounding box extent of a YOLO
+come from geometry -- not from the bounding box extent of a YOLO
 detection. Adding new class labels (via OIV7 or a custom HEF) only
 improves the gating + semantic tagging, not the measurement
 accuracy.

--- a/star-ros2/src/star_perception/models/coco_classes.yaml
+++ b/star-ros2/src/star_perception/models/coco_classes.yaml
@@ -1,0 +1,83 @@
+# COCO 2017 80 classes, YOLOv8 index order. Used by HailoYoloNode when
+# driven by COCO-trained HEFs (yolov8n.hef, yolov8s_h8l.hef, etc).
+names:
+  - person
+  - bicycle
+  - car
+  - motorcycle
+  - airplane
+  - bus
+  - train
+  - truck
+  - boat
+  - traffic light
+  - fire hydrant
+  - stop sign
+  - parking meter
+  - bench
+  - bird
+  - cat
+  - dog
+  - horse
+  - sheep
+  - cow
+  - elephant
+  - bear
+  - zebra
+  - giraffe
+  - backpack
+  - umbrella
+  - handbag
+  - tie
+  - suitcase
+  - frisbee
+  - skis
+  - snowboard
+  - sports ball
+  - kite
+  - baseball bat
+  - baseball glove
+  - skateboard
+  - surfboard
+  - tennis racket
+  - bottle
+  - wine glass
+  - cup
+  - fork
+  - knife
+  - spoon
+  - bowl
+  - banana
+  - apple
+  - sandwich
+  - orange
+  - broccoli
+  - carrot
+  - hot dog
+  - pizza
+  - donut
+  - cake
+  - chair
+  - couch
+  - potted plant
+  - bed
+  - dining table
+  - toilet
+  - tv
+  - laptop
+  - mouse
+  - remote
+  - keyboard
+  - cell phone
+  - microwave
+  - oven
+  - toaster
+  - sink
+  - refrigerator
+  - book
+  - clock
+  - vase
+  - scissors
+  - teddy bear
+  - hair drier
+  - toothbrush

--- a/star-ros2/src/star_perception/models/oiv7_classes.yaml
+++ b/star-ros2/src/star_perception/models/oiv7_classes.yaml
@@ -1,0 +1,606 @@
+# Ultralytics Open Images V7 class list, 601 classes in YOLOv8n-OIV7
+# index order. Used by HailoYoloNode when the perception pipeline is
+# driven by `yolov8n-oiv7.hef` (see scripts/compile_yolov8n_oiv7_hef.sh).
+# Source: https://github.com/ultralytics/ultralytics/blob/main/ultralytics/cfg/datasets/open-images-v7.yaml
+names:
+  - Accordion
+  - Adhesive tape
+  - Aircraft
+  - Airplane
+  - Alarm clock
+  - Alpaca
+  - Ambulance
+  - Animal
+  - Ant
+  - Antelope
+  - Apple
+  - Armadillo
+  - Artichoke
+  - Auto part
+  - Axe
+  - Backpack
+  - Bagel
+  - Baked goods
+  - Balance beam
+  - Ball
+  - Balloon
+  - Banana
+  - Band-aid
+  - Banjo
+  - Barge
+  - Barrel
+  - Baseball bat
+  - Baseball glove
+  - Bat (Animal)
+  - Bathroom accessory
+  - Bathroom cabinet
+  - Bathtub
+  - Beaker
+  - Bear
+  - Bed
+  - Bee
+  - Beehive
+  - Beer
+  - Beetle
+  - Bell pepper
+  - Belt
+  - Bench
+  - Bicycle
+  - Bicycle helmet
+  - Bicycle wheel
+  - Bidet
+  - Billboard
+  - Billiard table
+  - Binoculars
+  - Bird
+  - Blender
+  - Blue jay
+  - Boat
+  - Bomb
+  - Book
+  - Bookcase
+  - Boot
+  - Bottle
+  - Bottle opener
+  - Bow and arrow
+  - Bowl
+  - Bowling equipment
+  - Box
+  - Boy
+  - Brassiere
+  - Bread
+  - Briefcase
+  - Broccoli
+  - Bronze sculpture
+  - Brown bear
+  - Building
+  - Bull
+  - Burrito
+  - Bus
+  - Bust
+  - Butterfly
+  - Cabbage
+  - Cabinetry
+  - Cake
+  - Cake stand
+  - Calculator
+  - Camel
+  - Camera
+  - Can opener
+  - Canary
+  - Candle
+  - Candy
+  - Cannon
+  - Canoe
+  - Cantaloupe
+  - Car
+  - Carnivore
+  - Carrot
+  - Cart
+  - Cassette deck
+  - Castle
+  - Cat
+  - Cat furniture
+  - Caterpillar
+  - Cattle
+  - Ceiling fan
+  - Cello
+  - Centipede
+  - Chainsaw
+  - Chair
+  - Cheese
+  - Cheetah
+  - Chest of drawers
+  - Chicken
+  - Chime
+  - Chisel
+  - Chopsticks
+  - Christmas tree
+  - Clock
+  - Closet
+  - Clothing
+  - Coat
+  - Cocktail
+  - Cocktail shaker
+  - Coconut
+  - Coffee
+  - Coffee cup
+  - Coffee table
+  - Coffeemaker
+  - Coin
+  - Common fig
+  - Common sunflower
+  - Computer keyboard
+  - Computer monitor
+  - Computer mouse
+  - Container
+  - Convenience store
+  - Cookie
+  - Cooking spray
+  - Corded phone
+  - Cosmetics
+  - Couch
+  - Countertop
+  - Cowboy hat
+  - Crab
+  - Cream
+  - Cricket ball
+  - Crocodile
+  - Croissant
+  - Crown
+  - Crutch
+  - Cucumber
+  - Cupboard
+  - Curtain
+  - Cutting board
+  - Dagger
+  - Dairy Product
+  - Deer
+  - Desk
+  - Dessert
+  - Diaper
+  - Dice
+  - Digital clock
+  - Dinosaur
+  - Dishwasher
+  - Dog
+  - Dog bed
+  - Doll
+  - Dolphin
+  - Door
+  - Door handle
+  - Donut
+  - Dragonfly
+  - Drawer
+  - Dress
+  - Drill (Tool)
+  - Drink
+  - Drinking straw
+  - Drum
+  - Duck
+  - Dumbbell
+  - Eagle
+  - Earrings
+  - Egg (Food)
+  - Elephant
+  - Envelope
+  - Eraser
+  - Face powder
+  - Facial tissue holder
+  - Falcon
+  - Fashion accessory
+  - Fast food
+  - Fax
+  - Fedora
+  - Filing cabinet
+  - Fire hydrant
+  - Fireplace
+  - Fish
+  - Flag
+  - Flashlight
+  - Flower
+  - Flowerpot
+  - Flute
+  - Flying disc
+  - Food
+  - Food processor
+  - Football
+  - Football helmet
+  - Footwear
+  - Fork
+  - Fountain
+  - Fox
+  - French fries
+  - French horn
+  - Frog
+  - Fruit
+  - Frying pan
+  - Furniture
+  - Garden Asparagus
+  - Gas stove
+  - Giraffe
+  - Girl
+  - Glasses
+  - Glove
+  - Goat
+  - Goggles
+  - Goldfish
+  - Golf ball
+  - Golf cart
+  - Gondola
+  - Goose
+  - Grape
+  - Grapefruit
+  - Grinder
+  - Guacamole
+  - Guitar
+  - Hair dryer
+  - Hair spray
+  - Hamburger
+  - Hammer
+  - Hamster
+  - Hand dryer
+  - Handbag
+  - Handgun
+  - Harbor seal
+  - Harmonica
+  - Harp
+  - Harpsichord
+  - Hat
+  - Headphones
+  - Heater
+  - Hedgehog
+  - Helicopter
+  - Helmet
+  - High heels
+  - Hiking equipment
+  - Hippopotamus
+  - Home appliance
+  - Honeycomb
+  - Horizontal bar
+  - Horse
+  - Hot dog
+  - House
+  - Houseplant
+  - Human arm
+  - Human beard
+  - Human body
+  - Human ear
+  - Human eye
+  - Human face
+  - Human foot
+  - Human hair
+  - Human hand
+  - Human head
+  - Human leg
+  - Human mouth
+  - Human nose
+  - Humidifier
+  - Ice cream
+  - Indoor rower
+  - Infant bed
+  - Insect
+  - Invertebrate
+  - Ipod
+  - Isopod
+  - Jacket
+  - Jacuzzi
+  - Jaguar (Animal)
+  - Jeans
+  - Jellyfish
+  - Jet ski
+  - Jug
+  - Juice
+  - Kangaroo
+  - Kettle
+  - Kitchen & dining room table
+  - Kitchen appliance
+  - Kitchen knife
+  - Kitchen utensil
+  - Kitchenware
+  - Kite
+  - Knife
+  - Koala
+  - Ladder
+  - Ladle
+  - Ladybug
+  - Lamp
+  - Land vehicle
+  - Lantern
+  - Laptop
+  - Lavender (Plant)
+  - Lemon
+  - Leopard
+  - Light bulb
+  - Light switch
+  - Lighthouse
+  - Lily
+  - Limousine
+  - Lion
+  - Lipstick
+  - Lizard
+  - Lobster
+  - Loveseat
+  - Luggage and bags
+  - Lynx
+  - Magpie
+  - Mammal
+  - Man
+  - Mango
+  - Maple
+  - Maracas
+  - Marine invertebrates
+  - Marine mammal
+  - Measuring cup
+  - Mechanical fan
+  - Medical equipment
+  - Microphone
+  - Microwave oven
+  - Milk
+  - Miniskirt
+  - Mirror
+  - Missile
+  - Mixer
+  - Mixing bowl
+  - Mobile phone
+  - Monkey
+  - Moths and butterflies
+  - Motorcycle
+  - Mouse
+  - Muffin
+  - Mug
+  - Mule
+  - Mushroom
+  - Musical instrument
+  - Musical keyboard
+  - Nail (Construction)
+  - Necklace
+  - Nightstand
+  - Oboe
+  - Office building
+  - Office supplies
+  - Orange
+  - Organ (Musical Instrument)
+  - Ostrich
+  - Otter
+  - Oven
+  - Owl
+  - Oyster
+  - Paddle
+  - Palm tree
+  - Pancake
+  - Panda
+  - Paper cutter
+  - Paper towel
+  - Parachute
+  - Parking meter
+  - Parrot
+  - Pasta
+  - Pastry
+  - Peach
+  - Pear
+  - Pen
+  - Pencil case
+  - Pencil sharpener
+  - Penguin
+  - Perfume
+  - Person
+  - Personal care
+  - Personal flotation device
+  - Piano
+  - Picnic basket
+  - Picture frame
+  - Pig
+  - Pillow
+  - Pineapple
+  - Pitcher (Container)
+  - Pizza
+  - Pizza cutter
+  - Plant
+  - Plastic bag
+  - Plate
+  - Platter
+  - Plumbing fixture
+  - Polar bear
+  - Pomegranate
+  - Popcorn
+  - Porch
+  - Porcupine
+  - Poster
+  - Potato
+  - Power plugs and sockets
+  - Pressure cooker
+  - Pretzel
+  - Printer
+  - Pumpkin
+  - Punching bag
+  - Rabbit
+  - Raccoon
+  - Racket
+  - Radish
+  - Ratchet (Device)
+  - Raven
+  - Rays and skates
+  - Red panda
+  - Refrigerator
+  - Remote control
+  - Reptile
+  - Rhinoceros
+  - Rifle
+  - Ring binder
+  - Rocket
+  - Roller skates
+  - Rose
+  - Rugby ball
+  - Ruler
+  - Salad
+  - Salt and pepper shakers
+  - Sandal
+  - Sandwich
+  - Saucer
+  - Saxophone
+  - Scale
+  - Scarf
+  - Scissors
+  - Scoreboard
+  - Scorpion
+  - Screwdriver
+  - Sculpture
+  - Sea lion
+  - Sea turtle
+  - Seafood
+  - Seahorse
+  - Seat belt
+  - Segway
+  - Serving tray
+  - Sewing machine
+  - Shark
+  - Sheep
+  - Shelf
+  - Shellfish
+  - Shirt
+  - Shorts
+  - Shotgun
+  - Shower
+  - Shrimp
+  - Sink
+  - Skateboard
+  - Ski
+  - Skirt
+  - Skull
+  - Skunk
+  - Skyscraper
+  - Slow cooker
+  - Snack
+  - Snail
+  - Snake
+  - Snowboard
+  - Snowman
+  - Snowmobile
+  - Snowplow
+  - Soap dispenser
+  - Sock
+  - Sofa bed
+  - Sombrero
+  - Sparrow
+  - Spatula
+  - Spice rack
+  - Spider
+  - Spoon
+  - Sports equipment
+  - Sports uniform
+  - Squash (Plant)
+  - Squid
+  - Squirrel
+  - Stairs
+  - Stapler
+  - Starfish
+  - Stationary bicycle
+  - Stethoscope
+  - Stool
+  - Stop sign
+  - Strawberry
+  - Street light
+  - Stretcher
+  - Studio couch
+  - Submarine
+  - Submarine sandwich
+  - Suit
+  - Suitcase
+  - Sun hat
+  - Sunglasses
+  - Surfboard
+  - Sushi
+  - Swan
+  - Swim cap
+  - Swimming pool
+  - Swimwear
+  - Sword
+  - Syringe
+  - Table
+  - Table tennis racket
+  - Tablet computer
+  - Tableware
+  - Taco
+  - Tank
+  - Tap
+  - Tart
+  - Taxi
+  - Tea
+  - Teapot
+  - Teddy bear
+  - Telephone
+  - Television
+  - Tennis ball
+  - Tennis racket
+  - Tent
+  - Tiara
+  - Tick
+  - Tie
+  - Tiger
+  - Tin can
+  - Tire
+  - Toaster
+  - Toilet
+  - Toilet paper
+  - Tomato
+  - Tool
+  - Toothbrush
+  - Torch
+  - Tortoise
+  - Towel
+  - Tower
+  - Toy
+  - Traffic light
+  - Traffic sign
+  - Train
+  - Training bench
+  - Treadmill
+  - Tree
+  - Tree house
+  - Tripod
+  - Trombone
+  - Trousers
+  - Truck
+  - Trumpet
+  - Turkey
+  - Turtle
+  - Umbrella
+  - Unicycle
+  - Van
+  - Vase
+  - Vegetable
+  - Vehicle
+  - Vehicle registration plate
+  - Violin
+  - Volleyball (Ball)
+  - Waffle
+  - Waffle iron
+  - Wall clock
+  - Wardrobe
+  - Washing machine
+  - Waste container
+  - Watch
+  - Watercraft
+  - Watermelon
+  - Weapon
+  - Whale
+  - Wheel
+  - Wheelchair
+  - Whisk
+  - Whiteboard
+  - Willow
+  - Window
+  - Window blind
+  - Wine
+  - Wine glass
+  - Wine rack
+  - Winter melon
+  - Wok
+  - Woman
+  - Wood-burning stove
+  - Woodpecker
+  - Worm
+  - Wrench
+  - Zebra
+  - Zucchini

--- a/star-ros2/src/star_perception/models/yolov8n-oiv7.yaml
+++ b/star-ros2/src/star_perception/models/yolov8n-oiv7.yaml
@@ -19,7 +19,7 @@ network:
   network_name: yolov8n-oiv7
   paths:
     # The ML teammate fills this in after `yolo export ... format=onnx`.
-    # Placeholder path — override on the compile-host filesystem.
+    # Placeholder path -- override on the compile-host filesystem.
     network_path:
       - yolov8n-oiv7.onnx
     alls_script: yolov8n-oiv7.alls

--- a/star-ros2/src/star_perception/models/yolov8n-oiv7.yaml
+++ b/star-ros2/src/star_perception/models/yolov8n-oiv7.yaml
@@ -1,0 +1,44 @@
+# Hailo Model Zoo network config for YOLOv8n fine-tuned on Open
+# Images V7 (601 classes). Based on hailo_model_zoo/cfg/networks/yolov8n.yaml
+# with only the class count, dataset references, and output shape
+# adjusted. Drop this file next to the ONNX on the x86 compile host
+# and point `hailomz compile` at it via `--yaml`.
+base:
+  - base/yolov8.yaml
+
+postprocessing:
+  device_pre_post_layers:
+    nms: true
+    hpp: true
+  meta_arch: yolov8
+  anchors:
+    regression_length: 16
+    strides: [8, 16, 32]
+
+network:
+  network_name: yolov8n-oiv7
+  paths:
+    # The ML teammate fills this in after `yolo export ... format=onnx`.
+    # Placeholder path — override on the compile-host filesystem.
+    network_path:
+      - yolov8n-oiv7.onnx
+    alls_script: yolov8n-oiv7.alls
+
+info:
+  task: object detection
+  input_shape: 640x640x3
+  # 601-class NMS output: max 100 detections per class, 5 floats per row.
+  output_shape: 601x5x100
+  operations: 8.74G
+  parameters: 3.2M
+  framework: pytorch
+  training_data: Open Images V7 train (Ultralytics split)
+  validation_data: Open Images V7 val
+  eval_metric: mAP
+  source: https://github.com/ultralytics/ultralytics
+  license_url: https://github.com/ultralytics/ultralytics/blob/main/LICENSE
+  license_name: AGPL-3.0
+
+supported_hw_arch:
+  - hailo8
+  - hailo8l

--- a/star-ros2/src/star_perception/package.xml
+++ b/star-ros2/src/star_perception/package.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd"
+            schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>star_perception</name>
+  <version>0.1.0</version>
+  <description>
+    Hailo-8L accelerated YOLO perception for STAR. Runs YOLOv8s on the
+    Raspberry Pi AI HAT+ 13 TOPS against the cam0 rectified image and
+    fuses the resulting 2D detections with the existing stereo
+    disparity to publish 3D detections in cam0_optical_frame.
+
+    Requires the apt-installed hailo-all metapackage (kernel driver,
+    firmware, HailoRT) -- see scripts/install_hailo_stack.sh on the Pi 5.
+  </description>
+  <maintainer email="locked-inc@tamu.edu">Team Locked Inc.</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
+  <depend>stereo_msgs</depend>
+  <depend>vision_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>cv_bridge</depend>
+  <depend>image_transport</depend>
+  <depend>message_filters</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+
+  <exec_depend>python3-numpy</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
+
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/star-ros2/src/star_perception/scripts/compile_yolov8n_oiv7_hef.sh
+++ b/star-ros2/src/star_perception/scripts/compile_yolov8n_oiv7_hef.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Compile yolov8n-oiv7.pt -> .hef targeting Hailo-8L.
+#
+# **Must run on an x86_64 Linux host with the Hailo Dataflow Compiler +
+# hailo_model_zoo installed.** The Pi 5 cannot run the DFC. Expected
+# runtime: ~15-30 minutes on a current x86 dev box.
+#
+# Output: yolov8n-oiv7.hef dropped into this script's directory. Copy
+# it to the Pi 5 at:
+#   star-ros2/install/star_perception/share/star_perception/models/
+# and restart the perception launch. No rebuild needed.
+#
+# Usage:
+#   ./compile_yolov8n_oiv7_hef.sh [--calib-dir /path/to/images]
+#
+# If --calib-dir is omitted the script will look for a `calib/`
+# subdirectory next to the script and fail with a clear message if
+# missing. Put ~64-256 representative JPEG/PNG images there. Images
+# drawn from the Open Images V7 validation split are ideal; any
+# mixed-class indoor/outdoor set works.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+YAML="${PKG_ROOT}/models/yolov8n-oiv7.yaml"
+OUT_HEF="${SCRIPT_DIR}/yolov8n-oiv7.hef"
+
+CALIB_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --calib-dir) CALIB_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,25p' "$0"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -z "${CALIB_DIR}" ]] && CALIB_DIR="${SCRIPT_DIR}/calib"
+
+# -- sanity checks --
+if [[ "$(uname -m)" != "x86_64" ]]; then
+  echo "ERROR: Hailo Dataflow Compiler only runs on x86_64 Linux." >&2
+  echo "       Run this script on your development machine, then copy" >&2
+  echo "       the .hef to the Pi 5." >&2
+  exit 1
+fi
+if ! command -v yolo >/dev/null; then
+  echo "ERROR: ultralytics 'yolo' CLI not found. Run:" >&2
+  echo "       pip install ultralytics" >&2
+  exit 1
+fi
+if ! command -v hailomz >/dev/null; then
+  echo "ERROR: hailomz not found. Install the Hailo Model Zoo:" >&2
+  echo "       https://github.com/hailo-ai/hailo_model_zoo" >&2
+  exit 1
+fi
+if [[ ! -d "${CALIB_DIR}" ]] || [[ -z "$(ls -A "${CALIB_DIR}" 2>/dev/null)" ]]; then
+  echo "ERROR: calibration directory is missing or empty: ${CALIB_DIR}" >&2
+  echo "       Put ~64-256 representative JPEG/PNG images there." >&2
+  echo "       Open Images V7 validation split is a good source." >&2
+  exit 1
+fi
+
+# -- step 1: export Ultralytics .pt -> .onnx --
+ONNX="${SCRIPT_DIR}/yolov8n-oiv7.onnx"
+if [[ ! -f "${ONNX}" ]]; then
+  echo "[1/3] Exporting yolov8n-oiv7.pt to ONNX (first use auto-downloads)..."
+  # opset=11 matches what the Hailo zoo's yolov8n compile recipe uses.
+  # simplify=True folds redundant ops; imgsz=640 is required.
+  cd "${SCRIPT_DIR}"
+  yolo export model=yolov8n-oiv7.pt format=onnx imgsz=640 opset=11 simplify=True
+  # Ultralytics writes yolov8n-oiv7.onnx beside the .pt.
+else
+  echo "[1/3] ONNX already exported: ${ONNX}"
+fi
+
+# -- step 2: compile ONNX -> HEF targeting hailo8l --
+echo "[2/3] Compiling HEF targeting hailo8l (~15-30 min on x86)..."
+cd "${SCRIPT_DIR}"
+hailomz compile \
+  --ckpt "${ONNX}" \
+  --calib-path "${CALIB_DIR}" \
+  --yaml "${YAML}" \
+  --classes 601 \
+  --hw-arch hailo8l
+
+# hailomz drops the .hef beside the ONNX as yolov8n-oiv7.hef.
+PRODUCED="${SCRIPT_DIR}/yolov8n-oiv7.hef"
+if [[ ! -f "${PRODUCED}" ]]; then
+  echo "ERROR: hailomz did not produce ${PRODUCED}." >&2
+  exit 1
+fi
+
+# -- step 3: done --
+echo "[3/3] Success: ${PRODUCED}"
+ls -lh "${PRODUCED}"
+echo
+echo "Next: copy this .hef to the Pi 5, then on the Pi:"
+echo "  cp ~/yolov8n-oiv7.hef \\"
+echo "    /workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/"
+echo "  ros2 launch star_perception perception.launch.py \\"
+echo "    hef_path:=/workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/yolov8n-oiv7.hef \\"
+echo "    classes_yaml:=/workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models/oiv7_classes.yaml"

--- a/star-ros2/src/star_perception/scripts/download_yolov8s_hef.sh
+++ b/star-ros2/src/star_perception/scripts/download_yolov8s_hef.sh
@@ -40,7 +40,16 @@ fi
 
 echo "OK. File size:"
 ls -lh "${TARGET}"
-echo
-echo "If your Pi 5 already has the package installed, also copy the"
-echo "file into the install share so launch can find it:"
-echo "  cp ${TARGET} install/star_perception/share/star_perception/models/"
+
+# Auto-copy into the colcon install share if we can find it, so
+# `ros2 launch star_perception ...` picks it up without a rebuild.
+for candidate in \
+    "${PKG_ROOT}/../../../install/star_perception/share/star_perception/models" \
+    "/workspaces/STAR/star-ros2/install/star_perception/share/star_perception/models"
+do
+  if [[ -d "${candidate}" ]]; then
+    cp -f "${TARGET}" "${candidate}/"
+    echo "Also copied to: ${candidate}"
+    break
+  fi
+done

--- a/star-ros2/src/star_perception/scripts/download_yolov8s_hef.sh
+++ b/star-ros2/src/star_perception/scripts/download_yolov8s_hef.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Download the YOLOv8s .hef from the Hailo Model Zoo for Hailo-8L.
+#
+# Run on the Pi 5 (or any host with internet) from the package root.
+# Places the file at: <package>/models/yolov8s_h8l.hef
+#
+# After install, ros2 launch star_perception perception.launch.py finds
+# it via get_package_share_directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET="${PKG_ROOT}/models/yolov8s_h8l.hef"
+
+# Pinned model zoo URL. If the Hailo Model Zoo reorganises, update this.
+URL="https://hailo-model-zoo.s3.eu-west-2.amazonaws.com/ModelZoo/Compiled/v2.15.0/hailo8l/yolov8s.hef"
+
+mkdir -p "${PKG_ROOT}/models"
+
+if [[ -f "${TARGET}" ]]; then
+  echo "Already present: ${TARGET}"
+  echo "Delete it to force re-download."
+  exit 0
+fi
+
+echo "Downloading YOLOv8s.hef (Hailo-8L) from:"
+echo "  ${URL}"
+echo "to:"
+echo "  ${TARGET}"
+
+if command -v curl >/dev/null; then
+  curl -fL --retry 3 -o "${TARGET}" "${URL}"
+elif command -v wget >/dev/null; then
+  wget -O "${TARGET}" "${URL}"
+else
+  echo "Neither curl nor wget available." >&2
+  exit 1
+fi
+
+echo "OK. File size:"
+ls -lh "${TARGET}"
+echo
+echo "If your Pi 5 already has the package installed, also copy the"
+echo "file into the install share so launch can find it:"
+echo "  cp ${TARGET} install/star_perception/share/star_perception/models/"

--- a/star-ros2/src/star_perception/scripts/install_hailo_stack.sh
+++ b/star-ros2/src/star_perception/scripts/install_hailo_stack.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install the Hailo-8L runtime stack on a Raspberry Pi 5.
+#
+# Run this once after mounting the Raspberry Pi AI HAT+ 13 TOPS on the
+# Pi 5. Requires Raspberry Pi OS Bookworm 64-bit with kernel >= 6.6.31.
+#
+# Reboots the Pi at the end. Re-run if you swap the HAT or upgrade
+# Raspberry Pi OS.
+
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Re-running with sudo..."
+  exec sudo "$0" "$@"
+fi
+
+echo "[1/5] apt update + full-upgrade"
+apt update
+apt full-upgrade -y
+
+echo "[2/5] Installing hailo-all (kernel driver, firmware, HailoRT, TAPPAS)"
+apt install -y hailo-all
+
+echo "[3/5] Confirming PCIe overlay is enabled in /boot/firmware/config.txt"
+CONFIG=/boot/firmware/config.txt
+if ! grep -q "^dtparam=pciex1" "$CONFIG"; then
+  echo "dtparam=pciex1" >> "$CONFIG"
+  echo "  added dtparam=pciex1"
+fi
+if ! grep -q "^dtoverlay=pciex1-compat-pi5" "$CONFIG"; then
+  echo "dtoverlay=pciex1-compat-pi5,no-mip" >> "$CONFIG"
+  echo "  added dtoverlay=pciex1-compat-pi5,no-mip"
+fi
+
+echo "[4/5] Verifying device file"
+if [[ -e /dev/hailo0 ]]; then
+  echo "  /dev/hailo0 present"
+else
+  echo "  /dev/hailo0 not present yet -- will appear after reboot"
+fi
+
+echo "[5/5] Reboot required to load the kernel driver."
+echo "After reboot, run:"
+echo "  hailortcli fw-control identify"
+echo "Expected output: Device: Hailo-8L"
+echo
+read -r -p "Reboot now? [y/N] " ans
+if [[ "$ans" =~ ^[Yy]$ ]]; then
+  reboot
+fi

--- a/star-ros2/src/star_perception/scripts/install_hailo_stack.sh
+++ b/star-ros2/src/star_perception/scripts/install_hailo_stack.sh
@@ -116,7 +116,7 @@ if [[ "${OS_KIND}" == "ubuntu-noble" ]]; then
     chown -R star:star "${DST}"
     echo "  hailo_platform installed into ${DST}"
   else
-    echo "  hailo_platform not found in deb layout — check package version" >&2
+    echo "  hailo_platform not found in deb layout -- check package version" >&2
     exit 1
   fi
   rm -rf "${WORK}"

--- a/star-ros2/src/star_perception/scripts/install_hailo_stack.sh
+++ b/star-ros2/src/star_perception/scripts/install_hailo_stack.sh
@@ -1,48 +1,141 @@
 #!/usr/bin/env bash
-# Install the Hailo-8L runtime stack on a Raspberry Pi 5.
+# Install the Hailo-8L runtime stack on a Pi 5.
 #
-# Run this once after mounting the Raspberry Pi AI HAT+ 13 TOPS on the
-# Pi 5. Requires Raspberry Pi OS Bookworm 64-bit with kernel >= 6.6.31.
+# Supports two target OSes:
+#   - Raspberry Pi OS Bookworm 64-bit (Python 3.11): apt install hailo-all
+#     is sufficient; `hailo_platform` imports directly under the system
+#     python and the perception node uses the in-process HailoRT path.
+#   - Ubuntu 24.04 Noble (Python 3.12): the apt `hailo-all` meta-package
+#     is not available and the cp311 PyHailoRT wheel is ABI-incompatible
+#     with the system python. We install the driver + firmware + CLI
+#     runtime from Hailo's apt repo, then build a Python 3.11 venv at
+#     /home/star/hailo-venv and install `python3-hailort` into it so the
+#     perception node can reach HailoRT via its subprocess-bridge path.
 #
-# Reboots the Pi at the end. Re-run if you swap the HAT or upgrade
-# Raspberry Pi OS.
+# Re-run after swapping the HAT+ or upgrading the host OS.
 
 set -euo pipefail
 
 if [[ $EUID -ne 0 ]]; then
   echo "Re-running with sudo..."
-  exec sudo "$0" "$@"
+  exec sudo --preserve-env=HOME "$0" "$@"
 fi
 
-echo "[1/5] apt update + full-upgrade"
+# -- detect OS --
+. /etc/os-release
+case "${ID}:${VERSION_CODENAME:-}" in
+  raspbian:bookworm|debian:bookworm)
+    OS_KIND="pi-os-bookworm"
+    ;;
+  ubuntu:noble)
+    OS_KIND="ubuntu-noble"
+    ;;
+  *)
+    echo "Unsupported host: ${PRETTY_NAME}."
+    echo "Supported: Raspberry Pi OS Bookworm, Ubuntu 24.04 Noble."
+    exit 1
+    ;;
+esac
+echo "Target OS: ${OS_KIND}"
+
+echo "[1/6] apt update"
 apt update
-apt full-upgrade -y
 
-echo "[2/5] Installing hailo-all (kernel driver, firmware, HailoRT, TAPPAS)"
-apt install -y hailo-all
+if [[ "${OS_KIND}" == "pi-os-bookworm" ]]; then
+  echo "[2/6] Installing hailo-all (driver + firmware + HailoRT + TAPPAS)"
+  apt install -y hailo-all
+else
+  echo "[2/6] Installing hailo-dkms + hailofw + hailort + hailortcli"
+  # These are the standalone packages published by Hailo's apt repo;
+  # hailo-all is Debian-bookworm-only because it pulls tappas deps that
+  # need libav5.1 from bookworm.
+  apt install -y hailo-dkms hailofw hailort
+fi
 
-echo "[3/5] Confirming PCIe overlay is enabled in /boot/firmware/config.txt"
+echo "[3/6] Confirming PCIe overlay is enabled"
+# config.txt lives in /boot/firmware on both Pi OS Bookworm and Ubuntu 24.04.
 CONFIG=/boot/firmware/config.txt
-if ! grep -q "^dtparam=pciex1" "$CONFIG"; then
-  echo "dtparam=pciex1" >> "$CONFIG"
-  echo "  added dtparam=pciex1"
-fi
-if ! grep -q "^dtoverlay=pciex1-compat-pi5" "$CONFIG"; then
-  echo "dtoverlay=pciex1-compat-pi5,no-mip" >> "$CONFIG"
-  echo "  added dtoverlay=pciex1-compat-pi5,no-mip"
+if [[ -f "$CONFIG" ]]; then
+  if ! grep -q "^dtparam=pciex1" "$CONFIG"; then
+    echo "dtparam=pciex1" >> "$CONFIG"
+    echo "  added dtparam=pciex1"
+  fi
+  if ! grep -q "^dtoverlay=pciex1-compat-pi5" "$CONFIG"; then
+    echo "dtoverlay=pciex1-compat-pi5,no-mip" >> "$CONFIG"
+    echo "  added dtoverlay=pciex1-compat-pi5,no-mip"
+  fi
+else
+  echo "  $CONFIG not present (non-standard image); skipping overlay edit"
 fi
 
-echo "[4/5] Verifying device file"
+echo "[4/6] Verifying device file"
 if [[ -e /dev/hailo0 ]]; then
   echo "  /dev/hailo0 present"
 else
   echo "  /dev/hailo0 not present yet -- will appear after reboot"
 fi
 
-echo "[5/5] Reboot required to load the kernel driver."
-echo "After reboot, run:"
-echo "  hailortcli fw-control identify"
-echo "Expected output: Device: Hailo-8L"
+if [[ "${OS_KIND}" == "ubuntu-noble" ]]; then
+  echo "[5/6] Building Python 3.11 venv for HailoRT Python bindings"
+  # Python 3.11 isn't in Ubuntu 24.04's main repos; enable deadsnakes if
+  # not already installed.
+  if ! command -v python3.11 >/dev/null; then
+    add-apt-repository -y ppa:deadsnakes/ppa
+    apt update
+    apt install -y python3.11 python3.11-venv python3.11-dev
+  fi
+
+  VENV=/home/star/hailo-venv
+  if [[ ! -x "${VENV}/bin/python3.11" ]]; then
+    sudo -u star python3.11 -m venv "${VENV}"
+  fi
+  # numpy<2 is REQUIRED: the cp311 _pyhailort.so is compiled against
+  # numpy 1.x ABI. numpy >= 2 fails inference with a misleading
+  # "Memory size of vstream ... does not match the frame count" error.
+  sudo -u star "${VENV}/bin/pip" install --upgrade pip wheel
+  sudo -u star "${VENV}/bin/pip" install 'numpy<2' netaddr contextlib2 argcomplete future
+
+  # Extract hailo_platform/ from the cp311 deb into the venv.
+  DEB_PATH=/tmp/python3-hailort.deb
+  if [[ ! -f "${DEB_PATH}" ]]; then
+    apt download python3-hailort || {
+      echo "  python3-hailort not available via apt download; ensure"
+      echo "  Hailo's apt repo is configured in /etc/apt/sources.list.d/."
+      exit 1
+    }
+    mv python3-hailort_*.deb "${DEB_PATH}"
+  fi
+  WORK=$(mktemp -d)
+  dpkg-deb -x "${DEB_PATH}" "${WORK}"
+  # The deb drops hailo_platform/ under usr/lib/python3/dist-packages/.
+  SRC="${WORK}/usr/lib/python3/dist-packages/hailo_platform"
+  if [[ -d "${SRC}" ]]; then
+    DST="${VENV}/lib/python3.11/site-packages/hailo_platform"
+    rm -rf "${DST}"
+    cp -r "${SRC}" "${DST}"
+    chown -R star:star "${DST}"
+    echo "  hailo_platform installed into ${DST}"
+  else
+    echo "  hailo_platform not found in deb layout — check package version" >&2
+    exit 1
+  fi
+  rm -rf "${WORK}"
+
+  sudo -u star "${VENV}/bin/python" -c "import hailo_platform; print('venv import OK:', hailo_platform.__file__)" || {
+    echo "  venv import of hailo_platform failed." >&2
+    exit 1
+  }
+else
+  echo "[5/6] Pi OS Bookworm: hailo_platform available from system python, no venv needed"
+fi
+
+echo "[6/6] Done. Next steps:"
+echo "  1. Reboot (sudo reboot) to load the kernel driver if /dev/hailo0"
+echo "     didn't show up in step 4."
+echo "  2. Verify: hailortcli fw-control identify"
+echo "     Expected: Device Architecture: HAILO8L"
+echo "  3. Download the YOLOv8s model:"
+echo "     bash $(dirname "$0")/download_yolov8s_hef.sh"
 echo
 read -r -p "Reboot now? [y/N] " ans
 if [[ "$ans" =~ ^[Yy]$ ]]; then

--- a/star-ros2/src/star_perception/setup.cfg
+++ b/star-ros2/src/star_perception/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/star_perception
+[install]
+install_scripts=$base/lib/star_perception

--- a/star-ros2/src/star_perception/setup.py
+++ b/star-ros2/src/star_perception/setup.py
@@ -1,0 +1,41 @@
+"""ament_python setup for the STAR Hailo-8L perception package."""
+
+from glob import glob
+from pathlib import Path
+
+from setuptools import find_packages, setup
+
+PACKAGE_NAME = "star_perception"
+HERE = Path(__file__).parent
+
+
+setup(
+    name=PACKAGE_NAME,
+    version="0.1.0",
+    packages=find_packages(include=[PACKAGE_NAME, f"{PACKAGE_NAME}.*"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages",
+         ["resource/" + PACKAGE_NAME]),
+        (f"share/{PACKAGE_NAME}", ["package.xml"]),
+        (f"share/{PACKAGE_NAME}/launch", glob("launch/*.py")),
+        (f"share/{PACKAGE_NAME}/config", glob("config/*.yaml")),
+        (f"share/{PACKAGE_NAME}/scripts", glob("scripts/*.sh")),
+    ],
+    install_requires=[
+        "setuptools",
+        "numpy",
+    ],
+    zip_safe=True,
+    maintainer="Team Locked Inc.",
+    maintainer_email="locked-inc@tamu.edu",
+    description="Hailo-8L accelerated YOLO perception for STAR.",
+    license="MIT",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "hailo_yolo_node = star_perception.hailo_yolo_node:main",
+            "detection_3d_fusion_node = "
+            "star_perception.detection_3d_fusion_node:main",
+        ],
+    },
+)

--- a/star-ros2/src/star_perception/setup.py
+++ b/star-ros2/src/star_perception/setup.py
@@ -21,7 +21,8 @@ setup(
         (f"share/{PACKAGE_NAME}/config", glob("config/*.yaml")),
         (f"share/{PACKAGE_NAME}/scripts", glob("scripts/*.sh")),
         (f"share/{PACKAGE_NAME}/models",
-         glob("models/*.hef") + glob("models/README.md")),
+         glob("models/*.hef") + glob("models/*.yaml")
+         + glob("models/README.md")),
     ],
     install_requires=[
         "setuptools",

--- a/star-ros2/src/star_perception/setup.py
+++ b/star-ros2/src/star_perception/setup.py
@@ -20,6 +20,8 @@ setup(
         (f"share/{PACKAGE_NAME}/launch", glob("launch/*.py")),
         (f"share/{PACKAGE_NAME}/config", glob("config/*.yaml")),
         (f"share/{PACKAGE_NAME}/scripts", glob("scripts/*.sh")),
+        (f"share/{PACKAGE_NAME}/models",
+         glob("models/*.hef") + glob("models/README.md")),
     ],
     install_requires=[
         "setuptools",

--- a/star-ros2/src/star_perception/star_perception/__init__.py
+++ b/star-ros2/src/star_perception/star_perception/__init__.py
@@ -1,0 +1,3 @@
+"""STAR Hailo-8L YOLO perception package."""
+
+__version__ = "0.1.0"

--- a/star-ros2/src/star_perception/star_perception/_hailo_worker.py
+++ b/star-ros2/src/star_perception/star_perception/_hailo_worker.py
@@ -3,7 +3,7 @@
 
 Subprocess run by `HailoYoloRunner` under the Python 3.11 interpreter
 in /home/star/hailo-venv when the ROS2 Jazzy system interpreter
-(Python 3.12) cannot import `hailo_platform` directly — HailoRT 4.20
+(Python 3.12) cannot import `hailo_platform` directly -- HailoRT 4.20
 only ships a cp311 aarch64 wheel, and there is no cp312 wheel. On
 Raspberry Pi OS Bookworm (Python 3.11) the runner imports
 `hailo_platform` in-process and this worker is not spawned.

--- a/star-ros2/src/star_perception/star_perception/_hailo_worker.py
+++ b/star-ros2/src/star_perception/star_perception/_hailo_worker.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Long-lived Hailo-8L YOLOv8 inference worker.
+
+Subprocess run by `HailoYoloRunner` under the Python 3.11 interpreter
+in /home/star/hailo-venv when the ROS2 Jazzy system interpreter
+(Python 3.12) cannot import `hailo_platform` directly — HailoRT 4.20
+only ships a cp311 aarch64 wheel, and there is no cp312 wheel. On
+Raspberry Pi OS Bookworm (Python 3.11) the runner imports
+`hailo_platform` in-process and this worker is not spawned.
+
+IPC protocol (length-prefixed binary over stdin/stdout):
+
+  parent -> worker:  <4B big-endian N><N bytes uint8 HxWx3 RGB canvas>
+                     (N = input_size * input_size * 3)
+  worker -> parent:  <4B big-endian M><M bytes UTF-8 JSON>
+                     JSON = {"detections": [[class_id, score,
+                                             x_min_n, y_min_n,
+                                             x_max_n, y_max_n], ...]}
+                     All coords normalized to [0, 1] of the input
+                     canvas. Matches the runner's `InferenceBackend`
+                     return tuple order.
+
+First message from worker to parent is always the handshake:
+  {"status": "ready"}   on successful HEF load
+  {"status": "error", "message": "..."}   otherwise
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import signal
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from hailo_platform import (
+    HEF,
+    VDevice,
+    HailoStreamInterface,
+    ConfigureParams,
+    InputVStreamParams,
+    OutputVStreamParams,
+    InferVStreams,
+    FormatType,
+)
+
+
+def _write_message(buf: bytes) -> None:
+    sys.stdout.buffer.write(struct.pack(">I", len(buf)))
+    sys.stdout.buffer.write(buf)
+    sys.stdout.buffer.flush()
+
+
+def _read_exact(n: int) -> bytes:
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sys.stdin.buffer.read(n - len(buf))
+        if not chunk:
+            raise EOFError
+        buf.extend(chunk)
+    return bytes(buf)
+
+
+def _decode_hailo_yolov8_output(raw):
+    """Flatten Hailo NMS output into list of (class_id, score, x_min_n,
+    y_min_n, x_max_n, y_max_n).
+
+    The YOLOv8 HEF from the Hailo Model Zoo emits
+    `list[batch][class][(num_dets, 5)]` with each row
+    `(y_min, x_min, y_max, x_max, score)` in normalized canvas coords.
+    Verified empirically on yolov8s_h8l.hef with ultralytics bus.jpg.
+    """
+    if isinstance(raw, list) and len(raw) == 1:
+        per_class = raw[0]
+    elif isinstance(raw, list):
+        per_class = raw
+    else:
+        arr = np.asarray(raw)
+        if arr.ndim >= 1 and arr.shape[0] == 1:
+            arr = arr[0]
+        per_class = list(arr)
+
+    out = []
+    for class_id, dets in enumerate(per_class):
+        arr = np.asarray(dets)
+        if arr.size == 0 or arr.ndim != 2 or arr.shape[1] < 5:
+            continue
+        for row in arr:
+            score = float(row[4])
+            if score <= 0.0:
+                continue
+            y_min = float(row[0]); x_min = float(row[1])
+            y_max = float(row[2]); x_max = float(row[3])
+            out.append((int(class_id), score, x_min, y_min, x_max, y_max))
+    return out
+
+
+class _Runner:
+    def __init__(self, hef_path: Path, input_size: int):
+        self.hef_path = hef_path
+        self.input_size = input_size
+        self.vdevice = None
+        self._ng = None
+        self._in_name = None
+        self._out_name = None
+        self._ip = None
+        self._op = None
+
+    def setup(self) -> None:
+        hef = HEF(str(self.hef_path))
+        self.vdevice = VDevice()
+        cp = ConfigureParams.create_from_hef(
+            hef=hef, interface=HailoStreamInterface.PCIe
+        )
+        self._ng = self.vdevice.configure(hef, cp)[0]
+        self._in_name = hef.get_input_vstream_infos()[0].name
+        self._out_name = hef.get_output_vstream_infos()[0].name
+        self._ip = InputVStreamParams.make(self._ng, format_type=FormatType.UINT8)
+        self._op = OutputVStreamParams.make(self._ng, format_type=FormatType.FLOAT32)
+
+    def infer(self, canvas_hwc: np.ndarray):
+        batched = np.expand_dims(canvas_hwc, axis=0)
+        with InferVStreams(self._ng, self._ip, self._op) as pipe:
+            with self._ng.activate(self._ng.create_params()):
+                raw = pipe.infer({self._in_name: batched})
+        return _decode_hailo_yolov8_output(raw[self._out_name])
+
+    def shutdown(self) -> None:
+        if self.vdevice is not None:
+            try:
+                self.vdevice.release()
+            except Exception:
+                pass
+            self.vdevice = None
+
+
+def _install_signal_handlers(runner: _Runner) -> None:
+    def _handler(signum, frame):
+        runner.shutdown()
+        sys.exit(0)
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, _handler)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--hef", required=True, type=Path)
+    parser.add_argument("--input-size", type=int, default=640)
+    args = parser.parse_args()
+
+    runner = _Runner(args.hef, args.input_size)
+    try:
+        runner.setup()
+    except Exception as exc:
+        _write_message(json.dumps(
+            {"status": "error", "message": str(exc)}).encode())
+        return 1
+
+    _install_signal_handlers(runner)
+    _write_message(json.dumps({"status": "ready"}).encode())
+
+    expected = args.input_size * args.input_size * 3
+    try:
+        while True:
+            header = sys.stdin.buffer.read(4)
+            if len(header) != 4:
+                break
+            n = struct.unpack(">I", header)[0]
+            if n != expected:
+                _read_exact(n)
+                _write_message(json.dumps(
+                    {"detections": [],
+                     "error": f"expected {expected} bytes, got {n}"}
+                ).encode())
+                continue
+            payload = _read_exact(n)
+            canvas = np.frombuffer(payload, dtype=np.uint8).reshape(
+                args.input_size, args.input_size, 3
+            ).copy()  # hailo_platform requires a writeable buffer
+            try:
+                dets = runner.infer(canvas)
+            except Exception as exc:
+                _write_message(json.dumps(
+                    {"detections": [], "error": str(exc)}).encode())
+                continue
+            _write_message(json.dumps({"detections": dets}).encode())
+    finally:
+        runner.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/star-ros2/src/star_perception/star_perception/depth_fusion.py
+++ b/star-ros2/src/star_perception/star_perception/depth_fusion.py
@@ -1,0 +1,220 @@
+"""
+Pure-Python geometry helpers for fusing a 2D bounding box with a
+disparity image to produce a 3D detection in the camera optical frame.
+
+Kept separate from the ROS2 node so the math is unit-testable without
+rclpy / cv_bridge / stereo_msgs.
+
+Conventions
+-----------
+- Image pixel coordinates: u (column) right, v (row) down, origin at
+  the top-left of the image.
+- Camera intrinsics matrix K (3x3, row-major):
+      [[fx,  0, cx],
+       [ 0, fy, cy],
+       [ 0,  0,  1]].
+- Camera optical frame (REP-103): x right, y down, z forward (into the
+  scene). All 3D outputs are in this frame.
+- Disparity (in pixels) -> depth (metres):
+      Z = f * baseline_m / disparity_px
+  where f is the rectified focal length in pixels and baseline_m is the
+  stereo baseline in metres (both supplied by stereo_image_proc).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+
+MIN_VALID_SAMPLES_DEFAULT = 30
+DISPARITY_BORDER_PCT_DEFAULT = 0.15
+MAX_DEPTH_M_DEFAULT = 6.0
+MIN_DEPTH_M_DEFAULT = 0.20
+
+
+@dataclass(frozen=True)
+class CameraIntrinsics:
+    """Pinhole-camera intrinsics, in pixels for fx/fy/cx/cy."""
+
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+
+    @classmethod
+    def from_k_matrix(cls, k_row_major: np.ndarray) -> "CameraIntrinsics":
+        """Construct from the row-major K matrix in sensor_msgs/CameraInfo."""
+        k = np.asarray(k_row_major, dtype=np.float64).reshape(3, 3)
+        return cls(fx=float(k[0, 0]), fy=float(k[1, 1]),
+                   cx=float(k[0, 2]), cy=float(k[1, 2]))
+
+
+@dataclass(frozen=True)
+class Detection3D:
+    """A 3D detection in the camera optical frame, axis-aligned bbox."""
+
+    class_id: int
+    class_name: str
+    score: float
+    cx_m: float       # bbox centre X in metres (camera optical frame).
+    cy_m: float       # bbox centre Y in metres.
+    cz_m: float       # bbox centre Z in metres (depth).
+    size_x_m: float   # bbox extent in X (metres).
+    size_y_m: float   # bbox extent in Y (metres).
+    size_z_m: float   # bbox extent in Z (metres) -- coarse, see notes.
+    sample_count: int  # number of valid disparity samples used.
+
+
+def median_disparity_in_bbox(disparity: np.ndarray,
+                             x_min: float, y_min: float,
+                             x_max: float, y_max: float,
+                             border_pct: float
+                             = DISPARITY_BORDER_PCT_DEFAULT
+                             ) -> tuple[float, int]:
+    """
+    Median of valid disparity samples inside the inset 2D bounding box.
+
+    Args:
+        disparity:   HxW float32 array of disparities in pixels. NaN, inf,
+                     and non-positive values are treated as invalid.
+        x_min, y_min, x_max, y_max: bbox in pixel coordinates of the
+                     same image. Will be clamped to the image bounds.
+        border_pct:  Fraction of bbox width/height to crop off each
+                     edge before sampling. Default 0.15 (15 percent).
+                     This rejects edge artefacts where stereo matching
+                     tends to fail.
+
+    Returns:
+        (median_disparity_px, valid_sample_count). If there are no
+        valid samples, returns (nan, 0).
+    """
+    if disparity.ndim != 2:
+        raise ValueError("disparity must be a 2D array.")
+    if not (0.0 <= border_pct < 0.5):
+        raise ValueError("border_pct must be in [0, 0.5).")
+
+    h, w = disparity.shape
+    bw = max(0.0, x_max - x_min)
+    bh = max(0.0, y_max - y_min)
+    inset_x = bw * border_pct
+    inset_y = bh * border_pct
+    x0 = max(0, int(np.floor(x_min + inset_x)))
+    y0 = max(0, int(np.floor(y_min + inset_y)))
+    x1 = min(w, int(np.ceil(x_max - inset_x)))
+    y1 = min(h, int(np.ceil(y_max - inset_y)))
+    if x1 <= x0 or y1 <= y0:
+        return float("nan"), 0
+
+    roi = disparity[y0:y1, x0:x1]
+    finite_mask = np.isfinite(roi) & (roi > 0.0)
+    valid = roi[finite_mask]
+    if valid.size == 0:
+        return float("nan"), 0
+    return float(np.median(valid)), int(valid.size)
+
+
+def depth_from_disparity(disparity_px: float,
+                         focal_px: float,
+                         baseline_m: float) -> float:
+    """Z = f * T / d. Returns nan if disparity is non-positive."""
+    if not (disparity_px > 0.0):
+        return float("nan")
+    if not (focal_px > 0.0 and baseline_m > 0.0):
+        raise ValueError("focal_px and baseline_m must be positive.")
+    return float(focal_px * baseline_m / disparity_px)
+
+
+def back_project_pixel(u: float, v: float, z_m: float,
+                       k: CameraIntrinsics) -> tuple[float, float, float]:
+    """Pinhole back-projection of pixel (u, v) at depth z_m into 3D."""
+    if not (z_m > 0.0):
+        raise ValueError("z_m must be positive.")
+    x = (u - k.cx) * z_m / k.fx
+    y = (v - k.cy) * z_m / k.fy
+    return float(x), float(y), float(z_m)
+
+
+def fuse_bbox_to_3d(disparity: np.ndarray,
+                    intrinsics: CameraIntrinsics,
+                    focal_px: float,
+                    baseline_m: float,
+                    class_id: int,
+                    class_name: str,
+                    score: float,
+                    x_min: float, y_min: float,
+                    x_max: float, y_max: float,
+                    border_pct: float
+                    = DISPARITY_BORDER_PCT_DEFAULT,
+                    min_valid_samples: int
+                    = MIN_VALID_SAMPLES_DEFAULT,
+                    min_depth_m: float = MIN_DEPTH_M_DEFAULT,
+                    max_depth_m: float = MAX_DEPTH_M_DEFAULT
+                    ) -> Optional[Detection3D]:
+    """
+    Convert a 2D detection + disparity image into a Detection3D, or
+    return None if the depth estimate is rejected.
+
+    The 3D bbox is approximated from the 2D bbox by:
+      - centre (cx_m, cy_m, cz_m) from back-projection of bbox centre
+        at the median ROI depth;
+      - size_x_m, size_y_m from bbox pixel extents scaled by Z/f;
+      - size_z_m from the spread (95th - 5th percentile) of the valid
+        disparity samples. Coarse but useful for RViz visualisation.
+
+    Returns None when:
+      - the bbox has fewer than min_valid_samples valid disparities;
+      - the median depth falls outside [min_depth_m, max_depth_m].
+    """
+    median_d, sample_count = median_disparity_in_bbox(
+        disparity, x_min, y_min, x_max, y_max, border_pct,
+    )
+    if sample_count < min_valid_samples:
+        return None
+    z_m = depth_from_disparity(median_d, focal_px, baseline_m)
+    if not np.isfinite(z_m):
+        return None
+    if not (min_depth_m <= z_m <= max_depth_m):
+        return None
+
+    u_c = 0.5 * (x_min + x_max)
+    v_c = 0.5 * (y_min + y_max)
+    cx_m, cy_m, cz_m = back_project_pixel(u_c, v_c, z_m, intrinsics)
+
+    size_x_m = (x_max - x_min) * z_m / intrinsics.fx
+    size_y_m = (y_max - y_min) * z_m / intrinsics.fy
+
+    # Coarse depth extent from disparity spread: small numbers OK.
+    # We re-sample the same ROI to get spread; cheap relative to NPU.
+    h, w = disparity.shape
+    bw = max(0.0, x_max - x_min)
+    bh = max(0.0, y_max - y_min)
+    inset_x = bw * border_pct
+    inset_y = bh * border_pct
+    x0 = max(0, int(np.floor(x_min + inset_x)))
+    y0 = max(0, int(np.floor(y_min + inset_y)))
+    x1 = min(w, int(np.ceil(x_max - inset_x)))
+    y1 = min(h, int(np.ceil(y_max - inset_y)))
+    roi = disparity[y0:y1, x0:x1]
+    finite_mask = np.isfinite(roi) & (roi > 0.0)
+    valid = roi[finite_mask]
+    if valid.size >= 4:
+        d_low, d_high = np.percentile(valid, [5.0, 95.0])
+        z_low = depth_from_disparity(float(d_high), focal_px, baseline_m)
+        z_high = depth_from_disparity(float(d_low), focal_px, baseline_m)
+        size_z_m = float(max(0.05, z_high - z_low))
+    else:
+        size_z_m = 0.10  # default 10 cm extent.
+
+    return Detection3D(
+        class_id=int(class_id),
+        class_name=str(class_name),
+        score=float(score),
+        cx_m=cx_m, cy_m=cy_m, cz_m=cz_m,
+        size_x_m=float(max(0.01, size_x_m)),
+        size_y_m=float(max(0.01, size_y_m)),
+        size_z_m=size_z_m,
+        sample_count=int(sample_count),
+    )

--- a/star-ros2/src/star_perception/star_perception/detection_3d_fusion_node.py
+++ b/star-ros2/src/star_perception/star_perception/detection_3d_fusion_node.py
@@ -1,0 +1,329 @@
+"""
+3D detection fusion node.
+
+Fuses each `vision_msgs/Detection2DArray` from the Hailo YOLO node with
+the rectified disparity image already published by
+`stereo_image_proc::DisparityNode` to emit a 3D detection in
+`cam0_optical_frame`.
+
+Subscribes to:
+  /perception/detections_2d   vision_msgs/Detection2DArray
+  /stereo/disparity            stereo_msgs/DisparityImage
+  /cam0/camera/camera_info    sensor_msgs/CameraInfo  (latched-style)
+
+Publishes:
+  /perception/detections_3d   vision_msgs/Detection3DArray
+  /perception/markers          visualization_msgs/MarkerArray  (RViz)
+
+Parameters:
+  enabled                  bool   default true
+  min_valid_samples        int    default 30
+  max_depth_m              float  default 6.0
+  min_depth_m              float  default 0.20
+  disparity_border_pct     float  default 0.15
+  sync_slop_sec            float  default 0.10
+  marker_lifetime_sec      float  default 0.50
+
+Time synchronisation uses message_filters.ApproximateTimeSynchronizer
+between the 2D detections and the disparity image. The CameraInfo is
+held in the latest-known cache (the existing pipeline only ever sends
+one set of intrinsics, then they are static).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+
+from sensor_msgs.msg import CameraInfo
+from stereo_msgs.msg import DisparityImage
+from vision_msgs.msg import (
+    BoundingBox3D,
+    Detection2DArray,
+    Detection3D,
+    Detection3DArray,
+    ObjectHypothesisWithPose,
+)
+from visualization_msgs.msg import Marker, MarkerArray
+import message_filters
+
+from star_perception.depth_fusion import (
+    CameraIntrinsics,
+    Detection3D as Det3D,
+    DISPARITY_BORDER_PCT_DEFAULT,
+    MAX_DEPTH_M_DEFAULT,
+    MIN_DEPTH_M_DEFAULT,
+    MIN_VALID_SAMPLES_DEFAULT,
+    fuse_bbox_to_3d,
+)
+
+
+DETECTIONS_2D_TOPIC = "/perception/detections_2d"
+DISPARITY_TOPIC = "/stereo/disparity"
+CAMERA_INFO_TOPIC = "/cam0/camera/camera_info"
+DETECTIONS_3D_TOPIC = "/perception/detections_3d"
+MARKERS_TOPIC = "/perception/markers"
+DEFAULT_FRAME = "cam0_optical_frame"
+
+
+class Detection3dFusionNode(Node):
+
+    def __init__(self) -> None:
+        super().__init__("star_detection_3d_fusion_node")
+
+        self.declare_parameter("enabled", True)
+        self.declare_parameter(
+            "min_valid_samples", MIN_VALID_SAMPLES_DEFAULT)
+        self.declare_parameter("max_depth_m", MAX_DEPTH_M_DEFAULT)
+        self.declare_parameter("min_depth_m", MIN_DEPTH_M_DEFAULT)
+        self.declare_parameter(
+            "disparity_border_pct", DISPARITY_BORDER_PCT_DEFAULT)
+        self.declare_parameter("sync_slop_sec", 0.10)
+        self.declare_parameter("marker_lifetime_sec", 0.50)
+
+        self._intrinsics: Optional[CameraIntrinsics] = None
+        self._cv_bridge = self._import_cv_bridge()
+
+        qos_sensor = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            depth=5,
+        )
+        qos_camera_info = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            depth=1,
+        )
+
+        self._sub_camera_info = self.create_subscription(
+            CameraInfo, CAMERA_INFO_TOPIC, self._on_camera_info,
+            qos_camera_info,
+        )
+        self._sub_dets = message_filters.Subscriber(
+            self, Detection2DArray, DETECTIONS_2D_TOPIC, qos_profile=qos_sensor,
+        )
+        self._sub_disp = message_filters.Subscriber(
+            self, DisparityImage, DISPARITY_TOPIC, qos_profile=qos_sensor,
+        )
+        slop = float(self.get_parameter("sync_slop_sec").value)
+        self._sync = message_filters.ApproximateTimeSynchronizer(
+            [self._sub_dets, self._sub_disp], queue_size=10, slop=slop,
+        )
+        self._sync.registerCallback(self._on_synced)
+
+        self._pub_3d = self.create_publisher(
+            Detection3DArray, DETECTIONS_3D_TOPIC, 10,
+        )
+        self._pub_markers = self.create_publisher(
+            MarkerArray, MARKERS_TOPIC, 10,
+        )
+
+        self.get_logger().info(
+            "star_detection_3d_fusion_node ready. "
+            f"slop={slop:.2f}s, "
+            f"depth=[{self.get_parameter('min_depth_m').value:.2f}, "
+            f"{self.get_parameter('max_depth_m').value:.2f}] m."
+        )
+
+    # ------------------------------------------------------------------
+
+    def _import_cv_bridge(self):
+        try:
+            from cv_bridge import CvBridge
+            return CvBridge()
+        except ImportError:  # pragma: no cover
+            self.get_logger().warn(
+                "cv_bridge not available; node will not function.")
+            return None
+
+    def _on_camera_info(self, msg: CameraInfo) -> None:
+        # K is the original camera matrix; for rectified images we
+        # actually want P[:3, :3] (the projection matrix's left 3x3),
+        # but the existing stereo_image_proc pipeline rectifies, so
+        # the published CameraInfo's K already reflects rectified
+        # intrinsics on the rectified image_rect_color topic. The
+        # camera_info topic carries identical intrinsics either way
+        # for this rig (camera_info is sourced from the same YAML).
+        try:
+            self._intrinsics = CameraIntrinsics.from_k_matrix(
+                np.asarray(msg.k))
+        except Exception as exc:  # pragma: no cover
+            self.get_logger().error(f"Bad CameraInfo K matrix: {exc}")
+
+    # ------------------------------------------------------------------
+
+    def _on_synced(self, dets: Detection2DArray,
+                   disp_msg: DisparityImage) -> None:
+        if not self.get_parameter("enabled").value:
+            return
+        if self._intrinsics is None:
+            self.get_logger().warn(
+                "No CameraInfo received yet; dropping detections.",
+                throttle_duration_sec=5.0)
+            return
+        if self._cv_bridge is None:
+            return
+
+        try:
+            disparity = self._cv_bridge.imgmsg_to_cv2(
+                disp_msg.image, desired_encoding="passthrough")
+        except Exception as exc:  # pragma: no cover
+            self.get_logger().warn(f"cv_bridge disparity convert: {exc}")
+            return
+        if disparity.dtype != np.float32:
+            disparity = disparity.astype(np.float32)
+
+        focal_px = float(disp_msg.f)
+        baseline_m = float(disp_msg.t)
+        if not (focal_px > 0.0 and baseline_m > 0.0):
+            self.get_logger().warn(
+                f"Invalid disparity calibration: f={focal_px}, "
+                f"T={baseline_m}", throttle_duration_sec=5.0)
+            return
+
+        out = Detection3DArray()
+        out.header.stamp = dets.header.stamp
+        out.header.frame_id = DEFAULT_FRAME
+
+        markers = MarkerArray()
+        marker_id = 0
+        marker_lifetime = float(
+            self.get_parameter("marker_lifetime_sec").value)
+
+        min_samples = int(self.get_parameter("min_valid_samples").value)
+        min_depth = float(self.get_parameter("min_depth_m").value)
+        max_depth = float(self.get_parameter("max_depth_m").value)
+        border = float(self.get_parameter("disparity_border_pct").value)
+
+        for d2d in dets.detections:
+            if not d2d.results:
+                continue
+            class_name = d2d.results[0].hypothesis.class_id
+            score = float(d2d.results[0].hypothesis.score)
+
+            cx = d2d.bbox.center.position.x
+            cy = d2d.bbox.center.position.y
+            sx = d2d.bbox.size_x
+            sy = d2d.bbox.size_y
+            x_min = cx - 0.5 * sx
+            y_min = cy - 0.5 * sy
+            x_max = cx + 0.5 * sx
+            y_max = cy + 0.5 * sy
+
+            det3d = fuse_bbox_to_3d(
+                disparity, self._intrinsics,
+                focal_px, baseline_m,
+                class_id=0,  # YOLO node passes class via class_id string.
+                class_name=class_name,
+                score=score,
+                x_min=x_min, y_min=y_min,
+                x_max=x_max, y_max=y_max,
+                border_pct=border,
+                min_valid_samples=min_samples,
+                min_depth_m=min_depth,
+                max_depth_m=max_depth,
+            )
+            if det3d is None:
+                continue
+
+            out.detections.append(self._to_detection3d_msg(det3d, out.header))
+            markers.markers.extend(self._to_markers(
+                det3d, marker_id, out.header, marker_lifetime))
+            marker_id += 2  # one cube + one text per detection.
+
+        self._pub_3d.publish(out)
+        self._pub_markers.publish(markers)
+
+    # ------------------------------------------------------------------
+
+    def _to_detection3d_msg(self, d: Det3D, header) -> Detection3D:
+        msg = Detection3D()
+        msg.header = header
+
+        bbox = BoundingBox3D()
+        bbox.center.position.x = d.cx_m
+        bbox.center.position.y = d.cy_m
+        bbox.center.position.z = d.cz_m
+        bbox.center.orientation.w = 1.0
+        bbox.size.x = d.size_x_m
+        bbox.size.y = d.size_y_m
+        bbox.size.z = d.size_z_m
+        msg.bbox = bbox
+
+        hyp = ObjectHypothesisWithPose()
+        hyp.hypothesis.class_id = d.class_name
+        hyp.hypothesis.score = d.score
+        hyp.pose.pose.position.x = d.cx_m
+        hyp.pose.pose.position.y = d.cy_m
+        hyp.pose.pose.position.z = d.cz_m
+        hyp.pose.pose.orientation.w = 1.0
+        msg.results.append(hyp)
+        return msg
+
+    def _to_markers(self, d: Det3D, base_id: int, header,
+                    lifetime_sec: float) -> list:
+        from builtin_interfaces.msg import Duration as DurationMsg
+        cube = Marker()
+        cube.header = header
+        cube.ns = "yolo3d"
+        cube.id = base_id
+        cube.type = Marker.CUBE
+        cube.action = Marker.ADD
+        cube.pose.position.x = d.cx_m
+        cube.pose.position.y = d.cy_m
+        cube.pose.position.z = d.cz_m
+        cube.pose.orientation.w = 1.0
+        cube.scale.x = max(0.01, d.size_x_m)
+        cube.scale.y = max(0.01, d.size_y_m)
+        cube.scale.z = max(0.01, d.size_z_m)
+        cube.color.r = 0.0
+        cube.color.g = 0.85
+        cube.color.b = 0.0
+        cube.color.a = 0.35
+        cube.lifetime = DurationMsg(
+            sec=int(lifetime_sec),
+            nanosec=int((lifetime_sec - int(lifetime_sec)) * 1e9),
+        )
+
+        text = Marker()
+        text.header = header
+        text.ns = "yolo3d_label"
+        text.id = base_id + 1
+        text.type = Marker.TEXT_VIEW_FACING
+        text.action = Marker.ADD
+        text.pose.position.x = d.cx_m
+        text.pose.position.y = d.cy_m - 0.5 * d.size_y_m - 0.05
+        text.pose.position.z = d.cz_m
+        text.pose.orientation.w = 1.0
+        text.scale.z = 0.10
+        text.color.r = 1.0
+        text.color.g = 1.0
+        text.color.b = 1.0
+        text.color.a = 1.0
+        text.text = f"{d.class_name} {d.score:.2f} ({d.cz_m:.2f}m)"
+        text.lifetime = cube.lifetime
+        return [cube, text]
+
+
+def main(args=None):  # pragma: no cover
+    rclpy.init(args=args)
+    node = Detection3dFusionNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/star-ros2/src/star_perception/star_perception/hailo_runner.py
+++ b/star-ros2/src/star_perception/star_perception/hailo_runner.py
@@ -36,6 +36,30 @@ import numpy as np
 YOLOV8_INPUT_SIZE = 640
 LETTERBOX_PAD_VALUE = 114  # YOLOv8 convention (mid-grey).
 DEFAULT_WORKER_PYTHON = "/home/star/hailo-venv/bin/python"
+
+
+def load_class_names(path: str | Path) -> tuple[str, ...]:
+    """Load an ordered class list from a YAML file with a top-level
+    `names:` field. Matches the Ultralytics dataset-yaml convention
+    used by the zoo's coco_classes.yaml / oiv7_classes.yaml."""
+    try:
+        import yaml
+    except ImportError as exc:
+        raise RuntimeError(
+            "PyYAML is required to load class lists. "
+            "apt install python3-yaml, or pip install pyyaml.") from exc
+    p = Path(path)
+    with p.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict) or "names" not in data:
+        raise ValueError(f"{p} must contain a top-level 'names:' list")
+    names = data["names"]
+    if isinstance(names, dict):
+        names = [names[k] for k in sorted(names.keys())]
+    if not isinstance(names, list) or not all(
+            isinstance(n, str) for n in names):
+        raise ValueError(f"{p} names must be a list of strings")
+    return tuple(names)
 COCO_CLASSES = (
     "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train",
     "truck", "boat", "traffic light", "fire hydrant", "stop sign",

--- a/star-ros2/src/star_perception/star_perception/hailo_runner.py
+++ b/star-ros2/src/star_perception/star_perception/hailo_runner.py
@@ -1,0 +1,390 @@
+"""
+HailoRT wrapper for YOLOv8 inference on the Hailo-8L NPU.
+
+This module is intentionally ROS2-free so the letterbox / de-letterbox /
+NMS-decode math can be unit-tested on any host without an NPU. The
+hailort import is lazy and the constructor accepts an injectable
+inference backend; tests substitute a fake backend.
+
+The YOLOv8 .hef from the Hailo Model Zoo runs NMS on-chip and emits
+per-class detections in normalized [0, 1] coordinates of the 640x640
+letterboxed input. This wrapper:
+
+  1. Letterbox-resizes the source RGB image to 640x640 with grey padding,
+     remembering the scale and padding offsets.
+  2. Runs the HEF (or the injected backend).
+  3. Filters detections by score, removes the letterbox padding, and
+     scales back to source-image pixel coordinates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+
+
+YOLOV8_INPUT_SIZE = 640
+LETTERBOX_PAD_VALUE = 114  # YOLOv8 convention (mid-grey).
+COCO_CLASSES = (
+    "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train",
+    "truck", "boat", "traffic light", "fire hydrant", "stop sign",
+    "parking meter", "bench", "bird", "cat", "dog", "horse", "sheep",
+    "cow", "elephant", "bear", "zebra", "giraffe", "backpack", "umbrella",
+    "handbag", "tie", "suitcase", "frisbee", "skis", "snowboard",
+    "sports ball", "kite", "baseball bat", "baseball glove", "skateboard",
+    "surfboard", "tennis racket", "bottle", "wine glass", "cup", "fork",
+    "knife", "spoon", "bowl", "banana", "apple", "sandwich", "orange",
+    "broccoli", "carrot", "hot dog", "pizza", "donut", "cake", "chair",
+    "couch", "potted plant", "bed", "dining table", "toilet", "tv",
+    "laptop", "mouse", "remote", "keyboard", "cell phone", "microwave",
+    "oven", "toaster", "sink", "refrigerator", "book", "clock", "vase",
+    "scissors", "teddy bear", "hair drier", "toothbrush",
+)
+
+
+@dataclass(frozen=True)
+class Detection:
+    """A single 2D detection in source-image pixel coordinates."""
+
+    class_id: int
+    class_name: str
+    score: float
+    x_min: float
+    y_min: float
+    x_max: float
+    y_max: float
+
+    @property
+    def width(self) -> float:
+        return self.x_max - self.x_min
+
+    @property
+    def height(self) -> float:
+        return self.y_max - self.y_min
+
+    @property
+    def cx(self) -> float:
+        return 0.5 * (self.x_min + self.x_max)
+
+    @property
+    def cy(self) -> float:
+        return 0.5 * (self.y_min + self.y_max)
+
+
+@dataclass(frozen=True)
+class LetterboxParams:
+    """Geometry of a letterbox transform from source HxW to target SxS."""
+
+    src_h: int
+    src_w: int
+    target: int
+    scale: float
+    pad_x: int
+    pad_y: int
+
+
+def compute_letterbox(src_h: int, src_w: int,
+                      target: int = YOLOV8_INPUT_SIZE) -> LetterboxParams:
+    """Compute scale + padding to fit src into a square target canvas."""
+    if src_h <= 0 or src_w <= 0:
+        raise ValueError("Source dimensions must be positive.")
+    scale = float(target) / float(max(src_h, src_w))
+    new_h = int(round(src_h * scale))
+    new_w = int(round(src_w * scale))
+    pad_x = (target - new_w) // 2
+    pad_y = (target - new_h) // 2
+    return LetterboxParams(
+        src_h=src_h, src_w=src_w, target=target,
+        scale=scale, pad_x=pad_x, pad_y=pad_y,
+    )
+
+
+def letterbox_image(rgb: np.ndarray,
+                    params: LetterboxParams) -> np.ndarray:
+    """
+    Resize and pad rgb into params.target x params.target uint8 RGB.
+
+    Uses nearest-neighbour resize via numpy (avoids cv2 dependency in
+    the unit tests). Production callers may swap this for cv2.resize
+    with INTER_LINEAR for better quality, at the cost of a runtime dep.
+    """
+    if rgb.ndim != 3 or rgb.shape[2] != 3:
+        raise ValueError("Expected HxWx3 RGB image.")
+    if rgb.dtype != np.uint8:
+        raise ValueError("Expected uint8 RGB image.")
+    src_h, src_w = rgb.shape[:2]
+    if src_h != params.src_h or src_w != params.src_w:
+        raise ValueError("Image shape does not match letterbox params.")
+
+    new_h = int(round(src_h * params.scale))
+    new_w = int(round(src_w * params.scale))
+    # Nearest-neighbour resize via index lookup (no cv2 dep).
+    row_idx = (np.arange(new_h) / params.scale).astype(np.int32)
+    col_idx = (np.arange(new_w) / params.scale).astype(np.int32)
+    row_idx = np.clip(row_idx, 0, src_h - 1)
+    col_idx = np.clip(col_idx, 0, src_w - 1)
+    resized = rgb[row_idx][:, col_idx]
+
+    canvas = np.full(
+        (params.target, params.target, 3),
+        LETTERBOX_PAD_VALUE,
+        dtype=np.uint8,
+    )
+    canvas[params.pad_y:params.pad_y + new_h,
+           params.pad_x:params.pad_x + new_w] = resized
+    return canvas
+
+
+def deletterbox_bbox(x_min: float, y_min: float,
+                     x_max: float, y_max: float,
+                     params: LetterboxParams) -> tuple[float, float,
+                                                      float, float]:
+    """
+    Map a bbox in [0,1] coords of the letterboxed canvas back to the
+    source image's pixel coordinates.
+
+    Inputs are normalized to params.target (i.e. multiply by target to
+    get canvas pixels). Outputs are clamped to [0, src_w-1] / [0, src_h-1].
+    """
+    t = float(params.target)
+    cx_min = x_min * t - params.pad_x
+    cx_max = x_max * t - params.pad_x
+    cy_min = y_min * t - params.pad_y
+    cy_max = y_max * t - params.pad_y
+
+    sx_min = cx_min / params.scale
+    sx_max = cx_max / params.scale
+    sy_min = cy_min / params.scale
+    sy_max = cy_max / params.scale
+
+    sx_min = float(np.clip(sx_min, 0.0, params.src_w - 1))
+    sx_max = float(np.clip(sx_max, 0.0, params.src_w - 1))
+    sy_min = float(np.clip(sy_min, 0.0, params.src_h - 1))
+    sy_max = float(np.clip(sy_max, 0.0, params.src_h - 1))
+    return sx_min, sy_min, sx_max, sy_max
+
+
+# Type of an inference backend: takes uint8 (1, H, W, 3) or (H, W, 3)
+# and returns a list of (class_id, score, x_min_n, y_min_n, x_max_n,
+# y_max_n) tuples in normalized [0, 1] canvas coordinates. This shape
+# matches the post-NMS output of the Hailo Model Zoo YOLOv8 .hef.
+InferenceBackend = Callable[[np.ndarray],
+                            list[tuple[int, float, float, float,
+                                       float, float]]]
+
+
+class HailoYoloRunner:
+    """
+    Pre + post-processing wrapper around a Hailo YOLOv8 .hef.
+
+    The actual NPU call is delegated to a backend so this class can be
+    constructed in unit tests with a fake. The default constructor
+    builds the real HailoRT backend from an .hef path; the static
+    `with_backend` constructor accepts an injected callable.
+    """
+
+    def __init__(self,
+                 hef_path: str | Path,
+                 score_threshold: float = 0.35,
+                 input_size: int = YOLOV8_INPUT_SIZE,
+                 class_names: tuple[str, ...] = COCO_CLASSES,
+                 backend: Optional[InferenceBackend] = None) -> None:
+        if input_size <= 0:
+            raise ValueError("input_size must be positive.")
+        if not (0.0 < score_threshold < 1.0):
+            raise ValueError("score_threshold must be in (0, 1).")
+        self._input_size = int(input_size)
+        self._score_threshold = float(score_threshold)
+        self._class_names = tuple(class_names)
+        self._hef_path = Path(hef_path)
+        self._backend = backend if backend is not None else \
+            self._build_default_backend(self._hef_path, self._input_size)
+
+    @classmethod
+    def with_backend(cls, backend: InferenceBackend,
+                     score_threshold: float = 0.35,
+                     input_size: int = YOLOV8_INPUT_SIZE,
+                     class_names: tuple[str, ...] = COCO_CLASSES
+                     ) -> "HailoYoloRunner":
+        """Construct a runner with a pre-built backend (test seam)."""
+        return cls(
+            hef_path=Path("/dev/null"),
+            score_threshold=score_threshold,
+            input_size=input_size,
+            class_names=class_names,
+            backend=backend,
+        )
+
+    def infer(self, rgb_image: np.ndarray) -> list[Detection]:
+        """
+        Run inference on an HxWx3 uint8 RGB image.
+
+        Returns detections in source-image pixel coordinates, filtered
+        by `score_threshold`, sorted by score descending.
+        """
+        if rgb_image.ndim != 3 or rgb_image.shape[2] != 3:
+            raise ValueError("Expected HxWx3 RGB image.")
+        if rgb_image.dtype != np.uint8:
+            raise ValueError("Expected uint8 RGB image.")
+
+        params = compute_letterbox(rgb_image.shape[0], rgb_image.shape[1],
+                                   self._input_size)
+        canvas = letterbox_image(rgb_image, params)
+        raw = self._backend(canvas)
+
+        detections: list[Detection] = []
+        for class_id, score, xn0, yn0, xn1, yn1 in raw:
+            if score < self._score_threshold:
+                continue
+            x_min, y_min, x_max, y_max = deletterbox_bbox(
+                xn0, yn0, xn1, yn1, params,
+            )
+            if x_max <= x_min or y_max <= y_min:
+                continue
+            name = self._class_names[class_id] \
+                if 0 <= class_id < len(self._class_names) \
+                else f"class_{class_id}"
+            detections.append(Detection(
+                class_id=int(class_id),
+                class_name=name,
+                score=float(score),
+                x_min=x_min, y_min=y_min,
+                x_max=x_max, y_max=y_max,
+            ))
+        detections.sort(key=lambda d: d.score, reverse=True)
+        return detections
+
+    @staticmethod
+    def _build_default_backend(hef_path: Path,
+                               input_size: int) -> InferenceBackend:
+        """
+        Lazily construct the HailoRT backend.
+
+        Imports are inside the function so that test environments
+        without hailort installed can still import this module.
+        """
+        try:
+            import hailo_platform as hp
+        except ImportError as exc:  # pragma: no cover - hardware path
+            raise RuntimeError(
+                "hailo_platform is not installed. On the Pi 5, run "
+                "`sudo apt install hailo-all` and reboot.") from exc
+
+        if not hef_path.exists():
+            raise FileNotFoundError(
+                f"HEF not found at {hef_path}. Run "
+                "scripts/download_yolov8s_hef.sh on the Pi 5.")
+
+        hef = hp.HEF(str(hef_path))
+        target = hp.VDevice()
+        configure_params = hp.ConfigureParams.create_from_hef(
+            hef=hef, interface=hp.HailoStreamInterface.PCIe,
+        )
+        network_group = target.configure(hef, configure_params)[0]
+        ng_params = network_group.create_params()
+        input_vstreams_params = hp.InputVStreamParams.make(
+            network_group, format_type=hp.FormatType.UINT8,
+        )
+        output_vstreams_params = hp.OutputVStreamParams.make(
+            network_group, format_type=hp.FormatType.FLOAT32,
+        )
+        input_info = hef.get_input_vstream_infos()[0]
+
+        def backend(canvas: np.ndarray) -> list[tuple[int, float, float,
+                                                      float, float, float]]:
+            with network_group.activate(ng_params):
+                with hp.InferVStreams(network_group,
+                                      input_vstreams_params,
+                                      output_vstreams_params) as pipeline:
+                    feed = {input_info.name: np.expand_dims(canvas, axis=0)}
+                    outputs = pipeline.infer(feed)
+            return _decode_hailo_yolov8_output(outputs, input_size)
+
+        return backend
+
+
+def _decode_hailo_yolov8_output(outputs: dict, input_size: int
+                                ) -> list[tuple[int, float, float,
+                                                float, float, float]]:
+    """
+    Decode the post-NMS output of the Hailo Model Zoo YOLOv8 .hef.
+
+    The HEF emits per-class detection arrays. The shape convention used
+    by the Hailo zoo's YOLOv8 NMS post-processor is one array per class,
+    each of shape (max_dets_per_class, 5) holding (y_min, x_min, y_max,
+    x_max, score) in normalized [0, 1] coordinates. We re-emit as
+    (class_id, score, x_min, y_min, x_max, y_max).
+    """
+    decoded: list[tuple[int, float, float, float, float, float]] = []
+    if not outputs:
+        return decoded
+    name = next(iter(outputs))
+    arr = outputs[name]
+    if arr.ndim == 4 and arr.shape[0] == 1:
+        arr = arr[0]
+    # arr shape now: (num_classes, max_dets, 5) or list-of-arrays.
+    if isinstance(arr, list):
+        per_class = arr
+    else:
+        per_class = list(arr)
+    for class_id, dets in enumerate(per_class):
+        if dets is None or len(dets) == 0:
+            continue
+        for det in dets:
+            if len(det) < 5:
+                continue
+            y_min, x_min, y_max, x_max, score = (
+                float(det[0]), float(det[1]), float(det[2]),
+                float(det[3]), float(det[4]),
+            )
+            if score <= 0.0:
+                continue
+            decoded.append(
+                (int(class_id), score, x_min, y_min, x_max, y_max)
+            )
+    return decoded
+
+
+def _cli() -> None:  # pragma: no cover - manual smoke test
+    """Smoke-test entrypoint: load HEF, infer on an image, print FPS."""
+    parser = argparse.ArgumentParser(description="Hailo YOLO smoke test.")
+    parser.add_argument("--hef", required=True, help="Path to .hef file.")
+    parser.add_argument("--image", required=True, help="Path to RGB image.")
+    parser.add_argument("--iters", type=int, default=50,
+                        help="Inference iterations for FPS.")
+    parser.add_argument("--score", type=float, default=0.35)
+    args = parser.parse_args()
+
+    try:
+        import cv2
+    except ImportError as exc:
+        raise SystemExit("opencv-python is required for the CLI.") from exc
+
+    bgr = cv2.imread(args.image)
+    if bgr is None:
+        raise SystemExit(f"Could not read image {args.image}.")
+    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+
+    runner = HailoYoloRunner(args.hef, score_threshold=args.score)
+    detections = runner.infer(rgb)
+    print(f"First-pass detections: {len(detections)}")
+    for d in detections[:10]:
+        print(f"  {d.class_name:>14} {d.score:.2f} "
+              f"[{d.x_min:.0f},{d.y_min:.0f},"
+              f"{d.x_max:.0f},{d.y_max:.0f}]")
+
+    t0 = time.perf_counter()
+    for _ in range(args.iters):
+        runner.infer(rgb)
+    elapsed = time.perf_counter() - t0
+    fps = args.iters / elapsed if elapsed > 0 else 0.0
+    print(f"FPS over {args.iters} iters: {fps:.1f}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    _cli()

--- a/star-ros2/src/star_perception/star_perception/hailo_runner.py
+++ b/star-ros2/src/star_perception/star_perception/hailo_runner.py
@@ -298,7 +298,7 @@ class HailoYoloRunner:
         On Raspberry Pi OS Bookworm (Python 3.11) `hailo_platform`
         imports in-process and we use the direct call path. On Ubuntu
         24.04 Noble (Python 3.12) HailoRT 4.20 ships only a cp311 wheel
-        — the direct import fails, so we fall back to a subprocess
+        -- the direct import fails, so we fall back to a subprocess
         bridge running under the Python 3.11 venv at
         `/home/star/hailo-venv/bin/python`.
         """

--- a/star-ros2/src/star_perception/star_perception/hailo_runner.py
+++ b/star-ros2/src/star_perception/star_perception/hailo_runner.py
@@ -20,6 +20,11 @@ letterboxed input. This wrapper:
 from __future__ import annotations
 
 import argparse
+import json
+import os
+import struct
+import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +35,7 @@ import numpy as np
 
 YOLOV8_INPUT_SIZE = 640
 LETTERBOX_PAD_VALUE = 114  # YOLOv8 convention (mid-grey).
+DEFAULT_WORKER_PYTHON = "/home/star/hailo-venv/bin/python"
 COCO_CLASSES = (
     "person", "bicycle", "car", "motorcycle", "airplane", "bus", "train",
     "truck", "boat", "traffic light", "fire hydrant", "stop sign",
@@ -263,49 +269,142 @@ class HailoYoloRunner:
     def _build_default_backend(hef_path: Path,
                                input_size: int) -> InferenceBackend:
         """
-        Lazily construct the HailoRT backend.
+        Construct the HailoRT backend.
 
-        Imports are inside the function so that test environments
-        without hailort installed can still import this module.
+        On Raspberry Pi OS Bookworm (Python 3.11) `hailo_platform`
+        imports in-process and we use the direct call path. On Ubuntu
+        24.04 Noble (Python 3.12) HailoRT 4.20 ships only a cp311 wheel
+        — the direct import fails, so we fall back to a subprocess
+        bridge running under the Python 3.11 venv at
+        `/home/star/hailo-venv/bin/python`.
         """
-        try:
-            import hailo_platform as hp
-        except ImportError as exc:  # pragma: no cover - hardware path
-            raise RuntimeError(
-                "hailo_platform is not installed. On the Pi 5, run "
-                "`sudo apt install hailo-all` and reboot.") from exc
-
         if not hef_path.exists():
             raise FileNotFoundError(
                 f"HEF not found at {hef_path}. Run "
                 "scripts/download_yolov8s_hef.sh on the Pi 5.")
 
-        hef = hp.HEF(str(hef_path))
-        target = hp.VDevice()
-        configure_params = hp.ConfigureParams.create_from_hef(
-            hef=hef, interface=hp.HailoStreamInterface.PCIe,
-        )
-        network_group = target.configure(hef, configure_params)[0]
-        ng_params = network_group.create_params()
-        input_vstreams_params = hp.InputVStreamParams.make(
-            network_group, format_type=hp.FormatType.UINT8,
-        )
-        output_vstreams_params = hp.OutputVStreamParams.make(
-            network_group, format_type=hp.FormatType.FLOAT32,
-        )
-        input_info = hef.get_input_vstream_infos()[0]
+        try:
+            return _build_inprocess_backend(hef_path, input_size)
+        except ImportError:
+            return _build_subprocess_backend(hef_path, input_size)
 
-        def backend(canvas: np.ndarray) -> list[tuple[int, float, float,
-                                                      float, float, float]]:
-            with network_group.activate(ng_params):
-                with hp.InferVStreams(network_group,
-                                      input_vstreams_params,
-                                      output_vstreams_params) as pipeline:
-                    feed = {input_info.name: np.expand_dims(canvas, axis=0)}
-                    outputs = pipeline.infer(feed)
-            return _decode_hailo_yolov8_output(outputs, input_size)
 
-        return backend
+def _build_inprocess_backend(hef_path: Path, input_size: int
+                             ) -> InferenceBackend:
+    """Direct in-process HailoRT backend. Requires hailo_platform to be
+    importable under the current interpreter."""
+    import hailo_platform as hp  # noqa: raises ImportError -> caller catches
+
+    hef = hp.HEF(str(hef_path))
+    target = hp.VDevice()
+    configure_params = hp.ConfigureParams.create_from_hef(
+        hef=hef, interface=hp.HailoStreamInterface.PCIe,
+    )
+    network_group = target.configure(hef, configure_params)[0]
+    ng_params = network_group.create_params()
+    input_vstreams_params = hp.InputVStreamParams.make(
+        network_group, format_type=hp.FormatType.UINT8,
+    )
+    output_vstreams_params = hp.OutputVStreamParams.make(
+        network_group, format_type=hp.FormatType.FLOAT32,
+    )
+    input_info = hef.get_input_vstream_infos()[0]
+
+    def backend(canvas: np.ndarray) -> list[tuple[int, float, float,
+                                                  float, float, float]]:
+        with network_group.activate(ng_params):
+            with hp.InferVStreams(network_group,
+                                  input_vstreams_params,
+                                  output_vstreams_params) as pipeline:
+                feed = {input_info.name: np.expand_dims(canvas, axis=0)}
+                outputs = pipeline.infer(feed)
+        return _decode_hailo_yolov8_output(outputs, input_size)
+
+    return backend
+
+
+def _build_subprocess_backend(hef_path: Path, input_size: int,
+                              python_bin: str = DEFAULT_WORKER_PYTHON
+                              ) -> InferenceBackend:
+    """Subprocess-bridge backend for Python 3.12 hosts where
+    `hailo_platform` is only available under a Python 3.11 venv.
+
+    Spawns a long-lived worker (`_hailo_worker.py`) under `python_bin`
+    and talks to it via length-prefixed binary frames + JSON responses
+    over stdin/stdout. Dead worker restarts lazily on the next call.
+    """
+    worker_script = Path(__file__).parent / "_hailo_worker.py"
+    if not worker_script.exists():
+        raise RuntimeError(
+            f"hailo worker script missing at {worker_script}. "
+            "Rebuild the star_perception package.")
+    if not Path(python_bin).exists():
+        raise RuntimeError(
+            f"Hailo worker python {python_bin} not found. On Ubuntu 24.04 "
+            "create the venv per scripts/install_hailo_stack.sh.")
+
+    state = {"proc": None, "lock": threading.Lock()}
+
+    def _spawn() -> subprocess.Popen:
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)  # don't leak ROS2's 3.12 paths into 3.11
+        proc = subprocess.Popen(
+            [python_bin, str(worker_script),
+             "--hef", str(hef_path),
+             "--input-size", str(input_size)],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, bufsize=0, env=env,
+        )
+        hello_len_raw = proc.stdout.read(4)
+        if len(hello_len_raw) != 4:
+            err = proc.stderr.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"hailo worker handshake failed: {err}")
+        hello_len = struct.unpack(">I", hello_len_raw)[0]
+        hello = json.loads(proc.stdout.read(hello_len))
+        if hello.get("status") != "ready":
+            raise RuntimeError(f"hailo worker refused: {hello}")
+        return proc
+
+    def _ensure_alive() -> subprocess.Popen:
+        proc = state["proc"]
+        if proc is None or proc.poll() is not None:
+            proc = _spawn()
+            state["proc"] = proc
+        return proc
+
+    def backend(canvas: np.ndarray) -> list[tuple[int, float, float,
+                                                  float, float, float]]:
+        arr = np.ascontiguousarray(canvas, dtype=np.uint8)
+        expected = (input_size, input_size, 3)
+        if arr.shape != expected:
+            raise ValueError(
+                f"expected canvas shape {expected}, got {arr.shape}")
+        payload = arr.tobytes()
+        header = struct.pack(">I", len(payload))
+        with state["lock"]:
+            proc = _ensure_alive()
+            try:
+                proc.stdin.write(header + payload)
+                proc.stdin.flush()
+                resp_len_raw = proc.stdout.read(4)
+                if len(resp_len_raw) != 4:
+                    raise BrokenPipeError("worker closed stdout")
+                resp_len = struct.unpack(">I", resp_len_raw)[0]
+                resp_raw = proc.stdout.read(resp_len)
+            except (BrokenPipeError, OSError) as exc:
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+                state["proc"] = None
+                raise RuntimeError(f"hailo worker IO failed: {exc}")
+        resp = json.loads(resp_raw)
+        if "error" in resp:
+            err_msg = resp['error']
+            raise RuntimeError(f"hailo worker inference failed: {err_msg}")
+        return [tuple(d) for d in resp.get("detections", [])]
+
+    return backend
 
 
 def _decode_hailo_yolov8_output(outputs: dict, input_size: int

--- a/star-ros2/src/star_perception/star_perception/hailo_yolo_node.py
+++ b/star-ros2/src/star_perception/star_perception/hailo_yolo_node.py
@@ -1,0 +1,275 @@
+"""
+Hailo-8L YOLOv8 inference node.
+
+Subscribes to:
+  /cam0/camera/image_rect_color   sensor_msgs/Image (RGB8, rectified)
+
+Publishes:
+  /perception/detections_2d   vision_msgs/Detection2DArray
+  /perception/image_overlay   sensor_msgs/Image  (debug, only if
+                              `publish_overlay` parameter is true)
+
+Parameters:
+  hef_path          Absolute path to the YOLOv8 .hef. Defaults to
+                    `<share>/star_perception/models/yolov8s_h8l.hef`
+                    -- override on the Pi 5 if installed elsewhere.
+  score_threshold   Drop detections below this score. Default 0.35.
+  target_fps        Soft cap. Frames arriving faster than this are
+                    dropped at the subscriber so the NPU is not
+                    saturated. Default 15.0 (matches cam0 capture).
+  publish_overlay   Publish a debug image with bbox overlays. Default
+                    false (saves CPU; enable for tuning sessions).
+  class_filter      Optional list of class names to keep; empty list
+                    means all 80 COCO classes. Default empty.
+
+Runtime disable:
+  Parameter `enabled` (default true) -- toggle live to short-circuit
+  inference without tearing down the node.
+
+The node reads `header.stamp` from the incoming Image and copies it to
+the outgoing Detection2DArray, so the 3D fusion node downstream can
+ApproximateTimeSync against `/stereo/disparity` correctly.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+
+from sensor_msgs.msg import Image
+from vision_msgs.msg import (
+    BoundingBox2D,
+    Detection2D,
+    Detection2DArray,
+    ObjectHypothesisWithPose,
+)
+
+from star_perception.hailo_runner import (
+    Detection,
+    HailoYoloRunner,
+)
+
+
+DEFAULT_TARGET_FPS = 15.0
+DEFAULT_SCORE_THRESHOLD = 0.35
+INPUT_TOPIC = "/cam0/camera/image_rect_color"
+DETECTIONS_TOPIC = "/perception/detections_2d"
+OVERLAY_TOPIC = "/perception/image_overlay"
+
+
+def _default_hef_path() -> str:
+    """Look for the .hef under the installed package share directory."""
+    try:
+        from ament_index_python.packages import get_package_share_directory
+        share = get_package_share_directory("star_perception")
+        candidate = Path(share) / "models" / "yolov8s_h8l.hef"
+        if candidate.exists():
+            return str(candidate)
+    except Exception:  # pragma: no cover - ament missing in tests
+        pass
+    # Fallback to source-tree path (development workflow).
+    return str(Path(__file__).resolve().parents[1] /
+               "models" / "yolov8s_h8l.hef")
+
+
+class HailoYoloNode(Node):
+
+    def __init__(self) -> None:
+        super().__init__("star_hailo_yolo_node")
+
+        self.declare_parameter("enabled", True)
+        self.declare_parameter("hef_path", _default_hef_path())
+        self.declare_parameter("score_threshold", DEFAULT_SCORE_THRESHOLD)
+        self.declare_parameter("target_fps", DEFAULT_TARGET_FPS)
+        self.declare_parameter("publish_overlay", False)
+        self.declare_parameter("class_filter", [])
+
+        self._min_period_sec = 1.0 / max(
+            float(self.get_parameter("target_fps").value), 0.1)
+        self._last_infer_sec: float = 0.0
+        self._first_inference_logged = False
+        self._infer_count = 0
+
+        self._runner: HailoYoloRunner | None = None
+        self._cv_bridge = self._import_cv_bridge()
+
+        self._class_filter = set(
+            self.get_parameter("class_filter").value or []
+        )
+
+        qos_image = QoSProfile(
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.VOLATILE,
+            depth=2,
+        )
+        self._sub = self.create_subscription(
+            Image, INPUT_TOPIC, self._on_image, qos_image,
+        )
+        self._pub_dets = self.create_publisher(
+            Detection2DArray, DETECTIONS_TOPIC, 10,
+        )
+        self._pub_overlay = self.create_publisher(
+            Image, OVERLAY_TOPIC, 1,
+        )
+
+        self.get_logger().info(
+            f"star_hailo_yolo_node ready. HEF="
+            f"{self.get_parameter('hef_path').value}, "
+            f"threshold={self.get_parameter('score_threshold').value}, "
+            f"target_fps={self.get_parameter('target_fps').value}."
+        )
+
+    # ------------------------------------------------------------------
+
+    def _import_cv_bridge(self):
+        """Lazy cv_bridge import; returns the CvBridge instance or None."""
+        try:
+            from cv_bridge import CvBridge
+            return CvBridge()
+        except ImportError:  # pragma: no cover
+            self.get_logger().warn(
+                "cv_bridge not available; node will not function.")
+            return None
+
+    def _ensure_runner(self) -> HailoYoloRunner | None:
+        if self._runner is not None:
+            return self._runner
+        hef = str(self.get_parameter("hef_path").value)
+        threshold = float(self.get_parameter("score_threshold").value)
+        try:
+            self._runner = HailoYoloRunner(
+                hef_path=hef, score_threshold=threshold,
+            )
+        except Exception as exc:
+            self.get_logger().error(
+                f"Failed to initialise HailoYoloRunner: {exc}")
+            self._runner = None
+        return self._runner
+
+    # ------------------------------------------------------------------
+
+    def _on_image(self, msg: Image) -> None:
+        if not self.get_parameter("enabled").value:
+            return
+        if self._cv_bridge is None:
+            return
+
+        now = self.get_clock().now().nanoseconds * 1e-9
+        if now - self._last_infer_sec < self._min_period_sec:
+            return  # Soft FPS cap.
+        self._last_infer_sec = now
+
+        runner = self._ensure_runner()
+        if runner is None:
+            return
+
+        try:
+            rgb = self._cv_bridge.imgmsg_to_cv2(msg, desired_encoding="rgb8")
+        except Exception as exc:  # pragma: no cover
+            self.get_logger().warn(f"cv_bridge convert failed: {exc}")
+            return
+
+        t0 = time.perf_counter()
+        try:
+            detections = runner.infer(rgb)
+        except Exception as exc:
+            self.get_logger().error(f"HEF inference failed: {exc}")
+            return
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+
+        if self._class_filter:
+            detections = [d for d in detections
+                          if d.class_name in self._class_filter]
+
+        self._publish_detections(detections, msg)
+        if bool(self.get_parameter("publish_overlay").value):
+            self._publish_overlay(rgb, detections, msg)
+
+        self._infer_count += 1
+        if not self._first_inference_logged:
+            self.get_logger().info(
+                f"First inference: {elapsed_ms:.1f} ms, "
+                f"{len(detections)} detections.")
+            self._first_inference_logged = True
+        elif self._infer_count % 30 == 0:
+            self.get_logger().debug(
+                f"Inference {self._infer_count}: {elapsed_ms:.1f} ms, "
+                f"{len(detections)} detections.")
+
+    # ------------------------------------------------------------------
+
+    def _publish_detections(self,
+                            detections: list[Detection],
+                            source: Image) -> None:
+        arr = Detection2DArray()
+        arr.header.stamp = source.header.stamp
+        arr.header.frame_id = source.header.frame_id or "cam0_optical_frame"
+
+        for det in detections:
+            d2d = Detection2D()
+            d2d.header = arr.header
+
+            bbox = BoundingBox2D()
+            bbox.center.position.x = det.cx
+            bbox.center.position.y = det.cy
+            bbox.center.theta = 0.0
+            bbox.size_x = det.width
+            bbox.size_y = det.height
+            d2d.bbox = bbox
+
+            hyp = ObjectHypothesisWithPose()
+            hyp.hypothesis.class_id = det.class_name
+            hyp.hypothesis.score = float(det.score)
+            d2d.results.append(hyp)
+
+            arr.detections.append(d2d)
+
+        self._pub_dets.publish(arr)
+
+    def _publish_overlay(self,
+                         rgb,
+                         detections: list[Detection],
+                         source: Image) -> None:
+        try:
+            import cv2
+        except ImportError:  # pragma: no cover
+            return
+        overlay = rgb.copy()
+        for d in detections:
+            p1 = (int(d.x_min), int(d.y_min))
+            p2 = (int(d.x_max), int(d.y_max))
+            cv2.rectangle(overlay, p1, p2, (0, 255, 0), 2)
+            label = f"{d.class_name} {d.score:.2f}"
+            cv2.putText(overlay, label, (p1[0], max(15, p1[1] - 4)),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 255, 0), 1)
+        try:
+            out = self._cv_bridge.cv2_to_imgmsg(overlay, encoding="rgb8")
+            out.header = source.header
+            self._pub_overlay.publish(out)
+        except Exception as exc:  # pragma: no cover
+            self.get_logger().warn(f"overlay publish failed: {exc}")
+
+
+def main(args=None):  # pragma: no cover
+    rclpy.init(args=args)
+    node = HailoYoloNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/star-ros2/src/star_perception/star_perception/hailo_yolo_node.py
+++ b/star-ros2/src/star_perception/star_perception/hailo_yolo_node.py
@@ -44,6 +44,7 @@ from rclpy.qos import (
     QoSProfile,
     ReliabilityPolicy,
 )
+from rcl_interfaces.msg import ParameterDescriptor
 
 from sensor_msgs.msg import Image
 from vision_msgs.msg import (
@@ -54,8 +55,10 @@ from vision_msgs.msg import (
 )
 
 from star_perception.hailo_runner import (
+    COCO_CLASSES,
     Detection,
     HailoYoloRunner,
+    load_class_names,
 )
 
 
@@ -92,6 +95,17 @@ class HailoYoloNode(Node):
         self.declare_parameter("target_fps", DEFAULT_TARGET_FPS)
         self.declare_parameter("publish_overlay", False)
         self.declare_parameter("class_filter", [])
+        self.declare_parameter(
+            "classes_yaml", "",
+            descriptor=ParameterDescriptor(
+                description=(
+                    "Absolute path to a YAML file with a top-level "
+                    "`names:` list giving class names in HEF index "
+                    "order. Empty string -> use the built-in COCO 80 "
+                    "list. Point this at "
+                    "share/star_perception/models/oiv7_classes.yaml "
+                    "when running a yolov8n-oiv7.hef."
+                )))
 
         self._min_period_sec = 1.0 / max(
             float(self.get_parameter("target_fps").value), 0.1)
@@ -145,9 +159,23 @@ class HailoYoloNode(Node):
             return self._runner
         hef = str(self.get_parameter("hef_path").value)
         threshold = float(self.get_parameter("score_threshold").value)
+        classes_yaml = str(self.get_parameter("classes_yaml").value).strip()
+        class_names = COCO_CLASSES
+        if classes_yaml:
+            try:
+                class_names = load_class_names(classes_yaml)
+                self.get_logger().info(
+                    f"Loaded {len(class_names)} class names from "
+                    f"{classes_yaml}")
+            except Exception as exc:
+                self.get_logger().warn(
+                    f"Could not load classes_yaml={classes_yaml}: {exc}. "
+                    "Falling back to COCO 80.")
         try:
             self._runner = HailoYoloRunner(
-                hef_path=hef, score_threshold=threshold,
+                hef_path=hef,
+                score_threshold=threshold,
+                class_names=class_names,
             )
         except Exception as exc:
             self.get_logger().error(

--- a/star-ros2/src/star_perception/test/test_depth_fusion.py
+++ b/star-ros2/src/star_perception/test/test_depth_fusion.py
@@ -1,0 +1,205 @@
+"""Unit tests for the depth-fusion geometry helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from star_perception.depth_fusion import (
+    CameraIntrinsics,
+    Detection3D,
+    back_project_pixel,
+    depth_from_disparity,
+    fuse_bbox_to_3d,
+    median_disparity_in_bbox,
+)
+
+
+# A simple synthetic camera: 640x480 with fx=fy=500, principal point centred.
+_K = np.array([[500.0, 0.0, 320.0],
+               [0.0, 500.0, 240.0],
+               [0.0, 0.0, 1.0]])
+_INTR = CameraIntrinsics.from_k_matrix(_K)
+_FOCAL_PX = 500.0
+_BASELINE_M = 0.061  # Matches the IMX219-83 stereo rig.
+
+
+def test_intrinsics_from_k_matrix():
+    assert _INTR.fx == 500.0
+    assert _INTR.fy == 500.0
+    assert _INTR.cx == 320.0
+    assert _INTR.cy == 240.0
+
+
+def test_depth_from_disparity_known_value():
+    # Object at 2.5 m: d = f * T / Z = 500 * 0.061 / 2.5 = 12.2 px.
+    z = depth_from_disparity(12.2, _FOCAL_PX, _BASELINE_M)
+    assert z == pytest.approx(2.5, rel=1e-3)
+
+
+def test_depth_from_disparity_invalid_returns_nan():
+    assert np.isnan(depth_from_disparity(0.0, _FOCAL_PX, _BASELINE_M))
+    assert np.isnan(depth_from_disparity(-1.0, _FOCAL_PX, _BASELINE_M))
+
+
+def test_depth_from_disparity_validates_positive_focal_and_baseline():
+    with pytest.raises(ValueError):
+        depth_from_disparity(10.0, 0.0, _BASELINE_M)
+    with pytest.raises(ValueError):
+        depth_from_disparity(10.0, _FOCAL_PX, 0.0)
+
+
+def test_back_project_centre_pixel_at_known_depth():
+    # Pixel = principal point at z=3 m -> (0, 0, 3) in camera frame.
+    x, y, z = back_project_pixel(320.0, 240.0, 3.0, _INTR)
+    assert (x, y, z) == pytest.approx((0.0, 0.0, 3.0))
+
+
+def test_back_project_offset_pixel():
+    # Move 100 px right of cx at 2 m: X = 100 * 2 / 500 = 0.40 m.
+    x, y, _ = back_project_pixel(420.0, 240.0, 2.0, _INTR)
+    assert x == pytest.approx(0.40)
+    assert y == pytest.approx(0.0)
+
+
+def test_back_project_rejects_non_positive_depth():
+    with pytest.raises(ValueError):
+        back_project_pixel(100.0, 100.0, 0.0, _INTR)
+
+
+def test_median_disparity_uniform_roi():
+    disp = np.full((480, 640), 12.2, dtype=np.float32)
+    median, count = median_disparity_in_bbox(
+        disp, x_min=200, y_min=180, x_max=440, y_max=300,
+        border_pct=0.15,
+    )
+    assert median == pytest.approx(12.2)
+    assert count > 1000
+
+
+def test_median_disparity_ignores_invalid_values():
+    disp = np.full((480, 640), 12.2, dtype=np.float32)
+    # Salt the ROI with NaN, inf, and zero.
+    disp[200:220, 250:270] = np.nan
+    disp[220:240, 250:270] = np.inf
+    disp[240:260, 250:270] = 0.0
+    median, count = median_disparity_in_bbox(
+        disp, x_min=200, y_min=180, x_max=440, y_max=300,
+        border_pct=0.15,
+    )
+    assert median == pytest.approx(12.2)
+    # Count must exclude the salted samples.
+    assert count > 0
+
+
+def test_median_disparity_empty_roi_returns_nan():
+    disp = np.zeros((480, 640), dtype=np.float32)
+    median, count = median_disparity_in_bbox(
+        disp, x_min=0, y_min=0, x_max=10, y_max=10,
+        border_pct=0.15,
+    )
+    assert np.isnan(median)
+    assert count == 0
+
+
+def test_median_disparity_rejects_invalid_border_pct():
+    disp = np.zeros((10, 10), dtype=np.float32)
+    with pytest.raises(ValueError):
+        median_disparity_in_bbox(disp, 0, 0, 10, 10, border_pct=0.5)
+    with pytest.raises(ValueError):
+        median_disparity_in_bbox(disp, 0, 0, 10, 10, border_pct=-0.1)
+
+
+def test_median_disparity_rejects_non_2d():
+    with pytest.raises(ValueError):
+        median_disparity_in_bbox(
+            np.zeros((10, 10, 3), dtype=np.float32),
+            0, 0, 10, 10, border_pct=0.0,
+        )
+
+
+def test_fuse_bbox_to_3d_centred_object():
+    """
+    Synthetic scene: a uniform 12.2 px disparity patch in the centre of
+    a 480x640 disparity image. With f=500 and T=0.061 the patch sits at
+    Z = 2.5 m. A 200 x 100 px bbox centred on the principal point should
+    back-project to (0, 0, 2.5) with size (0.80, 0.40, ~0.05) m.
+    """
+    disp = np.full((480, 640), 12.2, dtype=np.float32)
+    out = fuse_bbox_to_3d(
+        disp, _INTR, _FOCAL_PX, _BASELINE_M,
+        class_id=0, class_name="person", score=0.9,
+        x_min=220, y_min=190, x_max=420, y_max=290,
+    )
+    assert out is not None
+    assert out.cx_m == pytest.approx(0.0, abs=0.02)
+    assert out.cy_m == pytest.approx(0.0, abs=0.02)
+    assert out.cz_m == pytest.approx(2.5, rel=1e-3)
+    assert out.size_x_m == pytest.approx(1.0, rel=0.02)  # 200 * 2.5 / 500
+    assert out.size_y_m == pytest.approx(0.5, rel=0.02)  # 100 * 2.5 / 500
+    # Uniform disparity -> tiny size_z_m, but clamped to >=0.05.
+    assert out.size_z_m >= 0.05
+
+
+def test_fuse_bbox_to_3d_offset_object():
+    """
+    A bbox shifted right of centre at known depth must produce a positive
+    cx_m equal to back-projection of its centre.
+    """
+    disp = np.full((480, 640), 12.2, dtype=np.float32)  # 2.5 m everywhere.
+    out = fuse_bbox_to_3d(
+        disp, _INTR, _FOCAL_PX, _BASELINE_M,
+        class_id=56, class_name="chair", score=0.7,
+        x_min=420, y_min=190, x_max=620, y_max=290,
+    )
+    assert out is not None
+    # Centre u = 520, dx = 200 px. X = 200 * 2.5 / 500 = 1.00 m.
+    assert out.cx_m == pytest.approx(1.0, abs=0.02)
+    assert out.cz_m == pytest.approx(2.5, rel=1e-3)
+
+
+def test_fuse_bbox_to_3d_drops_below_min_samples():
+    disp = np.full((480, 640), float("nan"), dtype=np.float32)
+    # Tiny patch of valid disparity.
+    disp[200:205, 200:205] = 12.2
+    out = fuse_bbox_to_3d(
+        disp, _INTR, _FOCAL_PX, _BASELINE_M,
+        class_id=0, class_name="person", score=0.9,
+        x_min=190, y_min=190, x_max=215, y_max=215,
+        min_valid_samples=100,
+    )
+    assert out is None
+
+
+def test_fuse_bbox_to_3d_drops_too_close():
+    # Disparity 200 px -> Z = 0.15 m -- below 0.20 m floor.
+    disp = np.full((480, 640), 200.0, dtype=np.float32)
+    out = fuse_bbox_to_3d(
+        disp, _INTR, _FOCAL_PX, _BASELINE_M,
+        class_id=0, class_name="person", score=0.9,
+        x_min=200, y_min=180, x_max=440, y_max=300,
+    )
+    assert out is None
+
+
+def test_fuse_bbox_to_3d_drops_too_far():
+    # Disparity 1 px -> Z = 30.5 m -- well beyond 6 m max.
+    disp = np.full((480, 640), 1.0, dtype=np.float32)
+    out = fuse_bbox_to_3d(
+        disp, _INTR, _FOCAL_PX, _BASELINE_M,
+        class_id=0, class_name="person", score=0.9,
+        x_min=200, y_min=180, x_max=440, y_max=300,
+    )
+    assert out is None
+
+
+def test_detection_3d_dataclass_round_trip():
+    d = Detection3D(
+        class_id=0, class_name="person", score=0.8,
+        cx_m=1.0, cy_m=0.0, cz_m=2.5,
+        size_x_m=0.5, size_y_m=1.7, size_z_m=0.3,
+        sample_count=200,
+    )
+    assert d.class_name == "person"
+    assert d.cz_m == 2.5
+    assert d.sample_count == 200

--- a/star-ros2/src/star_perception/test/test_hailo_runner.py
+++ b/star-ros2/src/star_perception/test/test_hailo_runner.py
@@ -1,0 +1,213 @@
+"""Unit tests for the Hailo runner pre/post-processing math."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from star_perception.hailo_runner import (
+    COCO_CLASSES,
+    Detection,
+    HailoYoloRunner,
+    LETTERBOX_PAD_VALUE,
+    YOLOV8_INPUT_SIZE,
+    compute_letterbox,
+    deletterbox_bbox,
+    letterbox_image,
+)
+
+
+# ---------------------------------------------------------------------------
+# Letterbox geometry
+# ---------------------------------------------------------------------------
+
+
+def test_letterbox_landscape_geometry():
+    p = compute_letterbox(src_h=480, src_w=640, target=640)
+    assert p.scale == pytest.approx(1.0)
+    assert p.pad_x == 0
+    assert p.pad_y == (640 - 480) // 2
+
+def test_letterbox_portrait_geometry():
+    p = compute_letterbox(src_h=800, src_w=600, target=640)
+    assert p.scale == pytest.approx(640.0 / 800.0)
+    new_w = int(round(600 * p.scale))
+    assert p.pad_x == (640 - new_w) // 2
+    assert p.pad_y == 0
+
+def test_letterbox_square_geometry():
+    p = compute_letterbox(src_h=512, src_w=512, target=640)
+    assert p.scale == pytest.approx(640.0 / 512.0)
+    assert p.pad_x == 0
+    assert p.pad_y == 0
+
+
+def test_letterbox_image_pads_with_grey():
+    src = np.full((100, 200, 3), 30, dtype=np.uint8)
+    p = compute_letterbox(100, 200, 640)
+    canvas = letterbox_image(src, p)
+    assert canvas.shape == (640, 640, 3)
+    assert canvas.dtype == np.uint8
+    # Corner pixel must be the letterbox padding value.
+    assert int(canvas[0, 0, 0]) == LETTERBOX_PAD_VALUE
+    # Centre pixel of resized image content must be the source colour.
+    cy = p.pad_y + (int(round(100 * p.scale)) // 2)
+    cx = p.pad_x + (int(round(200 * p.scale)) // 2)
+    assert int(canvas[cy, cx, 0]) == 30
+
+
+def test_letterbox_image_rejects_wrong_dtype():
+    bad = np.zeros((100, 100, 3), dtype=np.float32)
+    p = compute_letterbox(100, 100, 640)
+    with pytest.raises(ValueError):
+        letterbox_image(bad, p)
+
+
+def test_letterbox_image_rejects_shape_mismatch():
+    src = np.zeros((100, 100, 3), dtype=np.uint8)
+    p = compute_letterbox(50, 50, 640)
+    with pytest.raises(ValueError):
+        letterbox_image(src, p)
+
+
+# ---------------------------------------------------------------------------
+# De-letterbox round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_deletterbox_round_trip_identity():
+    """A bbox covering the whole content area must map back to source."""
+    p = compute_letterbox(480, 640, 640)
+    # In letterboxed canvas, content occupies the central 480 rows.
+    t = float(p.target)
+    yn0 = p.pad_y / t
+    yn1 = (p.pad_y + 480) / t
+    x0, y0, x1, y1 = deletterbox_bbox(0.0, yn0, 1.0, yn1, p)
+    assert x0 == pytest.approx(0.0)
+    assert y0 == pytest.approx(0.0, abs=1e-3)
+    assert x1 == pytest.approx(639.0)
+    assert y1 == pytest.approx(479.0, abs=1.0)
+
+
+def test_deletterbox_clamps_to_image_bounds():
+    p = compute_letterbox(480, 640, 640)
+    # Out-of-bounds normalized values must be clamped, not blow up.
+    x0, y0, x1, y1 = deletterbox_bbox(-0.5, -0.5, 1.5, 1.5, p)
+    assert x0 == 0.0 and y0 == 0.0
+    assert x1 == 639.0 and y1 == 479.0
+
+
+# ---------------------------------------------------------------------------
+# Runner with injected backend
+# ---------------------------------------------------------------------------
+
+
+def _make_backend(detections):
+    """Return a backend callable that always emits the given detections."""
+    def backend(_canvas):
+        return list(detections)
+    return backend
+
+
+def test_runner_filters_by_score_threshold():
+    backend = _make_backend([
+        (0, 0.50, 0.10, 0.10, 0.20, 0.20),  # person, kept
+        (16, 0.20, 0.30, 0.30, 0.40, 0.40),  # dog, dropped
+    ])
+    runner = HailoYoloRunner.with_backend(backend, score_threshold=0.35)
+    rgb = np.zeros((480, 640, 3), dtype=np.uint8)
+    out = runner.infer(rgb)
+    assert len(out) == 1
+    assert out[0].class_name == "person"
+
+
+def test_runner_sorts_by_score_descending():
+    backend = _make_backend([
+        (0, 0.50, 0.0, 0.0, 0.1, 0.1),
+        (0, 0.90, 0.0, 0.0, 0.1, 0.1),
+        (0, 0.70, 0.0, 0.0, 0.1, 0.1),
+    ])
+    runner = HailoYoloRunner.with_backend(backend, score_threshold=0.10)
+    rgb = np.zeros((480, 640, 3), dtype=np.uint8)
+    out = runner.infer(rgb)
+    scores = [d.score for d in out]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_runner_drops_zero_area_boxes():
+    backend = _make_backend([
+        (0, 0.99, 0.50, 0.50, 0.50, 0.50),  # zero area
+    ])
+    runner = HailoYoloRunner.with_backend(backend, score_threshold=0.10)
+    rgb = np.zeros((480, 640, 3), dtype=np.uint8)
+    assert runner.infer(rgb) == []
+
+
+def test_runner_maps_unknown_class_id_to_placeholder():
+    backend = _make_backend([
+        (999, 0.99, 0.10, 0.10, 0.20, 0.20),
+    ])
+    runner = HailoYoloRunner.with_backend(backend, score_threshold=0.10)
+    rgb = np.zeros((480, 640, 3), dtype=np.uint8)
+    out = runner.infer(rgb)
+    assert out[0].class_name.startswith("class_")
+
+
+def test_runner_rejects_invalid_score_threshold():
+    backend = _make_backend([])
+    with pytest.raises(ValueError):
+        HailoYoloRunner.with_backend(backend, score_threshold=0.0)
+    with pytest.raises(ValueError):
+        HailoYoloRunner.with_backend(backend, score_threshold=1.0)
+
+
+def test_runner_rejects_non_rgb_image():
+    backend = _make_backend([])
+    runner = HailoYoloRunner.with_backend(backend, score_threshold=0.10)
+    bad_grey = np.zeros((480, 640), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        runner.infer(bad_grey)
+
+
+def test_runner_known_geometry_round_trip():
+    """
+    Place a bbox at the centre 50 percent of the canvas and verify the
+    de-letterboxed coordinates land within +/- 1 pixel of the centre
+    50 percent of the source 480x640 image.
+    """
+    backend = _make_backend([
+        (0, 0.99, 0.25, 0.25, 0.75, 0.75),
+    ])
+    runner = HailoYoloRunner.with_backend(backend, score_threshold=0.10)
+    rgb = np.zeros((480, 640, 3), dtype=np.uint8)
+    [det] = runner.infer(rgb)
+    # Source 640 wide: 25% to 75% -> 160 to 480.
+    assert det.x_min == pytest.approx(160.0, abs=2.0)
+    assert det.x_max == pytest.approx(480.0, abs=2.0)
+    # Source 480 tall, with letterbox pad of (640-480)/2 = 80.
+    # Canvas y 0.25..0.75 -> pixel 160..480 -> source 80..400.
+    assert det.y_min == pytest.approx(80.0, abs=2.0)
+    assert det.y_max == pytest.approx(400.0, abs=2.0)
+
+
+def test_coco_classes_complete():
+    """Sanity: 80 COCO classes, person at index 0, chair at 56."""
+    assert len(COCO_CLASSES) == 80
+    assert COCO_CLASSES[0] == "person"
+    assert COCO_CLASSES[56] == "chair"
+
+
+def test_detection_geometry_helpers():
+    d = Detection(
+        class_id=0, class_name="person", score=0.8,
+        x_min=10.0, y_min=20.0, x_max=30.0, y_max=60.0,
+    )
+    assert d.width == 20.0
+    assert d.height == 40.0
+    assert d.cx == 20.0
+    assert d.cy == 40.0
+
+
+def test_yolov8_input_size_constant_is_640():
+    """The Hailo zoo YOLOv8 .hef is compiled for 640 x 640."""
+    assert YOLOV8_INPUT_SIZE == 640


### PR DESCRIPTION
## Summary
- New `star_perception` ROS2 package runs YOLOv8s on the Pi AI HAT+ 13 TOPS (Hailo-8L) against the existing `/cam0/camera/image_rect_color` feed and fuses 2D detections with `/stereo/disparity` to publish `vision_msgs/Detection3DArray` in `cam0_optical_frame` -- no new camera required.
- Compliance engine integration: `protruding_objects_node` and `dynamic_obstacle_node` now consume the YOLO 3D feed. Transient COCO classes (`person`, `chair`, `backpack`, ...) clear the ADA 307 `flagged_violation` so the audit doesn't penalise the building for someone walking through the cane zone during a scan; YOLO + LiDAR agreement raises dynamic-obstacle confidence to 1.0; YOLO-only `person` detections (e.g. behind glass) appear as `source = "yolo"` with confidence 0.6.
- `ProtrudingObject.msg` gains `class_label` + `class_confidence`; `DynamicObstacle.msg` gains `source` + `class_label` (per the project's no-backward-compatibility policy, all publishers/consumers updated in this PR). `slam.launch.py` brings up the perception pipeline behind a new `use_perception` arg (default true).

## Implementation notes
- `hailo_runner.py` is ROS2-free with an injectable inference backend so the letterbox / de-letterbox / NMS-decode math is unit-tested without an NPU. The default backend lazily imports `hailo_platform` and loads a `.hef` from the Hailo Model Zoo.
- `depth_fusion.py` extracts the 2D-bbox -> 3D-detection geometry into pure functions tested with synthetic disparity. The fusion node uses `message_filters.ApproximateTimeSynchronizer(slop=0.10s)` between detections and disparity, matching the existing stereo pipeline's sync convention.
- Recommended model is YOLOv8s (44.9 mAP@COCO, ~30 FPS on Hailo-8L). Indoor-relevant classes: person, chair, couch, dining table, potted plant, tv, laptop, book, bottle, backpack, handbag.
- `.hef` binaries are not committed to git; `scripts/install_hailo_stack.sh` installs `hailo-all` on the Pi 5 and `scripts/download_yolov8s_hef.sh` pulls the model from the Hailo Model Zoo into `models/`.

## Test plan
- [x] Unit tests pass: 36 new in `star_perception` (`pytest test/`), 11 new in `compliance-engine` (`pytest tests/test_yolo_fusion.py` + 6 added cane-zone cases). Existing 143-test suite passes unchanged (now 79 + 17 skipped in compliance-engine, was 68 + 17).
- [x] ASCII-only check: `python3 scripts/utils/fix-encoding.py --check` clean on every new and modified file.
- [ ] Pi 5 hardware bring-up: mount AI HAT+, run `scripts/install_hailo_stack.sh`, verify `hailortcli fw-control identify` reports `Device: Hailo-8L`.
- [ ] Standalone HEF inference: `python3 -m star_perception.hailo_runner --hef models/yolov8s_h8l.hef --image /tmp/coco.jpg` reports 25-35 FPS.
- [ ] Live ROS2 graph: `ros2 launch star_bringup slam.launch.py use_perception:=true`. Verify `/perception/detections_2d` ~15 Hz, `/perception/detections_3d` ~5-10 Hz, and an RViz cube tagged `person` lands within 0.20 m of tape-measured ground truth at 2 m range.
- [ ] Compliance integration: chair in cane zone -> `class_label = "chair"`, `flagged_violation = false`. Cardboard box taped to wall -> `flagged_violation = true`.
- [ ] Thermal: 5 minute run with full perception + SLAM + Nav2 keeps Pi 5 CPU below 80 percent (existing safety-net threshold) and SoC below 75 degrees C.
- Code review checklist:
  - [x] No magic numbers (typed-enum equivalents in Python: module constants for thresholds and offsets)
  - [x] Inclusive terminology (no master/slave references introduced)
  - [x] No AI attribution in commit or PR
  - [x] No backward-compatibility shims (message field additions break consumers as designed; all consumers updated in same PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional YOLOv8s perception pipeline (toggleable) producing 2D detections and fused 3D localizations with RViz markers and optional image overlays.
  * Detections now carry YOLO class labels and confidence scores.
  * Hailo-8L hardware acceleration support with configurable model path, score threshold, FPS, and sync settings.

* **Documentation**
  * Model setup guide and download/install helper scripts for perception runtime and models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->