### PR TITLE
Pi5 GPIO sweep: handle SKIP_PINS in verifier, add first-run results

### DIFF
--- a/scripts/pi5_gpio_test/RESULTS.md
+++ b/scripts/pi5_gpio_test/RESULTS.md
@@ -1,0 +1,98 @@
+# Pi5 GPIO sweep -- first run
+
+Date: 2026-04-18
+
+Setup:
+- 2x Analog Discovery 2 on the Mac
+  - unit 0 (SN 210321A2AE49): DIO 0..15 wired
+  - unit 1 (SN 210321A36AAE): DIO 0..11 wired, DIO 12..15 floating
+- Pi5 running `scripts/pi5_gpio_test/pi5_toggle.py` on a monitor
+- HAT on top: Hailo AI Hat+
+- Toggler skips GPIO 0, 1, 2, 3, 7, 8 (claimed by HAT EEPROM / I2C / SPI)
+- 22 GPIOs should sweep; 28 wires plugged onto the 40-pin header
+
+## Results
+
+### Detected (15 of 22)
+
+| GPIO | unit | DIO |
+|------|------|-----|
+|   4  | 0    | 12  |
+|   5  | 0    |  5  |
+|   6  | 0    |  6  |
+|   9  | 0    |  0  |
+|  10  | 1    | 11  |
+|  11  | 0    |  2  |
+|  12  | 1    |  4  |
+|  13  | 0    | 11  |
+|  16  | 1    |  3  |
+|  17  | 0    |  1  |
+|  19  | 0    |  4  |
+|  20  | 1    |  0  |
+|  21  | 1    |  1  |
+|  22  | 0    |  9  |
+|  26  | 0    |  7  |
+
+### Not detected (7 of 22)
+
+| GPIO | Header pin | Notes                                          |
+|------|------------|------------------------------------------------|
+|  14  | 8          | UART0 TXD (serial console would hold this)     |
+|  15  | 10         | UART0 RXD (serial console would hold this)     |
+|  18  | 12         |                                                |
+|  23  | 16         |                                                |
+|  24  | 18         |                                                |
+|  25  | 22         |                                                |
+|  27  | 13         |                                                |
+
+### Crosstalk artifact
+
+unit 1 DIO 12 was supposed to be unwired. It showed 1 rising edge (vs
+2 expected per cycle) at the same time as GPIO 10 on unit 1 DIO 11.
+This is capacitive pickup from the adjacent wired DIO 11, not a real
+connection. Passive wiring check earlier confirmed DIO 12..15 are
+floating.
+
+## Interpretation
+
+28 wires on the header, 22 sweepable GPIOs. 15 confirmed working,
+13 wires unaccounted for. The 13 are almost certainly landing on the
+40-pin header's non-GPIO positions:
+
+- 2x 3V3 (pins 1, 17)
+- 2x 5V (pins 2, 4)
+- 8x GND (pins 6, 9, 14, 20, 25, 30, 34, 39)
+- 6x HAT-claimed GPIOs (0, 1, 2, 3, 7, 8 -- on pins 27, 28, 3, 5, 26, 24)
+
+That is 18 non-sweepable pins total, 7 of which would explain the
+missing GPIOs if wires meant for them ended up on power/ground/HAT
+pins instead.
+
+## Next step
+
+Move wires off power/ground/HAT pins onto the 7 missing GPIOs:
+
+| GPIO | Header pin position |
+|------|---------------------|
+|  14  | 8                   |
+|  15  | 10                  |
+|  18  | 12                  |
+|  27  | 13                  |
+|  23  | 16                  |
+|  24  | 18                  |
+|  25  | 22                  |
+
+Re-run:
+
+```
+# On the Pi5 (if not already looping):
+sudo python3 scripts/pi5_gpio_test/pi5_toggle.py
+
+# On the Mac:
+star-rx72n-firmware/gpio_test/host/venv/bin/python3 \
+    scripts/pi5_gpio_test/ad2_verify.py --verbose
+```
+
+If GPIO 14 or 15 still miss after re-wiring, check whether the serial
+console is enabled (`sudo raspi-config` -> Interface Options -> Serial
+Port -> disable login shell, keep hardware enabled, reboot).

--- a/scripts/pi5_gpio_test/RESULTS.md
+++ b/scripts/pi5_gpio_test/RESULTS.md
@@ -35,15 +35,25 @@ Setup:
 
 ### Not detected (7 of 22)
 
