### PR TITLE
Rename STAR acronym to Spatial Topography Accessibility Robot

### DIFF
--- a/.claude/agents/star-code-reviewer.md
+++ b/.claude/agents/star-code-reviewer.md
@@ -5,7 +5,7 @@ model: sonnet
 color: blue
 ---
 
-You are an elite embedded systems code reviewer specializing in safety-critical firmware for the STAR (Simultaneous Tracking and Robotics) project. Your expertise encompasses NASA Power of 10 rules, SOLID principles for C, and the STAR project's rigorous coding standards for Renesas RX72N firmware development.
+You are an elite embedded systems code reviewer specializing in safety-critical firmware for the STAR (Spatial Topography Accessibility Robot) project. Your expertise encompasses NASA Power of 10 rules, SOLID principles for C, and the STAR project's rigorous coding standards for Renesas RX72N firmware development.
 
 ## Your Core Mission
 

--- a/.github/agents.md
+++ b/.github/agents.md
@@ -2,7 +2,7 @@
 
 ## Quick Reference
 
-**STAR (Simultaneous Tracking and Robotics)** is a distributed robotics platform with custom PCB hardware, Renesas RX72N motor control firmware (ThreadX RTOS), Raspberry Pi 5 control system (ROS2 Jazzy), and Protocol Buffers communication over SPI.
+**STAR (Spatial Topography Accessibility Robot)** is a distributed robotics platform for autonomous indoor ADA-compliance auditing, with custom PCB hardware, Renesas RX72N motor control firmware (ThreadX RTOS), a Raspberry Pi 5 control system (ROS2 Jazzy), and Protocol Buffers communication over SPI.
 
 **System Architecture:**
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 ## Quick Reference
 
-**STAR (Simultaneous Tracking and Robotics)** is a distributed robotics platform with custom PCB hardware, Renesas RX72N motor control firmware (ThreadX RTOS), Raspberry Pi 5 control system (ROS2 Jazzy), and Protocol Buffers communication over SPI.
+**STAR (Spatial Topography Accessibility Robot)** is a distributed robotics platform for autonomous indoor ADA-compliance auditing, with custom PCB hardware, Renesas RX72N motor control firmware (ThreadX RTOS), a Raspberry Pi 5 control system (ROS2 Jazzy), and Protocol Buffers communication over SPI.
 
 **System Architecture:**
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ python3 scripts/utils/fix-encoding.py --check path/to/dir
 
 ## Project Overview
 
-**STAR (Simultaneous Tracking and Robotics)** - A distributed robotics platform with custom PCB hardware, Renesas RX72N motor control firmware, Raspberry Pi 5 control system, and Protocol Buffers communication.
+**STAR (Spatial Topography Accessibility Robot)** - A distributed robotics platform for autonomous indoor ADA-compliance auditing, with custom PCB hardware, Renesas RX72N motor control firmware, a Raspberry Pi 5 control system, and Protocol Buffers communication.
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # STAR
 
-**Simultaneous Tracking and Robotics** - A distributed robotics platform for autonomous mobile robots.
+**Spatial Topography Accessibility Robot** - A distributed robotics platform for autonomous indoor ADA-compliance auditing.
 
 ## Overview
 

--- a/star-ros2/README.md
+++ b/star-ros2/README.md
@@ -1,6 +1,6 @@
 # STAR ROS2 Integration
 
-ROS2 Jazzy integration for the STAR (Simultaneous Tracking and Robotics) platform, providing high-level orchestration for autonomous navigation, sensor fusion, and robot control.
+ROS2 Jazzy integration for the STAR (Spatial Topography Accessibility Robot) platform, providing high-level orchestration for autonomous navigation, sensor fusion, and robot control.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Renames the project tagline in the six top-level docs / agent prompts from the old ""Simultaneous Tracking and Robotics"" to the canonical ""Spatial Topography Accessibility Robot"" name already used throughout `final_capstone/` writeups, posters, trifold, one-pager, and research dossier.
- Each affected line also gets a short clause noting that STAR is for **autonomous indoor ADA-compliance auditing**, replacing the generic ""distributed robotics platform for autonomous mobile robots"" phrasing that gave no hint of what the system does.
- Pure documentation rename. No code, schema, message, or test changes.

## Files changed
- `README.md`
- `CLAUDE.md`
- `.github/agents.md`
- `.github/copilot-instructions.md`
- `.claude/agents/star-code-reviewer.md`
- `star-ros2/README.md`

## Verification
````
$ rg 'Simultaneous Tracking'
(no matches)
````

## Test plan
- [x] `git grep ""Simultaneous Tracking""` returns zero results across the repo
- [x] No source files modified -- existing 143-test ROS2 suite and 79-test compliance-engine suite are unaffected
- [x] All edits remain pure 7-bit ASCII (per `scripts/utils/fix-encoding.py`)
- [x] Acronym matches the spelling used in `final_capstone/writeup/00_abstract.md` and `final_capstone/poster/build_poster.py` (double-s in ""Accessibility"")