### PR TITLE
chore(final_docs): expand gitignore + remove stale LaTeX artifacts

### DIFF
--- a/final_docs/.gitignore
+++ b/final_docs/.gitignore
@@ -5,9 +5,11 @@
 *.toc
 *.lof
 *.lot
+*.lol
 *.fls
 *.fdb_latexmk
 *.synctex.gz
+*.synctex(busy)
 *.bbl
 *.blg
 *.idx
@@ -20,8 +22,39 @@
 *.bcf
 *.dvi
 *.ps
+*.xdv
+*.auxlock
+
+# LaTeX glossaries / acronyms
+*.glo
+*.gls
+*.glg
+*.glsdefs
+*.acn
+*.acr
+*.alg
+
+# minted / pygments
+*.pyg
+_minted-*/
+
+# TikZ external library
+*.figlist
+*.makefile
+*-figure*.pdf
+*-figure*.dpth
+*-figure*.md5
+*-figure*.log
+
+# latexmk
+*.fls
+*.fdb_latexmk
 
 # Editor/OS junk
 .DS_Store
+._*
+Thumbs.db
 *.swp
+*.swo
+*.bak
 *~


### PR DESCRIPTION
## Summary

- Removed six stale LaTeX build artifacts (.aux, .log, .out, .toc, .lof, .lot) left in the working tree after a prior local rebuild of the SDD. None were tracked in git -- the existing .gitignore already covered them -- but they were sitting on disk next to the .tex source. Cleanup only.
- Expanded \`final_docs/.gitignore\` to cover artifact families the original list missed: \`*.lol\`, \`*.xdv\`, \`*.auxlock\`, \`*.synctex(busy)\` (LaTeX); \`*.glo\` / \`*.gls\` / \`*.glg\` / \`*.glsdefs\` / \`*.acn\` / \`*.acr\` / \`*.alg\` (glossaries+acronyms); \`*.pyg\` / \`_minted-*/\` (pygments+minted); \`*.figlist\` / \`*.makefile\` / \`*-figure*.{pdf,dpth,md5,log}\` (TikZ external library); \`Thumbs.db\` (Windows), \`._*\` (macOS resource forks), \`*.swo\` (vim secondary swap), \`*.bak\` (editor backup).

## Test plan

- [x] \`git ls-files final_docs/ | grep -E '\.(aux|log|out|toc|lof|lot|...)$' \` -> no tracked artifacts before or after.
- [x] \`find final_docs -type f \( -name "*.aux" -o -name "*.log" -o ... \)\` -> empty after cleanup.
- [x] \`python3 scripts/utils/fix-encoding.py --check final_docs/\` -> "OK: No non-ASCII characters found."
- [x] No tracked-file content changes; only .gitignore expanded and 6 untracked artifacts removed from disk.