-| GPIO | Header pin | Notes                                          |
-|------|------------|------------------------------------------------|
-|  14  | 8          | UART0 TXD (serial console would hold this)     |
-|  15  | 10         | UART0 RXD (serial console would hold this)     |
-|  18  | 12         |                                                |
-|  23  | 16         |                                                |
-|  24  | 18         |                                                |
-|  25  | 22         |                                                |
-|  27  | 13         |                                                |
+| GPIO | Header pin | Notes                                           |
+|------|------------|-------------------------------------------------|
+|  14  | 8          | UART0 TXD (free -- see "Serial console" below)  |
+|  15  | 10         | UART0 RXD (free -- see "Serial console" below)  |
+|  18  | 12         |                                                 |
+|  23  | 16         |                                                 |
+|  24  | 18         |                                                 |
+|  25  | 22         |                                                 |
+|  27  | 13         |                                                 |
+
+### Serial console state (verified on this Pi5)
+
+- `/boot/firmware/cmdline.txt`: `console=tty1` only (no `serial0`/`ttyAMA0`)
+- `/boot/firmware/config.txt`: no `enable_uart=1`, no UART overlay
+- `systemctl`: no `serial-getty@` unit active
+- `gpioinfo gpiochip4`: lines 14 and 15 report `unused`
+
+So UART0 is not claiming GPIO 14/15. The missing edges on those pins
+are a wiring issue, not a kernel one.
 
 ### Crosstalk artifact
 
