### PR TITLE
Add Fusion 360 chassis assembly (STAR.f3z) via Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,6 @@ gcc-14.2.0.202511-GNURX-ELF.run filter=lfs diff=lfs merge=lfs -text
 star-beaglebone-blue/*.stl filter=lfs diff=lfs merge=lfs -text
 *.tgz filter=lfs diff=lfs merge=lfs -text
 RFP_CLI_Linux_V32200_x64.tgz filter=lfs diff=lfs merge=lfs -text
+# Fusion 360 CAD sources (chassis assembly)
+*.f3z filter=lfs diff=lfs merge=lfs -text
+*.f3d filter=lfs diff=lfs merge=lfs -text

--- a/cad/README.md
+++ b/cad/README.md
@@ -1,0 +1,25 @@
+# STAR Chassis CAD
+
+Fusion 360 sources for the STAR robot chassis assembly.
+
+## Files
+
+- `STAR.f3z` -- top-level chassis assembly (Fusion 360 archive, all
+  components bundled). Stored via Git LFS; install LFS before cloning:
+  ```
+  git lfs install
+  git clone https://github.com/Locked-Inc/STAR.git
+  ```
+
+## Working with the archive
+
+Open `STAR.f3z` directly in Fusion 360 (File -> Open) to load the whole
+assembly with its component tree. Editing in Fusion creates a new cloud
+copy -- to re-archive after changes, re-export as `.f3z` and overwrite
+this file, then commit.
+
+## Neutral exports
+
+When the assembly changes, also export a STEP file for downstream tools
+that do not read Fusion native format (KiCad 3D viewer, mechanical review,
+vendors without Autodesk licenses). Place it alongside as `STAR.step`.

--- a/cad/STAR.f3z
+++ b/cad/STAR.f3z
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f142a4474b622123e9b0a34bac6eb5606ed9a10f0375c1df39179ca971774b1
+size 55471687


### PR DESCRIPTION
## Summary
- Adds `cad/STAR.f3z` -- 55 MB top-level Fusion 360 chassis assembly, tracked via Git LFS
- Registers `*.f3z` / `*.f3d` as LFS-tracked in `.gitattributes`
- Adds `cad/README.md` with clone/open instructions and a note to also export STEP on future changes

## Test plan
- [x] LFS upload completed on push (56 MB transfer confirmed)
- [ ] CI green on main checks
- [ ] Spot-check: fresh clone + \`git lfs pull\` rehydrates STAR.f3z