@@ -93,6 +103,6 @@ star-rx72n-firmware/gpio_test/host/venv/bin/python3 \
     scripts/pi5_gpio_test/ad2_verify.py --verbose
 ```
 
-If GPIO 14 or 15 still miss after re-wiring, check whether the serial
-console is enabled (`sudo raspi-config` -> Interface Options -> Serial
-Port -> disable login shell, keep hardware enabled, reboot).
+Serial console is already off (see "Serial console state" above), so
+GPIO 14/15 should come up with wiring alone. If they still miss after
+re-wiring, re-check the probe, not the kernel config.

--- a/scripts/pi5_gpio_test/ad2_verify.py
+++ b/scripts/pi5_gpio_test/ad2_verify.py
@@ -207,9 +207,9 @@ def auto_map(edges: list[EdgeEvent],
         if sweep_len > 0:
             pin_period_ms = sweep_len / NUM_SWEEP
 
-    # t_after_gap is the first edge after the quiet window. Assume the
-    # Pi5 starts the sweep at GPIO 0, so t_after_gap is approximately
-    # GPIO 0's rising edge (or whichever wired GPIO is earliest).
+    # t_after_gap is the first edge after the quiet window, i.e. the
+    # rising edge of SWEEP_ORDER[0] (or whichever wired GPIO in the
+    # sweep is earliest).
     t_anchor = t_after_gap
     print(f"  anchor t = {t_anchor:.1f} ms, pin_period = "
           f"{pin_period_ms:.2f} ms, gap = {gap_dur:.0f} ms")

--- a/scripts/pi5_gpio_test/ad2_verify.py
+++ b/scripts/pi5_gpio_test/ad2_verify.py
@@ -43,12 +43,18 @@ AD2_SERIAL_NUMBERS = [
 ]
 CHANNELS_PER_AD2 = 16
 
-NUM_GPIO = 28
+# Must match pi5_toggle.py: pins claimed by HAT EEPROM, I2C-1 (Hailo),
+# SPI0 CS0/CS1. These are never driven by the toggler so the verifier
+# must not expect edges on them.
+SKIP_PINS = frozenset({0, 1, 2, 3, 7, 8})
+SWEEP_ORDER = [g for g in range(28) if g not in SKIP_PINS]
+NUM_SWEEP = len(SWEEP_ORDER)
+
 PIN_HIGH_MS = 10
 PIN_LOW_MS = 10
 PIN_PERIOD_MS = PIN_HIGH_MS + PIN_LOW_MS
 CYCLE_GAP_MS = 2000
-CYCLE_DURATION_MS = NUM_GPIO * PIN_PERIOD_MS + CYCLE_GAP_MS
+CYCLE_DURATION_MS = NUM_SWEEP * PIN_PERIOD_MS + CYCLE_GAP_MS
 
 
 @dataclass
@@ -199,7 +205,7 @@ def auto_map(edges: list[EdgeEvent],
         cycle_len = sum(lens) / len(lens)
         sweep_len = cycle_len - gap_dur
         if sweep_len > 0:
-            pin_period_ms = sweep_len / NUM_GPIO
+            pin_period_ms = sweep_len / NUM_SWEEP
 
     # t_after_gap is the first edge after the quiet window. Assume the
     # Pi5 starts the sweep at GPIO 0, so t_after_gap is approximately
@@ -209,7 +215,7 @@ def auto_map(edges: list[EdgeEvent],
           f"{pin_period_ms:.2f} ms, gap = {gap_dur:.0f} ms")
 
     mapping: dict[tuple[int, int], int] = {}
-    cycle_end = t_anchor + NUM_GPIO * pin_period_ms
+    cycle_end = t_anchor + NUM_SWEEP * pin_period_ms
     for key, s in stats.items():
         if cls[key]["verdict"] != "signal":
             continue
@@ -218,9 +224,9 @@ def auto_map(edges: list[EdgeEvent],
         if not after:
             continue
         t_first = min(after)
-        gpio = round((t_first - t_anchor) / pin_period_ms)
-        if 0 <= gpio < NUM_GPIO:
-            mapping[key] = gpio
+        sweep_idx = round((t_first - t_anchor) / pin_period_ms)
+        if 0 <= sweep_idx < NUM_SWEEP:
+            mapping[key] = SWEEP_ORDER[sweep_idx]
     return mapping, cls
 
 
@@ -236,7 +242,7 @@ def print_report(mapping: dict[tuple[int, int], int],
         print(f"  unit {unit} DIO{ch:2d}  ->  GPIO{mapping[key]:2d}")
 
     detected_gpios = set(mapping.values())
-    missing = [g for g in range(NUM_GPIO) if g not in detected_gpios]
+    missing = [g for g in SWEEP_ORDER if g not in detected_gpios]
 
     if missing:
         print(f"\n--- NOT DETECTED ({len(missing)}) ---")
@@ -244,7 +250,10 @@ def print_report(mapping: dict[tuple[int, int], int],
             print(f"  GPIO{g:2d}  (no DIO channel saw a valid edge)")
     else:
         print("\n--- NOT DETECTED (0) ---")
-        print("  all 28 GPIOs showed valid rising edges")
+        print(f"  all {NUM_SWEEP} swept GPIOs showed valid rising edges")
+    if SKIP_PINS:
+        print(f"  (skipped by toggler: "
+              f"{sorted(SKIP_PINS)} -- HAT/I2C/SPI claimed)")
 
     if verbose:
         print("\n--- per-channel detail ---")
@@ -257,7 +266,7 @@ def print_report(mapping: dict[tuple[int, int], int],
                   f"[{v['verdict']:6s}]  {gpio_str}")
 
     print("\n" + "=" * 72)
-    print(f"GPIO detected: {len(detected_gpios)}/{NUM_GPIO}   "
+    print(f"GPIO detected: {len(detected_gpios)}/{NUM_SWEEP}   "
           f"missing: {len(missing)}")
     print("=" * 72)
 
@@ -300,7 +309,7 @@ def main() -> None:
         mapping, cls = auto_map(edges, args.cycles)
         print_report(mapping, cls, args.verbose)
 
-        if set(mapping.values()) != set(range(NUM_GPIO)):
+        if set(mapping.values()) != set(SWEEP_ORDER):
             sys.exit(1)
     finally:
         for d in devs:


### PR DESCRIPTION
## Summary
- Mirror `pi5_toggle.py`'s `SKIP_PINS` set in `ad2_verify.py` so the edge-timing-to-GPIO mapping uses the actual 22-pin sweep order (not a naive 0..27 range) after the Hailo AI Hat+ / I2C-1 / SPI0 CS pins get skipped.
- Add `RESULTS.md` capturing first-run findings from the bench: 15 of 22 sweepable GPIOs toggle correctly, 7 missing (most likely mis-wired onto power/ground/HAT pins on the 40-pin header rather than broken silicon), plus one expected crosstalk artifact on an unwired DIO.

## Test plan
- [x] `ad2_verify.py --verbose` runs cleanly against 2x AD2 + live Pi5 toggler (output captured in `RESULTS.md`)
- [ ] Re-wire the 7 missing GPIOs (14, 15, 18, 23, 24, 25, 27) off power/ground/HAT pins and re-run for a full PASS
- [ ] If GPIO 14/15 still miss after re-wiring, disable serial console login on the Pi5 (`raspi-config` -> Interface Options -> Serial Port)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GPIO hardware sweep test results for Raspberry Pi 5, including detection status and wiring guidance.

* **Tests**
  * Refined GPIO verification logic to support selective GPIO testing and improved detection mapping calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->